### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] — 2026-05-28
+
+### Added
+- **Embedding env overrides** — the unified config now honors
+  `SURREAL_MEMORY_EMBEDDING_ENABLED` / `_PROVIDER` / `_MODEL` /
+  `_SIMILARITY_THRESHOLD` (precedence: env > `config.toml` > default), so the
+  MCP server and CLI follow the embedding provider set in their environment.
+- **`smem reindex`** — (re)embed a brain's neurons with the effective provider.
+  Flags: `--dry-run`, `--missing-only` (default) / `--all`, `--batch-size`;
+  idempotent and fail-soft per neuron.
+
+### Changed
+- **Effective config wins** — embedding `enabled`/`provider`/`model` now resolve
+  from the effective config (`config.toml` + env) instead of the stale stored
+  `brain.config`. Fixes embeddings silently staying disabled after a user edits
+  their config/env. `smem_health` now reports the effective embedding state.
+
+### Performance
+- The Stop hook no longer loads a local `sentence-transformers` model on every
+  session end (it was the dominant session-save latency). Semantic dedup uses a
+  local Ollama server when one is running, otherwise it is skipped.
+
 ## [2.1.0] — 2026-05-28
 
 ### Added

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.1.0"
+version = "2.2.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 __all__ = [
     "__version__",

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.1.0"
+        assert surreal_memory.__version__ == "2.2.0"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Release **2.2.0** (minor — new features from #8). Version unified to 2.2.0 across **all** packages: `pyproject.toml`, `src/surreal_memory/__init__.py`, the pinned `test_health_fixes` assertion, the 3 npm/vscode `package.json` **and** their `package-lock.json` roots, and `CHANGELOG.md`.

### What's in 2.2.0 (merged via #8)
- Honor `SURREAL_MEMORY_EMBEDDING_*` env overrides in the unified config (env > config.toml > default).
- `smem reindex` — (re)embed neurons with the effective provider (`--dry-run`, `--missing-only`/`--all`).
- **Effective config wins** — embedding resolves from config.toml + env, not the stale stored brain config (fixes silently-disabled embeddings).
- Stop hook no longer loads a sentence-transformers model every session end.

## Release steps (after merge)
1. Publish the prepared **draft release `v2.2.0`** (targets `main`) → tag `v2.2.0` → `release.yml` validates (tag == pyproject == __init__) and publishes PyPI (npm/ClawHub/VSCode skip cleanly if unconfigured, per #7).

## Test plan
- [x] version == 2.2.0 across all sources (+ lockfile roots); `test_version_is_current` passes
- [x] CHANGELOG `[2.2.0]` added
- [x] CI green on this PR