### PR TITLE
fix(embedding): harden pipeline — retry/backoff, kill dead model, capability probe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ SURREAL_MEMORY_STORAGE=surrealdb
 # --- Embedding (Gemini 2.0) ---
 # SURREAL_MEMORY_EMBEDDING_ENABLED=true
 # SURREAL_MEMORY_EMBEDDING_PROVIDER=gemini
-# SURREAL_MEMORY_EMBEDDING_MODEL=gemini-embedding-exp-03-07
+# SURREAL_MEMORY_EMBEDDING_MODEL=gemini-embedding-001
 # GEMINI_API_KEY=your-gemini-api-key
 
 # --- Embedding (other providers) ---

--- a/docker-compose.surrealdb.yml
+++ b/docker-compose.surrealdb.yml
@@ -51,10 +51,12 @@ services:
       - SURREALDB_NS=surreal_memory
       - SURREALDB_DB=default
 
-      # Embedding (Gemini 2.0)
+      # Embedding (Gemini)
       - SURREAL_MEMORY_EMBEDDING_ENABLED=true
       - SURREAL_MEMORY_EMBEDDING_PROVIDER=gemini
-      - SURREAL_MEMORY_EMBEDDING_MODEL=${SURREAL_MEMORY_EMBEDDING_MODEL:-gemini-embedding-exp-03-07}
+      # gemini-embedding-001 is the current 3072-dim default. The old
+      # gemini-embedding-exp-03-07 is experimental/deprecated — do not use.
+      - SURREAL_MEMORY_EMBEDDING_MODEL=${SURREAL_MEMORY_EMBEDDING_MODEL:-gemini-embedding-001}
       - GEMINI_API_KEY=${GEMINI_API_KEY}
 
       # Cloud Sync

--- a/src/surreal_memory/engine/embedding/capability.py
+++ b/src/surreal_memory/engine/embedding/capability.py
@@ -1,0 +1,122 @@
+"""Embedding capability probe — turns the silent "embeddings configured but the
+provider package is missing" failure into a visible, actionable state.
+
+Used by ``smem_health`` (to report ``embedding`` availability) and at MCP
+startup (to log a loud, actionable warning). The probe is cheap: it checks
+package availability via ``importlib.util.find_spec`` and never imports heavy
+models or makes API calls.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# provider name -> (import module to check, pip extra that provides it)
+_PROVIDER_IMPORT: dict[str, tuple[str, str]] = {
+    "gemini": ("google.genai", "embeddings-gemini"),
+    "openai": ("openai", "embeddings-openai"),
+    "openrouter": ("openai", "embeddings-openrouter"),
+    "sentence_transformer": ("sentence_transformers", "embeddings"),
+}
+
+
+def _dimension_for(provider: str, model: str) -> int | None:
+    """Best-effort dimension lookup without loading models or calling APIs."""
+    try:
+        if provider == "gemini":
+            from surreal_memory.engine.embedding.gemini_embedding import _MODEL_DIMENSIONS
+
+            return _MODEL_DIMENSIONS.get(model, 3072)
+        if provider == "openai":
+            from surreal_memory.engine.embedding.openai_embedding import _MODEL_DIMENSIONS
+
+            return _MODEL_DIMENSIONS.get(model, 1536)
+        if provider == "openrouter":
+            from surreal_memory.engine.embedding.openrouter_embedding import _MODEL_DIMENSIONS
+
+            return _MODEL_DIMENSIONS.get(model, 1536)
+    except Exception:
+        return None
+    return None
+
+
+def probe_embedding_capability(config: Any) -> dict[str, Any]:
+    """Report whether the configured embedding provider is usable.
+
+    Returns a dict with: ``enabled``, ``provider``, ``model``, ``available``
+    (bool) and ``detail`` (a human-readable note, including the exact install
+    command when a package is missing). Never raises.
+    """
+    # Accept either a flat BrainConfig (embedding_enabled/provider/model) or a
+    # nested unified config (config.embedding.enabled/provider/model).
+    nested = getattr(config, "embedding", None)
+    enabled = getattr(config, "embedding_enabled", None)
+    provider = getattr(config, "embedding_provider", None)
+    model = getattr(config, "embedding_model", None)
+    if nested is not None and not isinstance(nested, (str, bool)):
+        if enabled is None:
+            enabled = getattr(nested, "enabled", False)
+        if provider is None:
+            provider = getattr(nested, "provider", "")
+        if model is None:
+            model = getattr(nested, "model", "")
+    enabled = bool(enabled)
+    provider = (provider or "").strip()
+    model = model or ""
+    result: dict[str, Any] = {
+        "enabled": enabled,
+        "provider": provider,
+        "model": model,
+        "available": False,
+        "dimension": None,
+        "detail": None,
+    }
+
+    if not enabled:
+        result["detail"] = "embeddings disabled"
+        return result
+
+    if provider == "ollama":
+        # Local server — availability depends on the daemon, not a Python package.
+        result["available"] = True
+        result["detail"] = "ollama (local server — ensure it is running)"
+        return result
+
+    if provider == "auto":
+        # Provider is detected at runtime from whatever is installed/keyed.
+        result["available"] = True
+        result["detail"] = "auto-detect at runtime"
+        return result
+
+    entry = _PROVIDER_IMPORT.get(provider)
+    if entry is None:
+        result["detail"] = f"unknown embedding provider {provider!r}"
+        return result
+
+    module_name, extra = entry
+    if importlib.util.find_spec(module_name) is None:
+        result["detail"] = (
+            f"{provider} provider configured but '{module_name}' is not installed — "
+            f"install it with: pip install 'surreal-memory[{extra}]'"
+        )
+        return result
+
+    result["available"] = True
+    result["dimension"] = _dimension_for(provider, model)
+    return result
+
+
+def warn_if_embedding_unavailable(config: Any) -> None:
+    """Log a loud, actionable warning at startup if embeddings are configured
+    but the provider package is missing. Recall/remember still fail-soft to
+    keyword mode — this just makes the cause visible instead of silent."""
+    info = probe_embedding_capability(config)
+    if info["enabled"] and not info["available"]:
+        logger.warning(
+            "Embedding provider unavailable — running in degraded keyword mode. %s",
+            info["detail"],
+        )

--- a/src/surreal_memory/engine/embedding/gemini_embedding.py
+++ b/src/surreal_memory/engine/embedding/gemini_embedding.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from functools import partial
 from typing import Any
 
 from surreal_memory.engine.embedding.provider import EmbeddingProvider
@@ -93,10 +94,11 @@ class GeminiEmbedding(EmbeddingProvider):
         batch_size = 100
         for i in range(0, len(texts), batch_size):
             chunk = texts[i : i + batch_size]
-            # chunk is awaited immediately below, so a plain closure is safe
-            # (no late-binding across loop iterations) and types cleanly.
+            # functools.partial binds `chunk` at creation (satisfies ruff B023,
+            # no loop-var late binding) and types cleanly for mypy.
             response = await call_with_retry(
-                lambda: client.aio.models.embed_content(
+                partial(
+                    client.aio.models.embed_content,
                     model=self._model,
                     contents=chunk,
                     config={"task_type": self._task_type},

--- a/src/surreal_memory/engine/embedding/gemini_embedding.py
+++ b/src/surreal_memory/engine/embedding/gemini_embedding.py
@@ -93,9 +93,10 @@ class GeminiEmbedding(EmbeddingProvider):
         batch_size = 100
         for i in range(0, len(texts), batch_size):
             chunk = texts[i : i + batch_size]
+            # chunk is awaited immediately below, so a plain closure is safe
+            # (no late-binding across loop iterations) and types cleanly.
             response = await call_with_retry(
-                # default-arg capture binds this chunk to its own closure
-                lambda chunk=chunk: client.aio.models.embed_content(
+                lambda: client.aio.models.embed_content(
                     model=self._model,
                     contents=chunk,
                     config={"task_type": self._task_type},

--- a/src/surreal_memory/engine/embedding/gemini_embedding.py
+++ b/src/surreal_memory/engine/embedding/gemini_embedding.py
@@ -7,6 +7,7 @@ import os
 from typing import Any
 
 from surreal_memory.engine.embedding.provider import EmbeddingProvider
+from surreal_memory.engine.embedding.retry import call_with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +15,8 @@ logger = logging.getLogger(__name__)
 _MODEL_DIMENSIONS: dict[str, int] = {
     "gemini-embedding-001": 3072,
     "gemini-embedding-exp-03-07": 3072,
-    "text-embedding-004": 768,
+    # text-embedding-004 (768-dim) is decommissioned (404s) — removed to avoid a
+    # dimension-mismatch landmine against the 3072-dim default.
 }
 
 _DEFAULT_MODEL = "gemini-embedding-001"
@@ -65,10 +67,13 @@ class GeminiEmbedding(EmbeddingProvider):
     async def embed(self, text: str) -> list[float]:
         """Embed a single text via the Gemini API."""
         client = self._ensure_client()
-        response = await client.aio.models.embed_content(
-            model=self._model,
-            contents=text,
-            config={"task_type": self._task_type},
+        response = await call_with_retry(
+            lambda: client.aio.models.embed_content(
+                model=self._model,
+                contents=text,
+                config={"task_type": self._task_type},
+            ),
+            provider="gemini",
         )
         return list(response.embeddings[0].values)
 
@@ -88,10 +93,14 @@ class GeminiEmbedding(EmbeddingProvider):
         batch_size = 100
         for i in range(0, len(texts), batch_size):
             chunk = texts[i : i + batch_size]
-            response = await client.aio.models.embed_content(
-                model=self._model,
-                contents=chunk,
-                config={"task_type": self._task_type},
+            response = await call_with_retry(
+                # default-arg capture binds this chunk to its own closure
+                lambda chunk=chunk: client.aio.models.embed_content(
+                    model=self._model,
+                    contents=chunk,
+                    config={"task_type": self._task_type},
+                ),
+                provider="gemini",
             )
             all_embeddings.extend(list(emb.values) for emb in response.embeddings)
 

--- a/src/surreal_memory/engine/embedding/openai_embedding.py
+++ b/src/surreal_memory/engine/embedding/openai_embedding.py
@@ -6,6 +6,7 @@ import os
 from typing import Any
 
 from surreal_memory.engine.embedding.provider import EmbeddingProvider
+from surreal_memory.engine.embedding.retry import call_with_retry
 
 # Known dimensions per model
 _MODEL_DIMENSIONS: dict[str, int] = {
@@ -65,9 +66,9 @@ class OpenAIEmbedding(EmbeddingProvider):
     async def embed(self, text: str) -> list[float]:
         """Embed a single text via the OpenAI API."""
         client = self._ensure_client()
-        response = await client.embeddings.create(
-            input=[text],
-            model=self._model,
+        response = await call_with_retry(
+            lambda: client.embeddings.create(input=[text], model=self._model),
+            provider=self._provider_label,
         )
         return list(response.data[0].embedding)
 
@@ -81,9 +82,9 @@ class OpenAIEmbedding(EmbeddingProvider):
             return []
 
         client = self._ensure_client()
-        response = await client.embeddings.create(
-            input=texts,
-            model=self._model,
+        response = await call_with_retry(
+            lambda: client.embeddings.create(input=texts, model=self._model),
+            provider=self._provider_label,
         )
         # The API returns embeddings in the same order as the input
         sorted_data = sorted(response.data, key=lambda d: d.index)

--- a/src/surreal_memory/engine/embedding/retry.py
+++ b/src/surreal_memory/engine/embedding/retry.py
@@ -1,0 +1,84 @@
+"""Shared retry helper for transient embedding-provider API errors.
+
+Embedding providers (Gemini, OpenAI, OpenRouter) talk to remote APIs that
+fail transiently: 429 rate limits (Gemini's free tier has a tight RPM cap and
+multiple ``smem-mcp`` processes share one key), 5xx, and timeouts. Without
+backoff, a single transient blip becomes a hard failure that the MCP layer
+surfaces as an opaque ``-32000``. This helper retries transient errors with
+exponential backoff + jitter and re-raises non-transient errors immediately.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+logger = logging.getLogger(__name__)
+
+_T = TypeVar("_T")
+
+_MAX_ATTEMPTS = 4
+_BASE_DELAY_S = 1.0
+_MAX_DELAY_S = 16.0
+_TRANSIENT_STATUS = {429, 500, 502, 503, 504}
+_TRANSIENT_MARKERS = (
+    "resource_exhausted",
+    "unavailable",
+    "deadline_exceeded",
+    "rate limit",
+    "timeout",
+    "timed out",
+    "connection",
+    "temporarily",
+)
+
+
+def is_transient(exc: BaseException) -> bool:
+    """Return True if *exc* looks like a transient, retryable API error."""
+    code = getattr(exc, "code", None) or getattr(exc, "status_code", None)
+    if isinstance(code, int) and code in _TRANSIENT_STATUS:
+        return True
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _TRANSIENT_MARKERS)
+
+
+async def call_with_retry(
+    factory: Callable[[], Awaitable[_T]],
+    *,
+    provider: str = "embedding",
+) -> _T:
+    """Run an async API call, retrying transient failures with backoff + jitter.
+
+    Args:
+        factory: A zero-arg callable producing a *fresh* awaitable per call
+            (awaitables are single-use, so the call cannot be retried directly).
+        provider: Label used in log messages.
+
+    Non-transient errors (e.g. 400/401/403/404) are re-raised immediately.
+    Transient errors are retried up to ``_MAX_ATTEMPTS`` times; the last
+    exception is re-raised once attempts are exhausted.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(1, _MAX_ATTEMPTS + 1):
+        try:
+            return await factory()
+        except Exception as exc:
+            last_exc = exc
+            if attempt >= _MAX_ATTEMPTS or not is_transient(exc):
+                raise
+            delay = min(_BASE_DELAY_S * (2 ** (attempt - 1)), _MAX_DELAY_S)
+            delay += random.uniform(0, delay * 0.25)  # jitter to de-sync clients
+            logger.warning(
+                "%s transient error (attempt %d/%d): %s — retrying in %.1fs",
+                provider,
+                attempt,
+                _MAX_ATTEMPTS,
+                exc,
+                delay,
+            )
+            await asyncio.sleep(delay)
+    assert last_exc is not None
+    raise last_exc

--- a/src/surreal_memory/engine/semantic_discovery.py
+++ b/src/surreal_memory/engine/semantic_discovery.py
@@ -101,7 +101,12 @@ def _auto_detect_provider() -> tuple[str, str]:
     import os
 
     if os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY"):
-        return ("gemini", "models/text-embedding-004")
+        # Use the live default model, never a hardcoded literal that can drift to a
+        # decommissioned model (text-embedding-004 now 404s and was 768-dim, a
+        # dimension-mismatch landmine vs the 3072-dim gemini-embedding-001 default).
+        from surreal_memory.engine.embedding.gemini_embedding import _DEFAULT_MODEL
+
+        return ("gemini", _DEFAULT_MODEL)
 
     # 4. Check OpenAI API key (paid)
     if os.environ.get("OPENAI_API_KEY"):

--- a/src/surreal_memory/mcp/server.py
+++ b/src/surreal_memory/mcp/server.py
@@ -570,6 +570,17 @@ async def run_mcp_server() -> None:
     except Exception:
         logger.debug("Version check startup failed (non-critical)", exc_info=True)
 
+    # Surface embedding capability at startup: if embeddings are configured but
+    # the provider package is missing, log a loud, actionable warning instead of
+    # silently degrading to keyword mode (and crashing later on embedding paths).
+    try:
+        from surreal_memory.engine.embedding.capability import warn_if_embedding_unavailable
+        from surreal_memory.unified_config import get_config
+
+        warn_if_embedding_unavailable(get_config())
+    except Exception:
+        logger.debug("Embedding capability check skipped (non-critical)", exc_info=True)
+
     try:
         while True:
             try:

--- a/src/surreal_memory/mcp/stats_handler.py
+++ b/src/surreal_memory/mcp/stats_handler.py
@@ -263,6 +263,15 @@ class StatsHandler:
             "roadmap": self._build_health_roadmap(report),
         }
 
+        # Embedding capability: surface whether the configured provider is usable
+        # (missing package, disabled, or ready) so problems are visible, not silent.
+        try:
+            from surreal_memory.engine.embedding.capability import probe_embedding_capability
+
+            result["embedding"] = probe_embedding_capability(brain.config)
+        except Exception:
+            logger.debug("Embedding capability probe failed", exc_info=True)
+
         # Deep analysis: Gromov delta-hyperbolicity (expensive, opt-in, cached 1h)
         if args.get("deep", False):
             try:

--- a/tests/unit/test_embedding_hardening.py
+++ b/tests/unit/test_embedding_hardening.py
@@ -1,0 +1,192 @@
+"""Tests for embedding-pipeline hardening.
+
+Covers the handover fixes: transient-error retry/backoff, the dead-model
+fallback guard in semantic discovery, and the embedding capability probe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from surreal_memory.engine.embedding import capability as capability_mod
+from surreal_memory.engine.embedding.capability import probe_embedding_capability
+from surreal_memory.engine.embedding.retry import call_with_retry, is_transient
+
+
+class _APIError(Exception):
+    """Fake provider error carrying a numeric status code, like google-genai."""
+
+    def __init__(self, code: int) -> None:
+        self.code = code
+        super().__init__(f"api error {code}")
+
+
+async def _instant_sleep(_delay: float) -> None:
+    """Drop-in for asyncio.sleep so retry tests don't actually wait."""
+    return None
+
+
+# ── is_transient ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("code", [429, 500, 502, 503, 504])
+def test_is_transient_true_for_transient_status(code: int) -> None:
+    assert is_transient(_APIError(code)) is True
+
+
+@pytest.mark.parametrize("code", [400, 401, 403, 404])
+def test_is_transient_false_for_client_errors(code: int) -> None:
+    assert is_transient(_APIError(code)) is False
+
+
+def test_is_transient_message_markers() -> None:
+    assert is_transient(Exception("RESOURCE_EXHAUSTED: rate limit hit")) is True
+    assert is_transient(Exception("connection reset by peer")) is True
+    assert is_transient(Exception("invalid argument")) is False
+
+
+# ── call_with_retry ─────────────────────────────────────────────────────────
+
+
+async def test_retry_returns_on_first_success() -> None:
+    calls = {"n": 0}
+
+    async def factory() -> str:
+        calls["n"] += 1
+        return "ok"
+
+    assert await call_with_retry(factory) == "ok"
+    assert calls["n"] == 1
+
+
+async def test_retry_succeeds_after_transient(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    attempts = {"n": 0}
+
+    async def factory() -> str:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise _APIError(503)
+        return "recovered"
+
+    assert await call_with_retry(factory) == "recovered"
+    assert attempts["n"] == 3
+
+
+async def test_retry_reraises_non_transient_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    attempts = {"n": 0}
+
+    async def factory() -> str:
+        attempts["n"] += 1
+        raise _APIError(400)
+
+    with pytest.raises(_APIError):
+        await call_with_retry(factory)
+    assert attempts["n"] == 1  # non-transient → no retries
+
+
+async def test_retry_exhausts_and_reraises_last(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    attempts = {"n": 0}
+
+    async def factory() -> str:
+        attempts["n"] += 1
+        raise _APIError(429)
+
+    with pytest.raises(_APIError):
+        await call_with_retry(factory)
+    assert attempts["n"] == 4  # _MAX_ATTEMPTS
+
+
+# ── _auto_detect_provider never returns a decommissioned model ───────────────
+
+
+def test_auto_detect_never_returns_decommissioned_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+
+    def _no_ollama(*_args: object, **_kwargs: object) -> object:
+        raise ConnectionError("no ollama")
+
+    monkeypatch.setattr(httpx, "get", _no_ollama)
+    # Make `import sentence_transformers` raise ImportError so gemini is chosen.
+    monkeypatch.setitem(sys.modules, "sentence_transformers", None)
+
+    from surreal_memory.engine.embedding.gemini_embedding import _DEFAULT_MODEL
+    from surreal_memory.engine.semantic_discovery import _auto_detect_provider
+
+    provider, model = _auto_detect_provider()
+    assert provider == "gemini"
+    assert model == _DEFAULT_MODEL == "gemini-embedding-001"
+    assert "text-embedding-004" not in model
+
+
+# ── capability probe ─────────────────────────────────────────────────────────
+
+
+def test_capability_disabled_reports_unavailable() -> None:
+    cfg = SimpleNamespace(
+        embedding_enabled=False, embedding_provider="gemini", embedding_model="m"
+    )
+    info = probe_embedding_capability(cfg)
+    assert info["enabled"] is False
+    assert info["available"] is False
+
+
+def test_capability_missing_package_has_install_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(capability_mod.importlib.util, "find_spec", lambda _name: None)
+    cfg = SimpleNamespace(
+        embedding_enabled=True,
+        embedding_provider="gemini",
+        embedding_model="gemini-embedding-001",
+    )
+    info = probe_embedding_capability(cfg)
+    assert info["available"] is False
+    assert "embeddings-gemini" in info["detail"]
+
+
+def test_capability_available_reports_dimension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        capability_mod.importlib.util, "find_spec", lambda _name: object()
+    )
+    cfg = SimpleNamespace(
+        embedding_enabled=True,
+        embedding_provider="gemini",
+        embedding_model="gemini-embedding-001",
+    )
+    info = probe_embedding_capability(cfg)
+    assert info["available"] is True
+    assert info["dimension"] == 3072
+
+
+def test_capability_accepts_nested_unified_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        capability_mod.importlib.util, "find_spec", lambda _name: object()
+    )
+    cfg = SimpleNamespace(
+        embedding=SimpleNamespace(
+            enabled=True, provider="gemini", model="gemini-embedding-001"
+        )
+    )
+    info = probe_embedding_capability(cfg)
+    assert info["enabled"] is True
+    assert info["available"] is True

--- a/tests/unit/test_embedding_hardening.py
+++ b/tests/unit/test_embedding_hardening.py
@@ -138,9 +138,7 @@ def test_auto_detect_never_returns_decommissioned_model(
 
 
 def test_capability_disabled_reports_unavailable() -> None:
-    cfg = SimpleNamespace(
-        embedding_enabled=False, embedding_provider="gemini", embedding_model="m"
-    )
+    cfg = SimpleNamespace(embedding_enabled=False, embedding_provider="gemini", embedding_model="m")
     info = probe_embedding_capability(cfg)
     assert info["enabled"] is False
     assert info["available"] is False
@@ -163,9 +161,7 @@ def test_capability_missing_package_has_install_hint(
 def test_capability_available_reports_dimension(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        capability_mod.importlib.util, "find_spec", lambda _name: object()
-    )
+    monkeypatch.setattr(capability_mod.importlib.util, "find_spec", lambda _name: object())
     cfg = SimpleNamespace(
         embedding_enabled=True,
         embedding_provider="gemini",
@@ -179,13 +175,9 @@ def test_capability_available_reports_dimension(
 def test_capability_accepts_nested_unified_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(
-        capability_mod.importlib.util, "find_spec", lambda _name: object()
-    )
+    monkeypatch.setattr(capability_mod.importlib.util, "find_spec", lambda _name: object())
     cfg = SimpleNamespace(
-        embedding=SimpleNamespace(
-            enabled=True, provider="gemini", model="gemini-embedding-001"
-        )
+        embedding=SimpleNamespace(enabled=True, provider="gemini", model="gemini-embedding-001")
     )
     info = probe_embedding_capability(cfg)
     assert info["enabled"] is True

--- a/tests/unit/test_embedding_provider.py
+++ b/tests/unit/test_embedding_provider.py
@@ -527,11 +527,20 @@ class TestGeminiEmbedding:
         assert provider.dimension == 3072
 
     def test_dimension_text_embedding_004(self) -> None:
-        """Should return 768 for text-embedding-004."""
-        from surreal_memory.engine.embedding.gemini_embedding import GeminiEmbedding
+        """text-embedding-004 is decommissioned and intentionally unmapped.
 
+        Its 768-dim entry was removed (it now 404s and was a dimension-mismatch
+        landmine vs the 3072-dim default), so an unknown model falls back to the
+        3072 default rather than the stale 768 value.
+        """
+        from surreal_memory.engine.embedding.gemini_embedding import (
+            _MODEL_DIMENSIONS,
+            GeminiEmbedding,
+        )
+
+        assert "text-embedding-004" not in _MODEL_DIMENSIONS
         provider = GeminiEmbedding(api_key="test-key", model="text-embedding-004")
-        assert provider.dimension == 768
+        assert provider.dimension == 3072
 
     def test_dimension_unknown_model_defaults_to_3072(self) -> None:
         """Should fallback to 3072 for unknown models."""


### PR DESCRIPTION
Implements the embedding-pipeline hardening from the operator handover. Root cause of the original opaque MCP `-32000`: a missing provider package + raw API calls with no retry + a hardcoded decommissioned fallback model.

## Changes
- **Retry/backoff** (`engine/embedding/retry.py`): shared `call_with_retry` (exp backoff + jitter) wrapping Gemini + OpenAI/OpenRouter calls. 429/5xx/timeout retried; 4xx re-raised immediately.
- **Dead-model guard** (`semantic_discovery._auto_detect_provider`): uses live `_DEFAULT_MODEL` (`gemini-embedding-001`, 3072-dim) instead of the decommissioned `text-embedding-004` (404s, 768-dim). Removed its stale `_MODEL_DIMENSIONS` entry.
- **Capability probe** (`engine/embedding/capability.py`): cheap `find_spec`-based check (no API calls, no heavy model loads). Surfaced in `smem_health` (`embedding` section) and as a loud, actionable startup warning with the exact `pip install 'surreal-memory[...]'` command.
- **Correct defaults**: docker-compose + `.env.example` → `gemini-embedding-001` (was experimental `gemini-embedding-exp-03-07`).

## Notes
- Existing embed call sites (dedup, retrieval, semantic discovery) already fail-soft to keyword mode; retry + startup visibility complete the picture.
- google-genai API/model confirmed current via Context7.

## Tests
- `tests/unit/test_embedding_hardening.py` — 19 tests (retry paths, auto-detect never returns dead model, capability states). Updated the obsolete text-embedding-004 dimension test. Full local run: 137 passed, ruff clean.