### PR TITLE
fix(openclaw): repair invalid TS identifier Surreal-MemoryMcpClient

### DIFF
--- a/integrations/surrealmemory/src/index.ts
+++ b/integrations/surrealmemory/src/index.ts
@@ -43,7 +43,7 @@ import type {
   CommandEvent,
   GatewayStartupEvent,
 } from "./types.js";
-import { Surreal-MemoryMcpClient } from "./mcp-client.js";
+import { SurrealMemoryMcpClient } from "./mcp-client.js";
 import type { PluginLogger } from "./types.js";
 import { createToolsFromMcp, createFallbackTools, createCompatibilityTools } from "./tools.js";
 import type { ToolDefinition } from "./tools.js";
@@ -289,12 +289,12 @@ export function resolveConfig(raw?: Record<string, unknown>): PluginConfig {
 // Multiple workspaces may call register() independently, but all
 // should share the same MCP process per (pythonPath, brain) combo.
 
-const mcpClients = new Map<string, Surreal-MemoryMcpClient>();
+const mcpClients = new Map<string, SurrealMemoryMcpClient>();
 
 function getOrCreateMcpClient(
   cfg: PluginConfig,
   logger: PluginLogger,
-): Surreal-MemoryMcpClient {
+): SurrealMemoryMcpClient {
   const key = `${cfg.pythonPath}::${cfg.brain}`;
 
   const existing = mcpClients.get(key);
@@ -303,7 +303,7 @@ function getOrCreateMcpClient(
     return existing;
   }
 
-  const mcp = new Surreal-MemoryMcpClient({
+  const mcp = new SurrealMemoryMcpClient({
     pythonPath: cfg.pythonPath,
     brain: cfg.brain,
     logger,

--- a/integrations/surrealmemory/src/mcp-client.ts
+++ b/integrations/surrealmemory/src/mcp-client.ts
@@ -74,7 +74,7 @@ export const ALLOWED_ENV_KEYS: ReadonlySet<string> = new Set([
 
 // ── Client ─────────────────────────────────────────────────
 
-export class Surreal-MemoryMcpClient {
+export class SurrealMemoryMcpClient {
   private proc: ChildProcess | null = null;
   private requestId = 0;
   private readonly pending = new Map<number, PendingRequest>();

--- a/integrations/surrealmemory/src/tools.ts
+++ b/integrations/surrealmemory/src/tools.ts
@@ -16,7 +16,7 @@
  *   - Uses `number` instead of `integer` for Gemini compatibility
  */
 
-import type { Surreal-MemoryMcpClient, McpToolDefinition } from "./mcp-client.js";
+import type { SurrealMemoryMcpClient, McpToolDefinition } from "./mcp-client.js";
 
 // ── Types ──────────────────────────────────────────────────
 
@@ -130,7 +130,7 @@ function toSafeSchema(inputSchema?: Record<string, unknown>): JsonSchema {
 /**
  * Create a tool call helper that auto-reconnects to MCP.
  */
-function makeCallFn(mcp: Surreal-MemoryMcpClient) {
+function makeCallFn(mcp: SurrealMemoryMcpClient) {
   return async (
     toolName: string,
     args: Record<string, unknown>,
@@ -182,7 +182,7 @@ function mcpToolToOpenClaw(
  * Must be called after MCP connection is established.
  */
 export async function createToolsFromMcp(
-  mcp: Surreal-MemoryMcpClient,
+  mcp: SurrealMemoryMcpClient,
 ): Promise<ToolDefinition[]> {
   const mcpTools = await mcp.listTools();
   const call = makeCallFn(mcp);
@@ -194,7 +194,7 @@ export async function createToolsFromMcp(
  * Ensures the plugin still works even if the MCP server is an older version.
  */
 export function createFallbackTools(
-  mcp: Surreal-MemoryMcpClient,
+  mcp: SurrealMemoryMcpClient,
 ): ToolDefinition[] {
   const call = makeCallFn(mcp);
 
@@ -281,7 +281,7 @@ export function createFallbackTools(
  * memory-core tools but leaves the tools.profile allowList referencing them.
  */
 export function createCompatibilityTools(
-  mcp: Surreal-MemoryMcpClient,
+  mcp: SurrealMemoryMcpClient,
 ): ToolDefinition[] {
   const call = makeCallFn(mcp);
 


### PR DESCRIPTION
Global rename inserted a hyphen into the class identifier `Surreal-MemoryMcpClient` (illegal in TS — parsed as subtraction), breaking the OpenClaw plugin build (TS1011/1005/1109) and the npm publish job. Renamed to `SurrealMemoryMcpClient` in mcp-client.ts, tools.ts, index.ts. Verified `tsc --noEmit` clean. String literals unaffected.