### PR TITLE
chore(release): 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] — 2026-05-28
+
+### Added
+- **Project-aware memory hooks** — SessionStart, PreCompact, and Stop hooks scope
+  captured memories to the current project (git repo basename as `project_id`);
+  SessionStart injects only the current project's memories.
+- **Task-context hook** — new `smem-hook-task-context` entry point persists a rich,
+  structured per-task note as one project-scoped `context` memory.
+- **SurrealDB Project entity** — `add_project` / `get_project` / `get_project_by_name`
+  / `list_projects` / `update_project` / `delete_project` restored on the SurrealDB
+  backend (parity broken by the v2.0.0 SurrealDB-only refactor); new `project` table,
+  schema version 5.
+- `get_project_memories` declared on the `NeuralStorage` base interface.
+
+### Fixed
+- **Connection close** — `SurrealDBStorage.close()` tolerates transports that don't
+  implement `close()` (the HTTP connection raises `NotImplementedError`), fixing a
+  long-running MCP server degrading to "No brain configured".
+- **CLI regression** — restored `surreal_memory/utils/sandbox.py`; `smem` no longer
+  fails with `ModuleNotFoundError` (regression from the v2.0.0 refactor).
+- **Embedding pipeline hardening** — retry/backoff, embedding-capability probe, and
+  removal of a decommissioned default model.
+- **Latent recall bug** — save hooks persist the verbatim text as the fiber summary,
+  so SessionStart actually injects context (previously `fiber.summary`/`essence` were
+  always `None`).
+- Cross-backend parity test fixture (`connect()` → `initialize()`, and skip when the
+  optional `surrealdb` package is absent).
+
+### Documentation
+- README: new **Embeddings** section (Gemini `gemini-embedding-001` recommended; local
+  `sentence-transformers` `all-MiniLM-L6-v2` / `paraphrase-multilingual-MiniLM-L12-v2`
+  as the no-API-key fallback; Ollama / OpenAI / OpenRouter; `auto` detection).
+- Fixed rename-rot ("What's Different From NeuralMemory?", `~/.neuralmemory` migration)
+  and corrected counts: 15 memory types, 41 synapse types, 5500+ tests.
+- INSTALL_PROMPT: fixed stale repository URLs; Gemini recommended (not required) with a
+  documented local no-key path.
+- `.env.example`, `AGENTS.md`, `CONTRIBUTING.md` corrections.
+
+## [2.0.0] — 2026-05-27
+
 ### Removed — InfinityDB Pro chain + SQLite/InMemory demoted to test fixtures (BREAKING)
 
 Surreal-Memory is now **SurrealDB-only** on the public surface. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.0.0"
+version = "2.0.1"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
## Summary

Release prep for **2.0.1**:
- Bump version `2.0.0` → `2.0.1` in `pyproject.toml` and `src/surreal_memory/__init__.py` (the two sources `release.yml` validates against the tag).
- Add the `[2.0.1]` CHANGELOG entry and relabel the stale `[Unreleased]` section as `[2.0.0] — 2026-05-27` (its InfinityDB-removal content shipped in the existing `v2.0.0` tag).

Contents shipping in 2.0.1 (already merged via #4): project-aware memory hooks + `smem-hook-task-context`, SurrealDB Project entity, tolerant `SurrealDBStorage.close()` (fixes MCP "No brain configured"), CLI `sandbox` regression fix, embedding pipeline hardening, and a docs/accuracy pass.

## Not included
- npm (`surrealmemory`, `@acidkill/surreal-memory-client`) and the VS Code extension stay at 2.0.0 — they publish on their own RC cadence and `release.yml` only gates the Python package. (Their `package.json` is also caught by an over-broad `package.json` `.gitignore` rule — noted separately.)

## Release steps (after this merges)
1. `git tag v2.0.1 <merge-commit>` and push the tag → `release.yml` validates version == tag and publishes.
   - or publish the prepared GitHub **draft release** `v2.0.1` (targets `main`).
2. Verify the PyPI publish + GitHub release.

## Test plan
- [x] version consistent across `pyproject.toml` + `__init__.py` (2.0.1)
- [x] CHANGELOG entry added; `[2.0.0]` relabeled
- [ ] CI green on this PR
- [ ] tag push → `release.yml` publishes