### PR TITLE
fix!: persist SurrealDB data (surrealkv) — prevents total data loss on restart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ SURREAL_MEMORY_STORAGE=surrealdb
 
 # --- Sync (Hub) ---
 # Hub server URL for multi-device sync
-# SURREAL_MEMORY_HUB_URL=https://surreal-memory-sync-hub.toni-nowak84.workers.dev
+# SURREAL_MEMORY_HUB_URL=https://your-sync-hub.example.workers.dev
 # SURREAL_MEMORY_API_KEY=nmk_your_key_here
 # SURREAL_MEMORY_DEVICE_ID=my-laptop
 # SURREAL_MEMORY_SYNC_ENABLED=true

--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,6 @@ integrations/surrealmemory/coverage/
 
 # Task Master AI — local dev planning (never commit)
 .taskmaster/
+
+# Local hook event log — may capture secrets from tool output
+tool_events.jsonl

--- a/docker-compose.surrealdb.yml
+++ b/docker-compose.surrealdb.yml
@@ -11,7 +11,12 @@
 services:
   surrealdb:
     image: surrealdb/surrealdb:latest
-    command: start --user root --pass ${SURREALDB_PASS:-surrealmemory} --bind 0.0.0.0:8001
+    # surrealkv:///surrealdb/data/db makes storage PERSISTENT. Without a datastore
+    # path `surreal start` defaults to in-memory and ALL data is lost on restart.
+    # `user: root` is required because a fresh named volume is root-owned and the
+    # image's default `nonroot` user cannot create the datastore directory in it.
+    command: start --user root --pass ${SURREALDB_PASS:-surrealmemory} --bind 0.0.0.0:8001 surrealkv:///surrealdb/data/db
+    user: root
     ports:
       - "8001:8001"
     volumes:
@@ -55,7 +60,8 @@ services:
       # Cloud Sync
       - SURREAL_MEMORY_SYNC_ENABLED=true
       - SURREAL_MEMORY_SYNC_AUTO=true
-      - SURREAL_MEMORY_HUB_URL=https://surreal-memory-sync-hub.toni-nowak84.workers.dev
+      # Set SURREAL_MEMORY_HUB_URL in your .env — personal hub URL, not committed here.
+      - SURREAL_MEMORY_HUB_URL=${SURREAL_MEMORY_HUB_URL:-}
       # Set SURREAL_MEMORY_API_KEY in your .env — never hardcode it in this committed file.
       - SURREAL_MEMORY_API_KEY=${SURREAL_MEMORY_API_KEY:-}
 


### PR DESCRIPTION
## Problem (critical — data loss)
`docker-compose.surrealdb.yml` started `surreal start` with **no datastore path**, which defaults to **in-memory**. Every container restart wiped all stored memories.

## Fix
- `surrealkv:///surrealdb/data/db` → persistent on-disk storage on the `surrealdb_data` volume at `/surrealdb/data` (matches the layout already running in production).
- `user: root` — a fresh named volume is root-owned; the image's default `nonroot` user cannot create the datastore dir otherwise (verified: nonroot start fails with Permission denied).
- Hygiene: `SURREAL_MEMORY_HUB_URL` / `SURREAL_MEMORY_API_KEY` come from `.env` (no hardcoded defaults); `.env.example` uses a generic placeholder; `tool_events.jsonl` gitignored.

## Verified end-to-end
Controlled recreate on a live instance: neuron 392→392, synapse 933→933, app `/health` ok. Fresh install boots (as root). `docker compose config -q` passes.