### PR TITLE
chore(release): 2.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,7 +205,7 @@ en_core_web_lg/
 # Node (root-level tooling — dashboard has its own entry above)
 node_modules/
 package-lock.json
-package.json
+/package.json
 
 # Pay-hub (Cloudflare Worker — closed source, separate repo)
 pay-hub/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-05-28
+
+### Added
+- **Project-aware memory hooks** — SessionStart, PreCompact, and Stop hooks scope
+  captured memories to the current project (git repo basename as `project_id`);
+  SessionStart injects only the current project's memories.
+- **Task-context hook** — new `smem-hook-task-context` entry point persists a rich,
+  structured per-task note as one project-scoped `context` memory.
+- **SurrealDB Project entity** — `add_project` / `get_project` / `get_project_by_name`
+  / `list_projects` / `update_project` / `delete_project` restored on the SurrealDB
+  backend (parity broken by the v2.0.0 SurrealDB-only refactor); new `project` table,
+  schema version 5.
+- `get_project_memories` declared on the `NeuralStorage` base interface.
+
+### Fixed
+- **Connection close** — `SurrealDBStorage.close()` tolerates transports that don't
+  implement `close()` (the HTTP connection raises `NotImplementedError`), fixing a
+  long-running MCP server degrading to "No brain configured".
+- **CLI regression** — restored `surreal_memory/utils/sandbox.py`; `smem` no longer
+  fails with `ModuleNotFoundError` (regression from the v2.0.0 refactor).
+- **Embedding pipeline hardening** — retry/backoff, embedding-capability probe, and
+  removal of a decommissioned default model.
+- **Latent recall bug** — save hooks persist the verbatim text as the fiber summary,
+  so SessionStart actually injects context (previously `fiber.summary`/`essence` were
+  always `None`).
+- Cross-backend parity test fixture (`connect()` → `initialize()`, and skip when the
+  optional `surrealdb` package is absent).
+
+### Documentation
+- README: new **Embeddings** section (Gemini `gemini-embedding-001` recommended; local
+  `sentence-transformers` `all-MiniLM-L6-v2` / `paraphrase-multilingual-MiniLM-L12-v2`
+  as the no-API-key fallback; Ollama / OpenAI / OpenRouter; `auto` detection).
+- Fixed rename-rot ("What's Different From NeuralMemory?", `~/.neuralmemory` migration)
+  and corrected counts: 15 memory types, 41 synapse types, 5500+ tests.
+- INSTALL_PROMPT: fixed stale repository URLs; Gemini recommended (not required) with a
+  documented local no-key path.
+- `.env.example`, `AGENTS.md`, `CONTRIBUTING.md` corrections.
+
+## [2.0.0] — 2026-05-27
+
 ### Removed — InfinityDB Pro chain + SQLite/InMemory demoted to test fixtures (BREAKING)
 
 Surreal-Memory is now **SurrealDB-only** on the public surface. The

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "1.6.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "1.6.2",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.0.0"
+version = "2.1.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 __all__ = [
     "__version__",

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.0.0"
+        assert surreal_memory.__version__ == "2.1.0"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "0.4.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "0.4.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Release **2.1.0** — version unified across **every** package (no skew):
- `pyproject.toml`, `src/surreal_memory/__init__.py`
- npm `surrealmemory` (OpenClaw plugin) + `@acidkill/surreal-memory-client` (SDK) — `package.json` **and** lockfile root
- VS Code extension — `package.json` **and** lockfile root
- `CHANGELOG.md`: new `[2.1.0]`; stale `[Unreleased]` relabeled `[2.0.0] — 2026-05-27`

Minor bump (semver): 2.1.0 adds backward-compatible features (project-aware hooks, `smem-hook-task-context`, SurrealDB Project entity) on top of the connection/CLI fixes + docs pass from #4.

Also narrows the over-broad `package.json` `.gitignore` rule to `/package.json` (root only) so satellite manifests aren't accidentally ignored.

### Heads-up — pre-existing debt (not fixed here)
Satellite lockfile roots had drifted before this PR (`surrealmemory` lock was `1.6.2`, vscode lock was `0.4.1`) and the npm package **names** differ (`@surrealmemory/openclaw-plugin`, `surrealmemory`, `@acidkill/surreal-memory-client`). Versions are now unified to 2.1.0; name/lockfile-regeneration hygiene is a separate follow-up.

## Release steps (after merge)
1. Publish the prepared **draft release `v2.1.0`** (targets `main`) → creates tag `v2.1.0` → `release.yml` validates (tag == pyproject == __init__) and publishes PyPI + npm + ClawHub + VS Code.
   - or `git tag v2.1.0 <merge-commit> && git push origin v2.1.0`.

## Test plan
- [x] version == 2.1.0 across `pyproject` + `__init__` + 3 `package.json` (+ lockfile roots)
- [x] CHANGELOG `[2.1.0]` added; `[2.0.0]` relabeled
- [x] CI green on this PR
- [x] tag push → `release.yml` publishes