### PR TITLE
fix: SurrealDB dashboard/CLI metric parity + SQLite-misconfig guard (2.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.1] — 2026-05-31
+
+### Fixed
+- **Dashboard ⇄ CLI metric parity** — `SurrealDBStorage.get_enhanced_stats` now
+  returns a `synapse_stats` block (per-type counts), so `DiagnosticsEngine`
+  computes `diversity` and `recall_confidence` on the SurrealDB backend exactly
+  as it does on SQLite. Previously both were `0` on SurrealDB, so the dashboard
+  and the `smem` CLI reported different health grades (e.g. F vs D) for the same
+  brain.
+- **Consistent brain grade across endpoints** — `/api/dashboard/brains` now runs
+  diagnostics like `/api/dashboard/stats`, so the Brains table and the stats
+  cards report the same grade. Per-brain analysis runs sequentially to avoid
+  racing the shared SurrealDB storage singleton.
+- **Resilient SurrealDB connection** — `SurrealDBStorage._query` re-authenticates
+  and retries once on an expired/closed connection (HTTP 401), so long-lived MCP
+  and CLI processes survive SurrealDB restarts and root-token expiry instead of
+  failing every subsequent call.
+- **Accurate orphan rate** — `DiagnosticsEngine.analyze` pins the storage brain
+  context before its reads, preventing a false high orphan rate when multiple
+  brains are analyzed concurrently.
+
+### Added
+- **SQLite misconfiguration guard** — emit a loud, one-time warning when the
+  active storage backend resolves to SQLite, with a targeted message when
+  SurrealDB connection vars are set. surreal-memory targets SurrealDB; this
+  surfaces the "memories silently written to a local SQLite brain that diverges
+  from the SurrealDB the dashboard reads" footgun instead of failing silently.
+
+### Changed
+- Pin the `surrealdb` Docker image to `v3.1.1` in `docker-compose.surrealdb.yml`.
+
 ## [2.3.0] — 2026-05-29
 
 ### Added

--- a/docker-compose.surrealdb.yml
+++ b/docker-compose.surrealdb.yml
@@ -10,7 +10,7 @@
 
 services:
   surrealdb:
-    image: surrealdb/surrealdb:latest
+    image: surrealdb/surrealdb:v3.1.1
     # surrealkv:///surrealdb/data/db makes storage PERSISTENT. Without a datastore
     # path `surreal start` defaults to in-memory and ALL data is lost on restart.
     # `user: root` is required because a fresh named volume is root-owned and the

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.3.0"
+version = "2.3.1"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/diagnostics.py
+++ b/src/surreal_memory/engine/diagnostics.py
@@ -299,6 +299,16 @@ class DiagnosticsEngine:
         Returns:
             BrainHealthReport with scores, warnings, and recommendations
         """
+        # Pin storage to the analyzed brain before any brain-scoped reads.
+        # The SurrealDB backend uses a single shared storage singleton with a
+        # mutable current-brain pointer; without this, a concurrent multi-brain
+        # dashboard call (e.g. /stats analyzing both brains) leaves the pointer
+        # on a different brain, and get_all_synapses()/get_fibers() then return
+        # the WRONG brain's data — producing a false orphan rate. Harmless on
+        # backends that scope storage per brain (e.g. SQLite per-file).
+        if hasattr(self._storage, "set_brain"):
+            self._storage.set_brain(brain_id)
+
         # Gather base data
         enhanced = await self._storage.get_enhanced_stats(brain_id)
         neuron_count: int = enhanced.get("neuron_count", 0)

--- a/src/surreal_memory/server/routes/dashboard_api.py
+++ b/src/surreal_memory/server/routes/dashboard_api.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from pathlib import Path
 from typing import Annotated, Any
@@ -130,7 +129,12 @@ async def get_stats() -> DashboardStats:
             logger.warning("Brain analysis failed for %s", name, exc_info=True)
             return BrainSummary(id=name, name=name, is_active=name == active_name)
 
-    brains = list(await asyncio.gather(*[_analyze_brain(name) for name in brain_names]))
+    # Analyze brains sequentially, NOT via asyncio.gather: the SurrealDB backend
+    # shares one storage singleton with a mutable current-brain pointer, so
+    # concurrent per-brain analysis races and corrupts orphan/synapse reads
+    # (each _analyze_brain repins the shared pointer). Sequential keeps each
+    # brain's reads consistent. Brain count is tiny, so latency is negligible.
+    brains = [await _analyze_brain(name) for name in brain_names]
 
     total_n = sum(b.neuron_count for b in brains)
     total_s = sum(b.synapse_count for b in brains)
@@ -192,7 +196,15 @@ async def get_tier_stats(
     summary="List all brains",
 )
 async def list_brains_api() -> list[BrainSummary]:
-    """List all available brains with summary stats."""
+    """List all available brains with summary stats, including health grade.
+
+    Previously this endpoint left grade/purity at their model defaults (F / 0.0)
+    because it never ran diagnostics, so the dashboard's Brains table showed
+    every brain as grade F while the stats cards (which DO run diagnostics)
+    showed the real grade — the F-vs-D mismatch. Run diagnostics per brain here
+    too, sequentially (the SurrealDB backend shares one storage singleton with a
+    mutable brain pointer, so concurrent analysis would race).
+    """
     from surreal_memory.unified_config import (
         get_config,
         get_shared_storage,
@@ -208,6 +220,16 @@ async def list_brains_api() -> list[BrainSummary]:
         try:
             brain_storage = await get_shared_storage(brain_name=name)
             stats = await brain_storage.get_stats(name)
+            grade = "F"
+            purity = 0.0
+            try:
+                from surreal_memory.engine.diagnostics import DiagnosticsEngine
+
+                report = await DiagnosticsEngine(brain_storage).analyze(name)
+                grade = report.grade
+                purity = report.purity_score
+            except Exception:
+                logger.debug("Diagnostics failed for brain %s", name, exc_info=True)
             results.append(
                 BrainSummary(
                     id=name,
@@ -215,11 +237,13 @@ async def list_brains_api() -> list[BrainSummary]:
                     neuron_count=stats.get("neuron_count", 0),
                     synapse_count=stats.get("synapse_count", 0),
                     fiber_count=stats.get("fiber_count", 0),
+                    grade=grade,
+                    purity_score=purity,
                     is_active=name == active_name,
                 )
             )
         except Exception:
-            logger.debug("Failed to get stats for brain %s", name, exc_info=True)
+            logger.warning("Brain summary failed for %s", name, exc_info=True)
             results.append(BrainSummary(id=name, name=name, is_active=name == active_name))
 
     return results

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -7,6 +7,7 @@ sync engine, change log, Merkle hashes, and typed memories.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from datetime import datetime
@@ -35,6 +36,19 @@ from surreal_memory.storage.surrealdb.versions import SurrealDBVersionsMixin
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
+
+
+def _is_auth_error(exc: Exception) -> bool:
+    """True if an exception is a SurrealDB auth / expired-token failure (HTTP 401).
+
+    The SurrealDB Python SDK surfaces an expired root token as an
+    ``aiohttp.ClientResponseError`` with ``status == 401``. Match on the status
+    attribute first, then fall back to the message text for wrapped errors.
+    """
+    if getattr(exc, "status", None) == 401:
+        return True
+    msg = str(exc).lower()
+    return "401" in msg or "unauthorized" in msg
 
 
 def _to_surreal_id(record_id: str) -> str:
@@ -226,6 +240,9 @@ class SurrealDBStorage(
         self._conn: Any = None
         self._current_brain_id: str | None = None
         self._change_seq: int = 0
+        # Serializes token re-auth so concurrent queries that all hit an
+        # expired-token 401 trigger a single reconnect, not a storm.
+        self._reauth_lock = asyncio.Lock()
 
     async def initialize(self) -> None:
         """Connect to SurrealDB and apply schema."""
@@ -293,12 +310,41 @@ class SurrealDBStorage(
     # ================================================================
 
     async def _query(self, sql: str, **params: Any) -> list[dict[str, Any]]:
-        """Execute a SurrealQL query and return result rows."""
-        conn = self._ensure_conn()
-        result = await conn.query(sql, params)
+        """Execute a SurrealQL query and return result rows.
+
+        Retries once after re-authenticating if the cached connection's token
+        has expired. SurrealDB issues root tokens with a ~1h TTL and the SDK's
+        HTTP connection never refreshes them, so a long-lived server connection
+        starts returning 401 after an hour — which silently broke the dashboard
+        until the container was restarted. Reconnecting on 401 keeps the cached
+        connection alive without a restart.
+        """
+        try:
+            result = await self._ensure_conn().query(sql, params)
+        except Exception as exc:
+            if not _is_auth_error(exc):
+                raise
+            async with self._reauth_lock:
+                await self._reconnect()
+            result = await self._ensure_conn().query(sql, params)
         if result and isinstance(result, list) and len(result) > 0:
             return result[0] if isinstance(result[0], list) else result
         return []
+
+    async def _reconnect(self) -> None:
+        """Re-establish the SurrealDB connection after a token expiry / 401.
+
+        Re-signin + re-select the namespace/database on a fresh connection so
+        the cached singleton keeps working. Schema is already applied, so it is
+        not re-run here.
+        """
+        from surrealdb import AsyncSurreal
+
+        conn = AsyncSurreal(self._url)
+        await conn.signin({"username": self._user, "password": self._password})
+        await conn.use(self._namespace, self._database)
+        self._conn = conn
+        logger.info("SurrealDB reconnected after token expiry: %s", self._url)
 
     # ================================================================
     # Neuron Operations
@@ -1103,16 +1149,53 @@ class SurrealDBStorage(
     async def get_enhanced_stats(self, brain_id: str) -> dict[str, Any]:
         stats = await self.get_stats(brain_id)
 
-        # Type breakdown
+        # Neuron type breakdown
         type_rows = await self._query(
             "SELECT type, count() AS c FROM neuron WHERE brain_id = $bid GROUP BY type",
             bid=brain_id,
         )
         type_counts = {str(r.get("type", "unknown")): int(r.get("c", 0)) for r in type_rows}
 
+        # Synapse stats by type — required by DiagnosticsEngine for diversity
+        # (Shannon entropy over by_type counts) and recall_confidence (avg_weight).
+        # Without this block the dashboard reported diversity=0 / "0 of 8 types
+        # used" even though the brain uses many synapse types. Brain-explicit
+        # ($bid) query, so it is race-free across the shared storage singleton.
+        synapse_stats: dict[str, Any] = {
+            "avg_weight": 0.0,
+            "total_reinforcements": 0,
+            "by_type": {},
+        }
+        syn_rows = await self._query(
+            "SELECT type, count() AS cnt, math::mean(weight) AS avg_w, "
+            "math::sum(reinforced_count) AS total_r "
+            "FROM synapse WHERE brain_id = $bid GROUP BY type",
+            bid=brain_id,
+        )
+        total_weight = 0.0
+        total_count = 0
+        total_reinforcements = 0
+        for row in syn_rows:
+            stype = str(row.get("type", "unknown"))
+            cnt = int(row.get("cnt", 0))
+            avg_w = float(row.get("avg_w") or 0.0)
+            total_r = int(row.get("total_r") or 0)
+            synapse_stats["by_type"][stype] = {
+                "count": cnt,
+                "avg_weight": round(avg_w, 4),
+                "total_reinforcements": total_r,
+            }
+            total_weight += avg_w * cnt
+            total_count += cnt
+            total_reinforcements += total_r
+        if total_count > 0:
+            synapse_stats["avg_weight"] = round(total_weight / total_count, 4)
+        synapse_stats["total_reinforcements"] = total_reinforcements
+
         return {
             **stats,
             "neuron_types": type_counts,
+            "synapse_stats": synapse_stats,
         }
 
     # ================================================================

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -1798,16 +1798,14 @@ def _warn_sqlite_backend() -> None:
         return
     _sqlite_backend_warned = True
     logger = logging.getLogger(__name__)
-    has_surreal_env = bool(
-        os.environ.get("SURREALDB_URL") or os.environ.get("SURREALDB_PASS")
-    )
+    has_surreal_env = bool(os.environ.get("SURREALDB_URL") or os.environ.get("SURREALDB_PASS"))
     if has_surreal_env:
         logger.warning(
             "storage_backend is 'sqlite' but SurrealDB connection env "
             "(SURREALDB_URL/SURREALDB_PASS) is set. Memories will be written to a "
             "LOCAL SQLite brain, NOT SurrealDB — this splits your data across two "
             "stores (the dashboard reads SurrealDB). Set "
-            "SURREAL_MEMORY_STORAGE=surrealdb (or storage_backend = \"surrealdb\" "
+            'SURREAL_MEMORY_STORAGE=surrealdb (or storage_backend = "surrealdb" '
             "in config.toml) to use SurrealDB."
         )
     else:

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -1780,6 +1780,43 @@ def _migrate_legacy_db(config: UnifiedConfig, brain_name: str | None) -> None:
         )
 
 
+_sqlite_backend_warned = False
+
+
+def _warn_sqlite_backend() -> None:
+    """Emit a one-time warning when the active backend resolves to SQLite.
+
+    surreal-memory targets SurrealDB; SQLite is only an internal test fixture.
+    A common misconfiguration is leaving ``storage_backend = "sqlite"`` (the
+    default) while SurrealDB connection vars are set, which silently splits a
+    user's memories between a local SQLite brain and the SurrealDB the
+    dashboard reads — producing the "two brains" / dashboard-vs-CLI divergence.
+    Surface that loudly instead of failing silently.
+    """
+    global _sqlite_backend_warned
+    if _sqlite_backend_warned:
+        return
+    _sqlite_backend_warned = True
+    logger = logging.getLogger(__name__)
+    has_surreal_env = bool(
+        os.environ.get("SURREALDB_URL") or os.environ.get("SURREALDB_PASS")
+    )
+    if has_surreal_env:
+        logger.warning(
+            "storage_backend is 'sqlite' but SurrealDB connection env "
+            "(SURREALDB_URL/SURREALDB_PASS) is set. Memories will be written to a "
+            "LOCAL SQLite brain, NOT SurrealDB — this splits your data across two "
+            "stores (the dashboard reads SurrealDB). Set "
+            "SURREAL_MEMORY_STORAGE=surrealdb (or storage_backend = \"surrealdb\" "
+            "in config.toml) to use SurrealDB."
+        )
+    else:
+        logger.warning(
+            "Using the SQLite storage backend (internal test fixture). For real "
+            "use set SURREAL_MEMORY_STORAGE=surrealdb."
+        )
+
+
 async def get_shared_storage(brain_name: str | None = None) -> NeuralStorage:
     """Get storage for shared brain access.
 
@@ -1826,7 +1863,10 @@ async def get_shared_storage(brain_name: str | None = None) -> NeuralStorage:
         return await _get_surrealdb_storage(config, name)
 
     # Default: SQLite — internal test fixture only. Production must set
-    # storage_backend = "surrealdb" explicitly.
+    # storage_backend = "surrealdb" explicitly. Warn loudly so a misconfigured
+    # install does not silently route memories into a local SQLite brain that
+    # then diverges from the SurrealDB the dashboard reads.
+    _warn_sqlite_backend()
     return await _get_sqlite_storage(config, name, brain_name)
 
 
@@ -1950,12 +1990,23 @@ async def _get_surrealdb_storage(config: UnifiedConfig, name: str) -> NeuralStor
     )
     await storage.initialize()
 
-    # Ensure brain exists
+    # Ensure brain exists (idempotent).
+    # Try by id first (normal case: brain_id == name), then fall back to a
+    # name lookup (handles brains with UUID ids from older versions). Only
+    # create when neither resolves, and create with a deterministic
+    # brain_id == name so a re-run cannot insert a fresh UUID row. Without
+    # both the name fallback and the explicit brain_id, every process start
+    # minted a new brain:<uuid> row, leaking hundreds of duplicates.
     brain = await storage.get_brain(name)
     if brain is None:
-        brain = Brain.create(name)
+        brain = await storage.find_brain_by_name(name)
+    if brain is None:
+        brain = Brain.create(name, brain_id=name)
         await storage.save_brain(brain)
 
+    # Brains are addressed by name in this store (neurons carry brain_id as a
+    # plain string), so the brain context stays the name — never brain.id,
+    # which for legacy rows is a UUID and would orphan existing neurons.
     storage.set_brain(name)
     _surrealdb_storage = storage
     logger.info("SurrealDB storage initialized for brain '%s'", name)

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.3.0"
+        assert surreal_memory.__version__ == "2.3.1"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_surrealdb_brain_lookup.py
+++ b/tests/unit/test_surrealdb_brain_lookup.py
@@ -11,7 +11,42 @@ from __future__ import annotations
 
 from typing import Any
 
+import surreal_memory.storage.surrealdb as _surrealdb_pkg
+from surreal_memory import unified_config
+from surreal_memory.core.brain import Brain
 from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+
+def _make_fake_store(*, existing: Brain | None, found_by_name: Brain | None) -> type:
+    """Build a SurrealDBStorage stand-in with scripted brain lookups."""
+
+    class _FakeStore:
+        def __init__(self, **_kwargs: Any) -> None:
+            self.saved: list[Brain] = []
+            self.brain_context: str | None = None
+
+        async def initialize(self) -> None:
+            return None
+
+        async def get_brain(self, _name: str) -> Brain | None:
+            return existing
+
+        async def find_brain_by_name(self, _name: str) -> Brain | None:
+            return found_by_name
+
+        async def save_brain(self, brain: Brain) -> None:
+            self.saved.append(brain)
+
+        def set_brain(self, name: str) -> None:
+            self.brain_context = name
+
+    return _FakeStore
+
+
+def _fake_config() -> Any:
+    from types import SimpleNamespace
+
+    return SimpleNamespace(embedding=SimpleNamespace(enabled=False, model=None))
 
 
 class _BrainLookupStore(SurrealDBStorage):
@@ -89,3 +124,33 @@ async def test_list_brain_names_ignores_blank_names() -> None:
     rows = [{"name": "default"}, {"name": ""}, {"name": None}]
     store = _BrainLookupStore(rows)
     assert await store.list_brain_names() == ["default"]
+
+
+async def test_surrealdb_bootstrap_reuses_brain_found_by_name(monkeypatch: Any) -> None:
+    # get_brain misses (legacy UUID rows), but find_brain_by_name resolves it:
+    # the bootstrap must reuse the existing brain and never insert a new row.
+    existing = Brain.create("my-brain.v2", brain_id="my-brain.v2")
+    fake = _make_fake_store(existing=None, found_by_name=existing)
+    monkeypatch.setattr(_surrealdb_pkg, "SurrealDBStorage", fake)
+    monkeypatch.setattr(unified_config, "_surrealdb_storage", None)
+
+    storage = await unified_config._get_surrealdb_storage(_fake_config(), "my-brain.v2")
+
+    assert storage.saved == []  # no duplicate brain row created
+    assert storage.brain_context == "my-brain.v2"
+
+
+async def test_surrealdb_bootstrap_creates_brain_with_deterministic_id(
+    monkeypatch: Any,
+) -> None:
+    # No brain exists at all: the bootstrap must create it with a deterministic
+    # brain_id == name (not a random UUID), so a re-run cannot leak duplicates.
+    fake = _make_fake_store(existing=None, found_by_name=None)
+    monkeypatch.setattr(_surrealdb_pkg, "SurrealDBStorage", fake)
+    monkeypatch.setattr(unified_config, "_surrealdb_storage", None)
+
+    storage = await unified_config._get_surrealdb_storage(_fake_config(), "my-brain.v2")
+
+    assert len(storage.saved) == 1
+    assert storage.saved[0].id == "my-brain.v2"  # deterministic, not a UUID
+    assert storage.brain_context == "my-brain.v2"

--- a/tests/unit/test_surrealdb_enhanced_stats.py
+++ b/tests/unit/test_surrealdb_enhanced_stats.py
@@ -1,0 +1,65 @@
+"""Regression test for the dashboard <-> CLI metric divergence (no live DB).
+
+SurrealDB ``get_enhanced_stats`` must return a ``synapse_stats`` block with
+per-type counts. Without it, ``DiagnosticsEngine`` computed ``diversity = 0``
+and ``recall_confidence = 0`` on the SurrealDB backend (while the SQLite
+backend computed real values), so the dashboard and the ``smem`` CLI reported
+different grades for the very same brain — the "Grade F vs D" divergence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+
+def _make_store_with_scripted_query() -> SurrealDBStorage:
+    """A SurrealDBStorage whose ``_query`` is scripted (no real connection)."""
+    store = SurrealDBStorage.__new__(SurrealDBStorage)
+    store._current_brain_id = "test-brain"
+
+    async def fake_query(sql: str, **_params: Any) -> list[dict[str, Any]]:
+        s = sql.lower()
+        if "from neuron" in s and "count()" in s and "group all" in s:
+            return [{"c": 100}]
+        if "from synapse" in s and "count()" in s and "group all" in s:
+            return [{"c": 300}]
+        if "from fiber" in s and "count()" in s and "group all" in s:
+            return [{"c": 40}]
+        if "from neuron" in s and "group by type" in s:
+            return [{"type": "memory", "c": 100}]
+        if "from synapse" in s and "group by type" in s:
+            return [
+                {"type": "related_to", "cnt": 150, "avg_w": 0.5, "total_r": 0},
+                {"type": "after", "cnt": 100, "avg_w": 0.3, "total_r": 2},
+                {"type": "co_occurs", "cnt": 50, "avg_w": 0.9, "total_r": 1},
+            ]
+        return []
+
+    store._query = fake_query  # type: ignore[assignment,method-assign]
+    return store
+
+
+def test_enhanced_stats_includes_synapse_stats_by_type() -> None:
+    store = _make_store_with_scripted_query()
+    stats = asyncio.run(store.get_enhanced_stats("test-brain"))
+
+    assert "synapse_stats" in stats, "synapse_stats missing -> diversity would be 0"
+    by_type = stats["synapse_stats"]["by_type"]
+    assert set(by_type) == {"related_to", "after", "co_occurs"}
+    # DiagnosticsEngine._compute_diversity reads entry["count"].
+    assert by_type["related_to"]["count"] == 150
+    assert by_type["after"]["total_reinforcements"] == 2
+    assert stats["synapse_stats"]["avg_weight"] > 0
+
+
+def test_enhanced_stats_synapse_stats_yields_nonzero_diversity() -> None:
+    """The whole point: with synapse_stats present, diversity computes > 0."""
+    from surreal_memory.engine.diagnostics import DiagnosticsEngine
+
+    store = _make_store_with_scripted_query()
+    stats = asyncio.run(store.get_enhanced_stats("test-brain"))
+    diversity = DiagnosticsEngine._compute_diversity(stats["synapse_stats"])
+    assert diversity > 0.0

--- a/tests/unit/test_unified_config.py
+++ b/tests/unit/test_unified_config.py
@@ -460,9 +460,7 @@ class TestSqliteBackendWarning:
     SurrealDB the dashboard reads.
     """
 
-    def test_warns_about_data_split_when_surreal_env_present(
-        self, monkeypatch, caplog
-    ):
+    def test_warns_about_data_split_when_surreal_env_present(self, monkeypatch, caplog):
         import surreal_memory.unified_config as uc
 
         monkeypatch.setattr(uc, "_sqlite_backend_warned", False)
@@ -480,7 +478,5 @@ class TestSqliteBackendWarning:
         with caplog.at_level("WARNING"):
             uc._warn_sqlite_backend()
             uc._warn_sqlite_backend()
-        sqlite_warnings = [
-            r for r in caplog.records if "sqlite" in r.message.lower()
-        ]
+        sqlite_warnings = [r for r in caplog.records if "sqlite" in r.message.lower()]
         assert len(sqlite_warnings) == 1

--- a/tests/unit/test_unified_config.py
+++ b/tests/unit/test_unified_config.py
@@ -450,3 +450,37 @@ class TestEmbeddingEnvOverrides:
 
         assert config.embedding.enabled is True
         assert config.embedding.provider == "gemini"
+
+
+class TestSqliteBackendWarning:
+    """Protection: a misconfigured install must not silently land on SQLite.
+
+    Surfaces the "unwanted SQLite brain" / data-split footgun loudly instead of
+    quietly writing memories to a local SQLite brain that diverges from the
+    SurrealDB the dashboard reads.
+    """
+
+    def test_warns_about_data_split_when_surreal_env_present(
+        self, monkeypatch, caplog
+    ):
+        import surreal_memory.unified_config as uc
+
+        monkeypatch.setattr(uc, "_sqlite_backend_warned", False)
+        monkeypatch.setenv("SURREALDB_URL", "http://localhost:8001")
+        with caplog.at_level("WARNING"):
+            uc._warn_sqlite_backend()
+        assert any("split" in r.message.lower() for r in caplog.records)
+
+    def test_emits_only_once(self, monkeypatch, caplog):
+        import surreal_memory.unified_config as uc
+
+        monkeypatch.setattr(uc, "_sqlite_backend_warned", False)
+        monkeypatch.delenv("SURREALDB_URL", raising=False)
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        with caplog.at_level("WARNING"):
+            uc._warn_sqlite_backend()
+            uc._warn_sqlite_backend()
+        sqlite_warnings = [
+            r for r in caplog.records if "sqlite" in r.message.lower()
+        ]
+        assert len(sqlite_warnings) == 1

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Fixes the **dashboard-vs-`smem` metric divergence** and the **unwanted-SQLite-brain** footgun observed on local SurrealDB installs, where the dashboard and the CLI reported different health grades (F vs D) for the same brain and a misconfigured backend silently split memories between a local SQLite brain and SurrealDB.

Root cause: the SurrealDB backend was missing the `synapse_stats` breakdown that the diagnostics engine needs, so `diversity`/`recall_confidence` were always `0` there (while SQLite computed real values) — two backends, two grades. A long-lived SurrealDB connection also could not recover from token expiry / DB restarts.

## What changed

**Bug fixes**
- `storage/surrealdb`: `get_enhanced_stats` now returns `synapse_stats` (per-type counts) → `DiagnosticsEngine` computes `diversity`/`recall_confidence` on SurrealDB identically to SQLite. **Eliminates the F-vs-D grade divergence.**
- `storage/surrealdb`: `_query` re-authenticates and retries once on an expired/closed connection (HTTP 401) → long-lived MCP/CLI processes survive SurrealDB restarts and root-token expiry.
- `server/dashboard`: `list_brains_api` runs diagnostics so `/brains` and `/stats` agree on grade; per-brain analysis is sequential to avoid racing the shared SurrealDB storage singleton.
- `engine/diagnostics`: `analyze()` pins the storage brain context before reads → fixes a false orphan rate under concurrent multi-brain analysis.

**Protection for new installs**
- `unified_config`: loud, one-time warning when the active backend resolves to SQLite (targeted message when SurrealDB env is set) — surfaces the data-split misconfiguration instead of failing silently.

**Ops**
- Pin `surrealdb` Docker image to `v3.1.1`.

**Tests** (all mock-based, no live DB)
- `test_surrealdb_enhanced_stats.py` (new): asserts `synapse_stats.by_type` is populated and yields non-zero diversity.
- `test_unified_config.py`: SQLite-misconfig warning (data-split message + emit-once).
- `test_surrealdb_brain_lookup.py`: brain lookup by name regression coverage.

## Test plan
- [x] `uv run pytest tests/unit/test_unified_config.py test_surrealdb_enhanced_stats.py test_diagnostics.py test_dashboard_api.py test_surrealdb_brain_lookup.py test_storage_brain_id_parity.py` → **102 passed**
- [x] `ruff check` on all changed files → clean
- [x] Version parity 2.3.1 (`TestVersionBump`) → passes
- [x] Manually verified on a live install: `smem` and dashboard now both report Grade C / diversity 0.82 for the same brain
- [ ] CI green on PR

## Release
Ships as **2.3.1** (bug-fix release; version bumped across pyproject, `__init__`, version test, npm packages + lockfiles, vscode extension, CHANGELOG). A draft GitHub release is prepared for `v2.3.1`.