### PR TITLE
chore(release): 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.2] — 2026-06-01
+
+### Fixed
+- **SurrealDB auth fail-fast** — `SurrealDBStorage.initialize()` and `_reconnect()` now
+  raise `StorageAuthError` (actionable) instead of propagating the raw SDK
+  `NotAllowedError`. The MCP server surfaces this as JSON-RPC code `-32001` with a
+  hint pointing to `SURREALDB_PASS` and `smem doctor --fix`, replacing the opaque
+  `-32000 "failed unexpectedly"` that made bad-credential failures invisible.
+- **Default password unified** — the silent default `SURREALDB_PASS=root` (which never
+  matched the Docker default `surrealmemory`) is replaced by a single source of truth
+  in `storage/surrealdb/connection.py`. Both `store.py` and `unified_config.py` now
+  derive the default from this module, eliminating the drift that caused clean-install
+  auth failures.
+
+### Added
+- **`storage/surrealdb/connection.py`** (new module) — `SurrealSettings.from_env()`,
+  `StorageAuthError`, `is_credential_error()`, `build_mcp_env()`; single source of
+  truth for all SurrealDB connection defaults.
+- **Claude Desktop MCP support** — `smem init` and `smem setup mcp` now write the
+  `surreal-memory` entry (including the full `env` block with `SURREALDB_PASS`) to
+  `claude_desktop_config.json` on Linux, macOS, and Windows. Existing entries without
+  `env` are backfilled automatically.
+- **`env` block in all MCP configs** — `find_smem_command()` always returns an `env`
+  dict so newly written Claude Code and Cursor configs include SurrealDB connection
+  variables, preventing the "empty env" bug on clean installs.
+- **`smem doctor` SurrealDB checks** — two new diagnostic checks:
+  - `SurrealDB connection` (TIER_CORE): live auth test with 5-second timeout; FAIL
+    with actionable fix on `StorageAuthError`.
+  - `MCP env completeness` (TIER_RECOMMENDED): verifies `SURREALDB_PASS` is present
+    in the `env` block of each MCP client config.
+  - `smem doctor --fix` backfills missing env in all detected client configs.
+- **`_warn_missing_surreal_pass()`** — one-time warning when `storage=surrealdb` is
+  active but `SURREALDB_PASS` is unset.
+
+### Changed
+- `_check_brain` and `_check_schema_version` in `smem doctor` now return `SKIP`
+  (not `FAIL`) when the SurrealDB backend is active — those checks are SQLite-only.
+- `setup_mcp_claude()` uses JSON write path exclusively (the `claude mcp add` CLI
+  does not support the `env` block). Behaviour from the user perspective is identical.
+- `SURREALDB_PASS` default (`surrealmemory`) documented in installation and
+  contributing guides.
+
 ## [2.3.1] — 2026-05-31
 
 ### Fixed

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -90,8 +90,8 @@ make verify
 | `SURREAL_MEMORY_PORT` | No | `8000` | REST server port |
 | `SURREAL_MEMORY_TRUSTED_NETWORKS` | No | — | Trusted CIDR ranges (comma-separated) |
 | `SURREALDB_URL` | SurrealDB only | `http://localhost:8001` | SurrealDB endpoint |
-| `SURREALDB_USER` | SurrealDB only | — | SurrealDB username |
-| `SURREALDB_PASS` | SurrealDB only | — | SurrealDB password |
+| `SURREALDB_USER` | SurrealDB only | `root` | SurrealDB username |
+| `SURREALDB_PASS` | SurrealDB only | `surrealmemory` | SurrealDB password |
 | `SURREALDB_NS` | No | `surreal_memory` | SurrealDB namespace |
 | `SURREALDB_DB` | No | `default` | SurrealDB database name |
 | `SURREAL_MEMORY_ENCRYPTION_ENABLED` | No | `false` | Enable memory encryption at rest |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -97,7 +97,7 @@ Set these before starting `smem-mcp` (add to `~/.bashrc` or `~/.zshrc`):
 | `SURREAL_MEMORY_STORAGE` | `sqlite` | Set to `surrealdb` |
 | `SURREALDB_URL` | — | `http://localhost:8001` |
 | `SURREALDB_USER` | — | `root` |
-| `SURREALDB_PASS` | — | Your SurrealDB password |
+| `SURREALDB_PASS` | — | Your SurrealDB password. Default: `surrealmemory` |
 | `SURREALDB_NS` | — | `surreal_memory` |
 | `SURREALDB_DB` | — | `default` |
 | `GEMINI_API_KEY` | — | Your Gemini API key |

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.3.1"
+version = "2.3.2"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.3.1"
+__version__ = "2.3.2"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/cli/commands/tools.py
+++ b/src/surreal_memory/cli/commands/tools.py
@@ -241,6 +241,7 @@ def init(
         setup_config,
         setup_hooks_claude,
         setup_mcp_claude,
+        setup_mcp_claude_desktop,
         setup_mcp_cursor,
         setup_skills,
     )
@@ -279,6 +280,15 @@ def init(
             "failed": "failed to write config",
         }
         results["Cursor"] = cursor_labels.get(cursor_status, cursor_status)
+
+        desktop_status = setup_mcp_claude_desktop()
+        desktop_labels = {
+            "added": "claude_desktop_config.json (added MCP server)",
+            "exists": "claude_desktop_config.json (already configured)",
+            "not_found": "not detected (Claude Desktop not installed)",
+            "failed": "failed to write config",
+        }
+        results["Claude Desktop"] = desktop_labels.get(desktop_status, desktop_status)
 
     # 4. Hooks (Claude Code only)
     if not skip_mcp:

--- a/src/surreal_memory/cli/doctor.py
+++ b/src/surreal_memory/cli/doctor.py
@@ -40,7 +40,9 @@ _CHECK_TIERS: dict[str, str] = {
     "Dependencies": TIER_CORE,
     "Schema version": TIER_CORE,
     "CLI tools": TIER_CORE,
+    "SurrealDB connection": TIER_CORE,
     "Embedding provider": TIER_RECOMMENDED,
+    "MCP env completeness": TIER_RECOMMENDED,
     "MCP configuration": TIER_RECOMMENDED,
     "MCP server": TIER_RECOMMENDED,
     "Hooks": TIER_RECOMMENDED,
@@ -86,6 +88,8 @@ def run_doctor(
     checks.append(_check_surface())
     checks.append(_check_config_freshness())
     checks.append(_check_cli_tools())
+    checks.append(_check_surrealdb_connection())
+    checks.append(_check_mcp_env_completeness())
     checks.append(_check_pro_plugin())
     if dev:
         checks.extend(_check_dev_environment())
@@ -328,6 +332,12 @@ def _check_brain() -> dict[str, Any]:
 
         config = get_config(reload=True)
         brain_name = config.current_brain
+        if config.storage_backend == "surrealdb":
+            return {
+                "name": "Brain database",
+                "status": SKIP,
+                "detail": "surrealdb backend — brain lives in SurrealDB, not a local .db file",
+            }
     except Exception:
         brain_name = "default"
 
@@ -441,6 +451,12 @@ def _check_schema_version() -> dict[str, Any]:
         from surreal_memory.unified_config import get_config, get_surrealmemory_dir
 
         config = get_config(reload=True)
+        if config.storage_backend == "surrealdb":
+            return {
+                "name": "Schema version",
+                "status": SKIP,
+                "detail": "surrealdb backend — schema managed by SurrealDB, not SQLite",
+            }
         brain_name = config.current_brain
         db_path = get_surrealmemory_dir() / "brains" / f"{brain_name}.db"
 
@@ -865,6 +881,8 @@ _FIX_HANDLERS: dict[str, Any] = {
     "Dedup": lambda: _fix_dedup(),
     "Embedding provider": lambda: _fix_embedding(),
     "Config freshness": lambda: _fix_config_freshness(),
+    "MCP env completeness": lambda: _fix_mcp_env(),
+    "SurrealDB connection": lambda: _fix_mcp_env(),
 }
 
 
@@ -955,6 +973,174 @@ def _fix_config_freshness() -> dict[str, Any]:
         "name": "Config freshness",
         "status": WARN,
         "detail": "auto-fix failed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# SurrealDB-specific checks
+# ---------------------------------------------------------------------------
+
+
+def _run_surrealdb_ping() -> None:
+    """Attempt a real SurrealDB connection with a short timeout.
+
+    Raises StorageAuthError on bad credentials, any other exception on
+    connectivity issues.  Returns None on success.
+    """
+    import asyncio
+
+    from surreal_memory.storage.surrealdb.connection import SurrealSettings
+    from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+    async def _ping() -> None:
+        settings = SurrealSettings.from_env()
+        storage = SurrealDBStorage(
+            url=settings.url,
+            user=settings.user,
+            password=settings.password,
+            namespace=settings.namespace,
+            database=settings.database,
+        )
+        try:
+            await asyncio.wait_for(storage.initialize(), timeout=5)
+        finally:
+            await storage.close()
+
+    run_async(_ping())
+
+
+def _check_surrealdb_connection() -> dict[str, Any]:
+    """Check that the SurrealDB connection works (TIER_CORE for surrealdb backend).
+
+    Returns SKIP when storage backend is not surrealdb.
+    Returns FAIL with actionable hint when authentication fails.
+    Returns WARN when SurrealDB is unreachable (not running, wrong URL, etc.).
+    Returns OK on success.
+    """
+    import os
+
+    from surreal_memory.storage.surrealdb.connection import StorageAuthError
+
+    if os.environ.get("SURREAL_MEMORY_STORAGE") != "surrealdb":
+        try:
+            from surreal_memory.unified_config import get_config
+
+            config = get_config(reload=True)
+            if config.storage_backend != "surrealdb":
+                return {
+                    "name": "SurrealDB connection",
+                    "status": SKIP,
+                    "detail": "surrealdb backend not active",
+                }
+        except Exception as cfg_exc:
+            return {
+                "name": "SurrealDB connection",
+                "status": WARN,
+                "detail": f"could not load config to determine backend: {type(cfg_exc).__name__}",
+                "fix": "Check config.toml is valid; run: smem init",
+            }
+
+    try:
+        _run_surrealdb_ping()
+        return {
+            "name": "SurrealDB connection",
+            "status": OK,
+            "detail": "authenticated and connected",
+        }
+    except StorageAuthError:
+        return {
+            "name": "SurrealDB connection",
+            "status": FAIL,
+            "detail": "authentication failed (wrong password or user)",
+            "fix": "Set SURREALDB_PASS in your MCP client env or run: smem doctor --fix",
+            "fixable": True,
+        }
+    except Exception as exc:
+        return {
+            "name": "SurrealDB connection",
+            "status": WARN,
+            "detail": f"could not reach SurrealDB: {type(exc).__name__}",
+            "fix": "Ensure SurrealDB is running and SURREALDB_URL is correct",
+        }
+
+
+def _check_mcp_env_completeness() -> dict[str, Any]:
+    """Check that MCP entries contain the required env block (TIER_RECOMMENDED).
+
+    Reads ~/.claude.json (Claude Code) and claude_desktop_config.json to verify
+    that the surreal-memory entry has SURREALDB_PASS in its env block.
+    """
+    configs_to_check: list[tuple[str, Path]] = [
+        ("Claude Code (~/.claude.json)", Path.home() / ".claude.json"),
+    ]
+
+    # Also check Claude Desktop config
+    try:
+        from surreal_memory.cli.setup import _claude_desktop_config_path
+
+        desktop_path = _claude_desktop_config_path()
+        if desktop_path is not None:
+            configs_to_check.append(("Claude Desktop", desktop_path))
+    except Exception:
+        pass
+
+    missing_env: list[str] = []
+
+    for label, config_path in configs_to_check:
+        if not config_path.exists():
+            continue
+        try:
+            data = json.loads(config_path.read_text(encoding="utf-8"))
+            entry = data.get("mcpServers", {}).get("surreal-memory")
+            if entry is None:
+                continue
+            if not entry.get("env", {}).get("SURREALDB_PASS"):
+                missing_env.append(label)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+    if not any(p.exists() for _, p in configs_to_check):
+        return {
+            "name": "MCP env completeness",
+            "status": SKIP,
+            "detail": "no MCP client config files found",
+        }
+
+    if missing_env:
+        return {
+            "name": "MCP env completeness",
+            "status": WARN,
+            "detail": f"surreal-memory entry missing env in: {', '.join(missing_env)}",
+            "fix": "Run: smem doctor --fix",
+            "fixable": True,
+        }
+
+    return {
+        "name": "MCP env completeness",
+        "status": OK,
+        "detail": "env block with SURREALDB_PASS present",
+    }
+
+
+def _fix_mcp_env() -> dict[str, Any]:
+    """Auto-fix: backfill env into MCP client configs."""
+    from surreal_memory.cli.setup import setup_mcp_claude, setup_mcp_claude_desktop
+
+    try:
+        setup_mcp_claude()
+        setup_mcp_claude_desktop()
+        return {
+            "name": "MCP env completeness",
+            "status": OK,
+            "detail": "auto-fixed: env backfilled in MCP client configs",
+        }
+    except Exception:
+        pass
+    return {
+        "name": "MCP env completeness",
+        "status": WARN,
+        "detail": "auto-fix failed",
+        "fix": "Run: smem init",
     }
 
 

--- a/src/surreal_memory/cli/full_setup.py
+++ b/src/surreal_memory/cli/full_setup.py
@@ -306,6 +306,7 @@ def run_full_setup(
         setup_config,
         setup_hooks_claude,
         setup_mcp_claude,
+        setup_mcp_claude_desktop,
         setup_mcp_cursor,
         setup_skills,
     )
@@ -346,6 +347,15 @@ def run_full_setup(
             "failed": "failed",
         }
         results["Cursor"] = cursor_labels.get(cursor_status, cursor_status)
+
+        desktop_status = setup_mcp_claude_desktop()
+        desktop_labels = {
+            "added": "MCP server configured",
+            "exists": "already configured",
+            "not_found": "not detected",
+            "failed": "failed",
+        }
+        results["Claude Desktop"] = desktop_labels.get(desktop_status, desktop_status)
 
     # 4. Hooks
     if not skip_mcp:

--- a/src/surreal_memory/cli/setup.py
+++ b/src/surreal_memory/cli/setup.py
@@ -22,16 +22,27 @@ def find_smem_command() -> dict[str, Any]:
     1. smem-mcp entry point (cleanest)
     2. smem CLI with mcp subcommand
     3. python -m fallback (uses absolute path, normalized for Windows)
+
+    Always includes an ``env`` block so MCP clients receive the full
+    SurrealDB connection config and do not start with an empty environment.
     """
+    from surreal_memory.storage.surrealdb.connection import build_mcp_env
+
+    env = build_mcp_env()
+
     smem_mcp = shutil.which("smem-mcp")
     if smem_mcp:
-        return {"command": "smem-mcp"}
+        return {"command": "smem-mcp", "env": env}
 
     smem = shutil.which("smem")
     if smem:
-        return {"command": "smem", "args": ["mcp"]}
+        return {"command": "smem", "args": ["mcp"], "env": env}
 
-    return {"command": _normalize_path(sys.executable), "args": ["-m", "surreal_memory.mcp"]}
+    return {
+        "command": _normalize_path(sys.executable),
+        "args": ["-m", "surreal_memory.mcp"],
+        "env": env,
+    }
 
 
 def setup_config(data_dir: Path, *, force: bool = False) -> bool:
@@ -149,9 +160,13 @@ def setup_mcp_claude() -> str:
     """Auto-configure MCP in Claude Code.
 
     Strategy:
-    1. Use ``claude mcp add --scope user`` CLI if available (official method).
-    2. Fallback: write directly to ``~/.claude.json`` > ``mcpServers``.
-    3. Clean up deprecated ``~/.claude/mcp_servers.json`` (Claude Code ignores it).
+    Always use direct JSON write (``~/.claude.json``) rather than the
+    ``claude mcp add`` CLI path, because the CLI does not support the ``env``
+    block required for SurrealDB credential injection. The JSON write is
+    idempotent and includes the full ``env`` dict.
+
+    If an entry already exists but lacks ``env``, the env block is backfilled
+    so upgraded installations receive the credential config.
 
     Returns status string: "added", "exists", "failed", or "not_found".
     """
@@ -160,23 +175,35 @@ def setup_mcp_claude() -> str:
         return "not_found"
 
     claude_json = claude_dir.parent / ".claude.json"
-
-    # Already registered?
-    if _claude_json_has_server(claude_json, "surreal-memory"):
-        _cleanup_stale_mcp_servers_json()
-        return "exists"
-
-    # Build the command to register
     mcp_entry = find_smem_command()
-    command_args: list[str] = [mcp_entry["command"]]
-    command_args.extend(mcp_entry.get("args", []))
 
-    # Try official CLI first
-    if _add_via_claude_cli("user", command_args):
-        _cleanup_stale_mcp_servers_json()
-        return "added"
+    # Check for existing entry
+    if claude_json.exists():
+        try:
+            raw = claude_json.read_text(encoding="utf-8").strip()
+            if raw:
+                data: dict[str, Any] = json.loads(raw)
+                servers = data.get("mcpServers", {})
+                if "surreal-memory" in servers:
+                    existing = servers["surreal-memory"]
+                    # If env already present and populated → exists
+                    if existing.get("env", {}).get("SURREALDB_PASS"):
+                        _cleanup_stale_mcp_servers_json()
+                        return "exists"
+                    # Backfill env for upgraded installations — backup first
+                    try:
+                        backup = claude_json.with_suffix(".json.bak")
+                        backup.write_bytes(claude_json.read_bytes())
+                    except OSError:
+                        pass
+                    existing["env"] = mcp_entry.get("env", {})
+                    claude_json.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+                    _cleanup_stale_mcp_servers_json()
+                    return "added"
+        except (json.JSONDecodeError, OSError):
+            pass
 
-    # Fallback: direct JSON write
+    # Write full entry (includes env)
     if _add_via_claude_json(claude_json, mcp_entry):
         _cleanup_stale_mcp_servers_json()
         return "added"
@@ -216,6 +243,80 @@ def setup_mcp_cursor() -> str:
             json.dumps(existing, indent=2) + "\n",
             encoding="utf-8",
         )
+        return "added"
+    except OSError:
+        return "failed"
+
+
+def _claude_desktop_config_path() -> Path | None:
+    """Return the Claude Desktop config file path for the current OS.
+
+    Returns None when the parent directory does not exist (Desktop not installed).
+    """
+    import os
+
+    if sys.platform == "darwin":
+        config_dir = Path.home() / "Library" / "Application Support" / "Claude"
+    elif sys.platform == "win32":
+        appdata = os.environ.get("APPDATA", "")
+        if not appdata:
+            return None
+        config_dir = Path(appdata) / "Claude"
+    else:
+        config_dir = Path.home() / ".config" / "Claude"
+
+    if not config_dir.exists():
+        return None
+    return config_dir / "claude_desktop_config.json"
+
+
+def setup_mcp_claude_desktop() -> str:
+    """Auto-configure MCP in Claude Desktop.
+
+    Writes or updates ``claude_desktop_config.json`` with a ``surreal-memory``
+    entry including the full ``env`` block so the Desktop app never starts the
+    MCP server with an empty environment.
+
+    Idempotent: if the entry already exists and has ``env.SURREALDB_PASS``,
+    returns ``"exists"``.  If the entry exists without ``env``, backfills it
+    and returns ``"added"``.  Creates a ``.bak`` backup before any write.
+
+    Returns status string: ``"added"``, ``"exists"``, ``"failed"``,
+    or ``"not_found"`` (Desktop not installed).
+    """
+    config_path = _claude_desktop_config_path()
+    if config_path is None:
+        return "not_found"
+
+    mcp_entry = find_smem_command()
+
+    existing: dict[str, Any] = {}
+    if config_path.exists():
+        try:
+            raw = config_path.read_text(encoding="utf-8").strip()
+            if raw:
+                existing = json.loads(raw)
+        except (json.JSONDecodeError, OSError):
+            existing = {}
+
+        servers = existing.get("mcpServers", {})
+        if "surreal-memory" in servers:
+            current = servers["surreal-memory"]
+            if current.get("env", {}).get("SURREALDB_PASS"):
+                return "exists"
+            # Backfill env for upgraded installations — fall through to write
+
+        # Backup before modifying
+        try:
+            backup = config_path.with_suffix(".json.bak")
+            backup.write_bytes(config_path.read_bytes())
+        except OSError:
+            pass
+
+    try:
+        servers = existing.setdefault("mcpServers", {})
+        servers["surreal-memory"] = mcp_entry
+        config_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
         return "added"
     except OSError:
         return "failed"

--- a/src/surreal_memory/cli/wizard.py
+++ b/src/surreal_memory/cli/wizard.py
@@ -16,6 +16,7 @@ from surreal_memory.cli.setup import (
     setup_config,
     setup_hooks_claude,
     setup_mcp_claude,
+    setup_mcp_claude_desktop,
     setup_mcp_cursor,
     setup_skills,
 )
@@ -90,6 +91,9 @@ def run_wizard(*, force: bool = False) -> None:
 
     cursor_status = setup_mcp_cursor()
     _format_mcp_result(results, "Cursor", cursor_status)
+
+    desktop_status = setup_mcp_claude_desktop()
+    _format_mcp_result(results, "Claude Desktop", desktop_status)
 
     # Step 5: Hooks
     hook_status = setup_hooks_claude()

--- a/src/surreal_memory/mcp/server.py
+++ b/src/surreal_memory/mcp/server.py
@@ -55,6 +55,7 @@ from surreal_memory.mcp.train_handler import TrainHandler
 from surreal_memory.mcp.version_check_handler import VersionCheckHandler
 from surreal_memory.mcp.visualize_handler import VisualizeHandler
 from surreal_memory.mcp.watch_handler import WatchHandler
+from surreal_memory.storage.surrealdb.connection import StorageAuthError
 from surreal_memory.unified_config import get_config, get_shared_storage
 
 if TYPE_CHECKING:
@@ -491,6 +492,17 @@ async def handle_message(server: MCPServer, message: dict[str, Any]) -> dict[str
                     "code": -32000,
                     "message": f"Tool '{tool_name}' timed out after {_TOOL_CALL_TIMEOUT}s",
                 },
+            }
+        except StorageAuthError as exc:
+            logger.error("Tool '%s' failed: SurrealDB auth error", tool_name)
+            try:
+                await _record_tool_event(server, tool_name, tool_args, t0, success=False)
+            except Exception:
+                logger.debug("Tool event recording failed", exc_info=True)
+            return {
+                "jsonrpc": "2.0",
+                "id": msg_id,
+                "error": {"code": -32001, "message": str(exc)},
             }
         except Exception:
             logger.error("Tool '%s' raised an exception", tool_name, exc_info=True)

--- a/src/surreal_memory/storage/surrealdb/connection.py
+++ b/src/surreal_memory/storage/surrealdb/connection.py
@@ -76,13 +76,13 @@ def is_credential_error(exc: Exception) -> bool:
     Returns False for 401 token-expiry errors so the reconnect loop is not
     triggered on a bad password.
     """
-    # Try real isinstance first
+    # Try real isinstance first — guard against MagicMock stubs in tests.
     try:
         from surrealdb.errors import NotAllowedError  # type: ignore[import-untyped,unused-ignore]
 
-        if isinstance(exc, NotAllowedError):
+        if isinstance(NotAllowedError, type) and isinstance(exc, NotAllowedError):
             return True
-    except (ImportError, ModuleNotFoundError):
+    except (ImportError, ModuleNotFoundError, TypeError):
         pass
 
     # Class-name fallback (SDK installed but import path changed)

--- a/src/surreal_memory/storage/surrealdb/connection.py
+++ b/src/surreal_memory/storage/surrealdb/connection.py
@@ -1,0 +1,120 @@
+"""SurrealDB connection settings and auth error types.
+
+Single source of truth for:
+- Default connection parameters (URL, user, password, namespace, database)
+- Credential-error detection (distinct from 401 token-expiry errors)
+- MCP env dict generation for client config backfill
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+DEFAULT_URL = "http://localhost:8001"
+DEFAULT_USER = "root"
+DEFAULT_PASS = "surrealmemory"  # noqa: S105
+
+AUTH_HINT = (
+    "The MCP server env is likely empty or missing SURREALDB_PASS, so it fell back to the "
+    "default password. Set SURREALDB_PASS (and SURREALDB_URL/USER) in your MCP client config "
+    "(Claude Code: ~/.claude.json; Claude Desktop: claude_desktop_config.json) or run "
+    "`smem doctor --fix`."
+)
+DEFAULT_NS = "surreal_memory"
+DEFAULT_DB = "default"
+
+
+@dataclass(frozen=True)
+class SurrealSettings:
+    """Immutable SurrealDB connection settings resolved from environment."""
+
+    url: str
+    user: str
+    password: str
+    namespace: str
+    database: str
+
+    @classmethod
+    def from_env(cls) -> SurrealSettings:
+        """Build settings from environment variables, falling back to defaults."""
+        return cls(
+            url=os.getenv("SURREALDB_URL", DEFAULT_URL),
+            user=os.getenv("SURREALDB_USER", DEFAULT_USER),
+            password=os.getenv("SURREALDB_PASS", DEFAULT_PASS),
+            namespace=os.getenv("SURREALDB_NS", DEFAULT_NS),
+            database=os.getenv("SURREALDB_DB", DEFAULT_DB),
+        )
+
+
+class StorageAuthError(Exception):
+    """Raised when SurrealDB rejects credentials (wrong password / user).
+
+    Distinct from token-expiry 401 errors handled by _is_auth_error in store.py.
+    Carries an actionable hint so MCP clients surface the root cause instead of
+    a generic -32000 failure.
+    """
+
+    def __init__(self, message: str, hint: str = "") -> None:
+        super().__init__(message)
+        self.hint = hint
+
+    def __str__(self) -> str:
+        base = super().__str__()
+        return f"{base} {self.hint}".strip()
+
+
+def is_credential_error(exc: Exception) -> bool:
+    """True if *exc* signals bad credentials (wrong password / user not allowed).
+
+    Distinct from _is_auth_error (token-expiry 401) in store.py — do NOT merge.
+    Detects NotAllowedError from surrealdb SDK by three means (in order):
+      1. isinstance check when the SDK is importable
+      2. class-name match (works when import is not available)
+      3. string content match as last resort
+
+    Returns False for 401 token-expiry errors so the reconnect loop is not
+    triggered on a bad password.
+    """
+    # Try real isinstance first
+    try:
+        from surrealdb.errors import NotAllowedError  # type: ignore[import-untyped,unused-ignore]
+
+        if isinstance(exc, NotAllowedError):
+            return True
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    # Class-name fallback (SDK installed but import path changed)
+    if type(exc).__name__ == "NotAllowedError":
+        return True
+
+    # String-content fallback — match auth-specific phrases only.
+    # "not allowed" alone is too broad (SurrealDB reuses it for permission errors
+    # on tables/operations); require an auth-context indicator alongside it.
+    msg = str(exc).lower()
+    if "problem with authentication" in msg:
+        return True
+    if "not allowed" in msg and any(
+        kw in msg for kw in ("signin", "authenticate", "credentials", "login", "password")
+    ):
+        return True
+
+    return False
+
+
+def build_mcp_env() -> dict[str, str]:
+    """Return an env dict suitable for embedding in MCP client configs.
+
+    Reads actual env / .env values so a developer's local overrides are
+    preserved; falls back to defaults so clean installs get a working config.
+    """
+    s = SurrealSettings.from_env()
+    return {
+        "SURREAL_MEMORY_STORAGE": "surrealdb",
+        "SURREALDB_URL": s.url,
+        "SURREALDB_USER": s.user,
+        "SURREALDB_PASS": s.password,
+        "SURREALDB_NS": s.namespace,
+        "SURREALDB_DB": s.database,
+    }

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from datetime import datetime
 from hashlib import sha256
 from typing import Any, Literal
@@ -225,17 +224,20 @@ class SurrealDBStorage(
     def __init__(
         self,
         url: str = "",
-        namespace: str = "surreal_memory",
-        database: str = "default",
-        user: str = "root",
-        password: str = "root",
+        namespace: str = "",
+        database: str = "",
+        user: str = "",
+        password: str = "",
         embedding_dim: int = 3072,
     ) -> None:
-        self._url = url or os.getenv("SURREALDB_URL", "http://localhost:8001")
-        self._namespace = namespace or os.getenv("SURREALDB_NS", "surreal_memory")
-        self._database = database or os.getenv("SURREALDB_DB", "default")
-        self._user = user or os.getenv("SURREALDB_USER", "root")
-        self._password = password or os.getenv("SURREALDB_PASS", "root")
+        from surreal_memory.storage.surrealdb.connection import SurrealSettings
+
+        settings = SurrealSettings.from_env()
+        self._url = url or settings.url
+        self._namespace = namespace or settings.namespace
+        self._database = database or settings.database
+        self._user = user or settings.user
+        self._password = password or settings.password
         self._embedding_dim = embedding_dim
         self._conn: Any = None
         self._current_brain_id: str | None = None
@@ -248,8 +250,22 @@ class SurrealDBStorage(
         """Connect to SurrealDB and apply schema."""
         from surrealdb import AsyncSurreal
 
+        from surreal_memory.storage.surrealdb.connection import (
+            AUTH_HINT,
+            StorageAuthError,
+            is_credential_error,
+        )
+
         self._conn = AsyncSurreal(self._url)
-        await self._conn.signin({"username": self._user, "password": self._password})
+        try:
+            await self._conn.signin({"username": self._user, "password": self._password})
+        except Exception as exc:
+            if is_credential_error(exc):
+                raise StorageAuthError(
+                    f"SurrealDB authentication failed for user '{self._user}' at {self._url}.",
+                    hint=AUTH_HINT,
+                ) from exc
+            raise
         await self._conn.use(self._namespace, self._database)
         await ensure_schema(self._conn)
         logger.info(
@@ -340,8 +356,22 @@ class SurrealDBStorage(
         """
         from surrealdb import AsyncSurreal
 
+        from surreal_memory.storage.surrealdb.connection import (
+            AUTH_HINT,
+            StorageAuthError,
+            is_credential_error,
+        )
+
         conn = AsyncSurreal(self._url)
-        await conn.signin({"username": self._user, "password": self._password})
+        try:
+            await conn.signin({"username": self._user, "password": self._password})
+        except Exception as exc:
+            if is_credential_error(exc):
+                raise StorageAuthError(
+                    f"SurrealDB authentication failed for user '{self._user}' at {self._url}.",
+                    hint=AUTH_HINT,
+                ) from exc
+            raise
         await conn.use(self._namespace, self._database)
         self._conn = conn
         logger.info("SurrealDB reconnected after token expiry: %s", self._url)

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -1815,6 +1815,33 @@ def _warn_sqlite_backend() -> None:
         )
 
 
+_missing_surreal_pass_warned = False
+
+
+def _warn_missing_surreal_pass() -> None:
+    """Emit a one-time warning when storage=surrealdb and SURREALDB_PASS is unset.
+
+    A missing password means the server will attempt to authenticate with the
+    built-in default, which will fail if the DB was started with a different
+    password. Surface this before the connection attempt so the error is
+    actionable.
+    """
+    global _missing_surreal_pass_warned
+    if _missing_surreal_pass_warned:
+        return
+    if os.environ.get("SURREAL_MEMORY_STORAGE") != "surrealdb":
+        return
+    if os.environ.get("SURREALDB_PASS"):
+        return
+    _missing_surreal_pass_warned = True
+    logging.getLogger(__name__).warning(
+        "SURREALDB_PASS is not set and storage=surrealdb is active. "
+        "The server will use the default password ('surrealmemory'). "
+        "If your SurrealDB uses a different password, set SURREALDB_PASS "
+        "in your MCP client config or run `smem doctor --fix`."
+    )
+
+
 async def get_shared_storage(brain_name: str | None = None) -> NeuralStorage:
     """Get storage for shared brain access.
 
@@ -1967,6 +1994,7 @@ async def _get_surrealdb_storage(config: UnifiedConfig, name: str) -> NeuralStor
 
     from surreal_memory.core.brain import Brain
     from surreal_memory.storage.surrealdb import SurrealDBStorage
+    from surreal_memory.storage.surrealdb.connection import SurrealSettings
 
     if _surrealdb_storage is not None:
         _surrealdb_storage.set_brain(name)
@@ -1978,12 +2006,18 @@ async def _get_surrealdb_storage(config: UnifiedConfig, name: str) -> NeuralStor
 
         emb_dim = _MODEL_DIMENSIONS.get(config.embedding.model, 3072)
 
+    _warn_missing_surreal_pass()
+
+    # Use SurrealSettings.from_env() as single source of truth — no duplicate
+    # defaults here. SurrealDBStorage.__init__ also calls from_env() as fallback,
+    # but we pass values explicitly so the caller's env is captured at this point.
+    settings = SurrealSettings.from_env()
     storage = SurrealDBStorage(
-        url=os.getenv("SURREALDB_URL", "http://localhost:8001"),
-        namespace=os.getenv("SURREALDB_NS", "surreal_memory"),
-        database=os.getenv("SURREALDB_DB", "default"),
-        user=os.getenv("SURREALDB_USER", "root"),
-        password=os.getenv("SURREALDB_PASS", "root"),
+        url=settings.url,
+        namespace=settings.namespace,
+        database=settings.database,
+        user=settings.user,
+        password=settings.password,
         embedding_dim=emb_dim,
     )
     await storage.initialize()

--- a/tests/unit/test_doctor_enhanced.py
+++ b/tests/unit/test_doctor_enhanced.py
@@ -254,6 +254,8 @@ class TestRunDoctorIntegration:
     @patch("surreal_memory.cli.doctor._check_dedup")
     @patch("surreal_memory.cli.doctor._check_hooks")
     @patch("surreal_memory.cli.doctor._check_cli_tools")
+    @patch("surreal_memory.cli.doctor._check_mcp_env_completeness")
+    @patch("surreal_memory.cli.doctor._check_surrealdb_connection")
     @patch("surreal_memory.cli.doctor._check_mcp_connection")
     @patch("surreal_memory.cli.doctor._check_mcp_config")
     @patch("surreal_memory.cli.doctor._check_schema_version")
@@ -267,8 +269,122 @@ class TestRunDoctorIntegration:
             mock.return_value = {"name": "test", "status": OK, "detail": "ok"}
 
         result = run_doctor(json_output=True)
-        assert result["total"] == 14
-        assert result["passed"] == 14
+        assert result["total"] == 16  # 14 original + SurrealDB connection + MCP env completeness
+        assert result["passed"] == 16
 
     def test_quickstart_url_defined(self) -> None:
         assert "quickstart" in QUICKSTART_URL
+
+
+class TestCheckSurrealdbConnection:
+    """_check_surrealdb_connection() — new TIER_CORE check for auth-fail detection."""
+
+    def test_skip_when_storage_is_not_surrealdb(self, monkeypatch):
+        from surreal_memory.cli.doctor import _check_surrealdb_connection
+
+        monkeypatch.setenv("SURREAL_MEMORY_STORAGE", "sqlite")
+        result = _check_surrealdb_connection()
+        assert result["status"] == "skip"
+
+    def test_fail_when_storage_auth_error(self, monkeypatch):
+        from surreal_memory.cli.doctor import _check_surrealdb_connection
+        from surreal_memory.storage.surrealdb.connection import StorageAuthError
+
+        monkeypatch.setenv("SURREAL_MEMORY_STORAGE", "surrealdb")
+
+        with patch(
+            "surreal_memory.cli.doctor._run_surrealdb_ping",
+            side_effect=StorageAuthError("auth failed", hint="Set SURREALDB_PASS"),
+        ):
+            result = _check_surrealdb_connection()
+
+        assert result["status"] == "fail"
+        assert "SURREALDB_PASS" in result.get("fix", "")
+
+    def test_ok_when_connection_succeeds(self, monkeypatch):
+        from surreal_memory.cli.doctor import _check_surrealdb_connection
+
+        monkeypatch.setenv("SURREAL_MEMORY_STORAGE", "surrealdb")
+
+        with patch("surreal_memory.cli.doctor._run_surrealdb_ping", return_value=None):
+            result = _check_surrealdb_connection()
+
+        assert result["status"] == "ok"
+
+    def test_warn_on_generic_exception(self, monkeypatch):
+        from surreal_memory.cli.doctor import _check_surrealdb_connection
+
+        monkeypatch.setenv("SURREAL_MEMORY_STORAGE", "surrealdb")
+
+        with patch(
+            "surreal_memory.cli.doctor._run_surrealdb_ping",
+            side_effect=ConnectionRefusedError("refused"),
+        ):
+            result = _check_surrealdb_connection()
+
+        assert result["status"] == "warn"
+
+
+class TestCheckMcpEnvCompleteness:
+    """_check_mcp_env_completeness() — TIER_RECOMMENDED check for missing env."""
+
+    def test_warn_when_entry_lacks_env(self, tmp_path):
+        from surreal_memory.cli.doctor import _check_mcp_env_completeness
+
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text(
+            json.dumps({"mcpServers": {"surreal-memory": {"command": "smem-mcp"}}})
+        )
+        with patch("surreal_memory.cli.doctor.Path.home", return_value=tmp_path):
+            result = _check_mcp_env_completeness()
+
+        assert result["status"] == "warn"
+        assert result.get("fixable") is True
+
+    def test_ok_when_env_is_complete(self, tmp_path):
+        from surreal_memory.cli.doctor import _check_mcp_env_completeness
+
+        claude_json = tmp_path / ".claude.json"
+        claude_json.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "surreal-memory": {
+                            "command": "smem-mcp",
+                            "env": {"SURREALDB_PASS": "surrealmemory"},
+                        }
+                    }
+                }
+            )
+        )
+        with patch("surreal_memory.cli.doctor.Path.home", return_value=tmp_path):
+            result = _check_mcp_env_completeness()
+
+        assert result["status"] == "ok"
+
+    def test_skip_when_no_claude_json(self, tmp_path):
+        from surreal_memory.cli.doctor import _check_mcp_env_completeness
+
+        with patch("surreal_memory.cli.doctor.Path.home", return_value=tmp_path):
+            result = _check_mcp_env_completeness()
+
+        assert result["status"] in ("skip", "warn")
+
+
+class TestFixMcpEnv:
+    """_fix_mcp_env() auto-fix handler — calls setup to backfill env."""
+
+    def test_fix_handler_calls_setup_functions(self):
+        from surreal_memory.cli.doctor import _fix_mcp_env
+
+        with (
+            patch("surreal_memory.cli.setup.setup_mcp_claude", return_value="added") as mock_claude,
+            patch(
+                "surreal_memory.cli.setup.setup_mcp_claude_desktop", return_value="added"
+            ) as mock_desktop,
+        ):
+            result = _fix_mcp_env()
+
+        assert mock_claude.called
+        assert mock_desktop.called
+        assert result["status"] == "ok"

--- a/tests/unit/test_dx_wizard.py
+++ b/tests/unit/test_dx_wizard.py
@@ -191,13 +191,15 @@ class TestDoctor:
             patch("surreal_memory.cli.doctor._check_surface") as m11,
             patch("surreal_memory.cli.doctor._check_config_freshness") as m12,
             patch("surreal_memory.cli.doctor._check_pro_plugin") as m13,
+            patch("surreal_memory.cli.doctor._check_surrealdb_connection") as m14,
+            patch("surreal_memory.cli.doctor._check_mcp_env_completeness") as m15,
         ):
-            for m in [m1, m2, m3, m4, m5, m6, m7, m7b, m8, m9, m10, m11, m12, m13]:
+            for m in [m1, m2, m3, m4, m5, m6, m7, m7b, m8, m9, m10, m11, m12, m13, m14, m15]:
                 m.return_value = {"name": "test", "status": "ok", "detail": "ok"}
 
             result = run_doctor(json_output=True)
-            assert result["passed"] == 14
-            assert result["total"] == 14
+            assert result["passed"] == 16
+            assert result["total"] == 16
             assert result["failed"] == 0
 
     def test_run_doctor_with_failures(self) -> None:
@@ -246,9 +248,11 @@ class TestDoctor:
             patch("surreal_memory.cli.doctor._check_surface") as m11,
             patch("surreal_memory.cli.doctor._check_config_freshness") as m12,
             patch("surreal_memory.cli.doctor._check_pro_plugin") as m13,
+            patch("surreal_memory.cli.doctor._check_surrealdb_connection") as m14,
+            patch("surreal_memory.cli.doctor._check_mcp_env_completeness") as m16,
             patch("surreal_memory.cli.doctor._check_dev_environment") as m15,
         ):
-            for m in [m1, m2, m3, m4, m5, m6, m7, m7b, m8, m9, m10, m11, m12, m13]:
+            for m in [m1, m2, m3, m4, m5, m6, m7, m7b, m8, m9, m10, m11, m12, m13, m14, m16]:
                 m.return_value = {"name": "test", "status": "ok", "detail": "ok"}
             m15.return_value = [
                 {"name": "Source checkout", "status": "ok", "detail": "ok"},
@@ -257,8 +261,8 @@ class TestDoctor:
 
             result = run_doctor(json_output=True, dev=True)
 
-        assert result["passed"] == 16
-        assert result["total"] == 16
+        assert result["passed"] == 18
+        assert result["total"] == 18
         assert any(c["tier"] == "dev" for c in result["checks"])
 
 

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.3.1"
+        assert surreal_memory.__version__ == "2.3.2"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_mcp_server_errors.py
+++ b/tests/unit/test_mcp_server_errors.py
@@ -1,0 +1,110 @@
+"""Tests for MCP server auth error surfacing (StorageAuthError → -32001)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from surreal_memory.mcp.server import MCPServer, handle_message
+from surreal_memory.storage.surrealdb.connection import StorageAuthError
+
+
+def _make_server() -> MCPServer:
+    from surreal_memory.unified_config import ResponseConfig, ToolTierConfig
+
+    with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
+        mock_get_config.return_value = MagicMock(
+            current_brain="test-brain",
+            get_brain_db_path=MagicMock(return_value="/tmp/test.db"),
+            tool_tier=ToolTierConfig(tier="full"),
+            response=ResponseConfig(),
+            auto=MagicMock(enabled=False),
+        )
+        return MCPServer()
+
+
+class TestStorageAuthErrorSurfacing:
+    """StorageAuthError from a tool handler must become -32001 with hint in message."""
+
+    @pytest.mark.asyncio
+    async def test_storage_auth_error_returns_32001(self) -> None:
+        server = _make_server()
+
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 99,
+            "method": "tools/call",
+            "params": {"name": "smem_recall", "arguments": {"query": "test"}},
+        }
+
+        with patch.object(
+            server,
+            "call_tool",
+            side_effect=StorageAuthError(
+                "SurrealDB authentication failed for user 'root' at http://localhost:8001.",
+                hint="Set SURREALDB_PASS in your MCP client config or run `smem doctor --fix`.",
+            ),
+        ):
+            resp = await handle_message(server, msg)
+
+        assert resp is not None
+        assert resp["jsonrpc"] == "2.0"
+        assert resp["id"] == 99
+        assert "error" in resp
+        assert resp["error"]["code"] == -32001
+        assert "SURREALDB_PASS" in resp["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_still_returns_32000(self) -> None:
+        """Regression: plain Exception must still return -32000."""
+        server = _make_server()
+
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 42,
+            "method": "tools/call",
+            "params": {"name": "smem_recall", "arguments": {"query": "test"}},
+        }
+
+        with patch.object(
+            server,
+            "call_tool",
+            side_effect=RuntimeError("unexpected failure"),
+        ):
+            resp = await handle_message(server, msg)
+
+        assert resp is not None
+        assert "error" in resp
+        assert resp["error"]["code"] == -32000
+        assert "failed unexpectedly" in resp["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_storage_auth_error_does_not_log_password(self) -> None:
+        """Password must not appear in any log output."""
+
+        server = _make_server()
+
+        msg = {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "tools/call",
+            "params": {"name": "smem_recall", "arguments": {"query": "test"}},
+        }
+
+        with patch.object(
+            server,
+            "call_tool",
+            side_effect=StorageAuthError(
+                "auth failed",
+                hint="Set SURREALDB_PASS",
+            ),
+        ):
+            with patch("surreal_memory.mcp.server.logger") as mock_logger:
+                await handle_message(server, msg)
+
+        # error should be logged, but not with the password
+        assert mock_logger.error.called
+        logged_args = str(mock_logger.error.call_args_list)
+        assert "surrealmemory" not in logged_args.lower()
+        assert "password" not in logged_args.lower()

--- a/tests/unit/test_setup_mcp.py
+++ b/tests/unit/test_setup_mcp.py
@@ -78,8 +78,18 @@ class TestSetupMcpClaude:
     def test_already_exists(self, tmp_path: Path) -> None:
         (tmp_path / ".claude").mkdir()
         claude_json = tmp_path / ".claude.json"
+        # Entry with env.SURREALDB_PASS → considered complete, returns "exists"
         claude_json.write_text(
-            json.dumps({"mcpServers": {"surreal-memory": {"command": "smem-mcp"}}})
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "surreal-memory": {
+                            "command": "smem-mcp",
+                            "env": {"SURREALDB_PASS": "surrealmemory"},
+                        }
+                    }
+                }
+            )
         )
         with patch("surreal_memory.cli.setup.Path.home", return_value=tmp_path):
             assert setup_mcp_claude() == "exists"
@@ -118,3 +128,167 @@ class TestSetupMcpClaude:
         ):
             result = setup_mcp_claude()
         assert result == "added"
+
+
+class TestFindSmemCommandEnv:
+    """find_smem_command() must include an 'env' key with SurrealDB config."""
+
+    def test_returns_env_key(self, monkeypatch):
+        from surreal_memory.cli.setup import find_smem_command
+
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        result = find_smem_command()
+        assert "env" in result, "find_smem_command must return an 'env' key"
+
+    def test_env_contains_surrealdb_pass(self, monkeypatch):
+        from surreal_memory.cli.setup import find_smem_command
+
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        result = find_smem_command()
+        assert "SURREALDB_PASS" in result["env"]
+
+    def test_env_contains_storage_type(self, monkeypatch):
+        from surreal_memory.cli.setup import find_smem_command
+
+        result = find_smem_command()
+        assert result["env"].get("SURREAL_MEMORY_STORAGE") == "surrealdb"
+
+    def test_env_default_password_is_surrealmemory(self, monkeypatch):
+        from surreal_memory.cli.setup import find_smem_command
+
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        result = find_smem_command()
+        assert result["env"]["SURREALDB_PASS"] == "surrealmemory"  # noqa: S105
+
+    def test_env_respects_surrealdb_pass_override(self, monkeypatch):
+        from surreal_memory.cli.setup import find_smem_command
+
+        monkeypatch.setenv("SURREALDB_PASS", "custompass")
+        result = find_smem_command()
+        assert result["env"]["SURREALDB_PASS"] == "custompass"  # noqa: S105
+
+
+class TestAddViaClaudeJsonWithEnv:
+    """_add_via_claude_json writes env into the MCP entry."""
+
+    def test_writes_env_field(self, tmp_path: Path) -> None:
+        f = tmp_path / ".claude.json"
+        entry = {"command": "smem-mcp", "env": {"SURREALDB_PASS": "surrealmemory"}}
+        assert _add_via_claude_json(f, entry) is True
+        data = json.loads(f.read_text())
+        server = data["mcpServers"]["surreal-memory"]
+        assert server["env"]["SURREALDB_PASS"] == "surrealmemory"  # noqa: S105
+
+
+class TestSetupMcpClaudeDesktop:
+    """setup_mcp_claude_desktop() — new function for Claude Desktop support."""
+
+    def test_not_found_when_no_desktop_config_dir(self, tmp_path: Path) -> None:
+        from surreal_memory.cli.setup import setup_mcp_claude_desktop
+
+        with patch("surreal_memory.cli.setup.Path.home", return_value=tmp_path):
+            result = setup_mcp_claude_desktop()
+        assert result == "not_found"
+
+    def test_adds_entry_with_env(self, tmp_path: Path) -> None:
+        import sys
+
+        from surreal_memory.cli.setup import setup_mcp_claude_desktop
+
+        if sys.platform == "darwin":
+            config_dir = tmp_path / "Library" / "Application Support" / "Claude"
+        else:
+            config_dir = tmp_path / ".config" / "Claude"
+        config_dir.mkdir(parents=True)
+
+        with (
+            patch("surreal_memory.cli.setup.Path.home", return_value=tmp_path),
+            patch("surreal_memory.cli.setup.shutil.which", return_value=None),
+        ):
+            result = setup_mcp_claude_desktop()
+
+        assert result == "added"
+        config_file = config_dir / "claude_desktop_config.json"
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
+        assert "surreal-memory" in data["mcpServers"]
+        assert "env" in data["mcpServers"]["surreal-memory"]
+        assert "SURREALDB_PASS" in data["mcpServers"]["surreal-memory"]["env"]
+
+    def test_idempotent_returns_exists(self, tmp_path: Path) -> None:
+        import sys
+
+        from surreal_memory.cli.setup import setup_mcp_claude_desktop
+
+        if sys.platform == "darwin":
+            config_dir = tmp_path / "Library" / "Application Support" / "Claude"
+        else:
+            config_dir = tmp_path / ".config" / "Claude"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "claude_desktop_config.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "surreal-memory": {"command": "smem-mcp", "env": {"SURREALDB_PASS": "x"}}
+                    }
+                }
+            )
+        )
+
+        with (
+            patch("surreal_memory.cli.setup.Path.home", return_value=tmp_path),
+            patch("surreal_memory.cli.setup.shutil.which", return_value=None),
+        ):
+            result = setup_mcp_claude_desktop()
+
+        assert result == "exists"
+
+    def test_backfills_env_when_missing(self, tmp_path: Path) -> None:
+        """Entry exists but lacks env → should update env (returns 'added')."""
+        import sys
+
+        from surreal_memory.cli.setup import setup_mcp_claude_desktop
+
+        if sys.platform == "darwin":
+            config_dir = tmp_path / "Library" / "Application Support" / "Claude"
+        else:
+            config_dir = tmp_path / ".config" / "Claude"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "claude_desktop_config.json"
+        # Entry without env
+        config_file.write_text(
+            json.dumps({"mcpServers": {"surreal-memory": {"command": "smem-mcp"}}})
+        )
+
+        with (
+            patch("surreal_memory.cli.setup.Path.home", return_value=tmp_path),
+            patch("surreal_memory.cli.setup.shutil.which", return_value=None),
+        ):
+            result = setup_mcp_claude_desktop()
+
+        assert result == "added"
+        data = json.loads(config_file.read_text())
+        assert "env" in data["mcpServers"]["surreal-memory"]
+
+    def test_creates_backup_of_existing_file(self, tmp_path: Path) -> None:
+        import sys
+
+        from surreal_memory.cli.setup import setup_mcp_claude_desktop
+
+        if sys.platform == "darwin":
+            config_dir = tmp_path / "Library" / "Application Support" / "Claude"
+        else:
+            config_dir = tmp_path / ".config" / "Claude"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "claude_desktop_config.json"
+        config_file.write_text(json.dumps({"mcpServers": {}}))
+
+        with (
+            patch("surreal_memory.cli.setup.Path.home", return_value=tmp_path),
+            patch("surreal_memory.cli.setup.shutil.which", return_value=None),
+        ):
+            setup_mcp_claude_desktop()
+
+        backup = config_dir / "claude_desktop_config.json.bak"
+        assert backup.exists()

--- a/tests/unit/test_surrealdb_connection.py
+++ b/tests/unit/test_surrealdb_connection.py
@@ -1,0 +1,167 @@
+"""Tests for surreal_memory.storage.surrealdb.connection module."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestSurrealSettings:
+    def test_from_env_empty_returns_defaults(self, monkeypatch):
+        """Empty env → all defaults; password must be 'surrealmemory', not 'root'."""
+        from surreal_memory.storage.surrealdb.connection import SurrealSettings
+
+        monkeypatch.delenv("SURREALDB_URL", raising=False)
+        monkeypatch.delenv("SURREALDB_USER", raising=False)
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        monkeypatch.delenv("SURREALDB_NS", raising=False)
+        monkeypatch.delenv("SURREALDB_DB", raising=False)
+
+        s = SurrealSettings.from_env()
+        assert s.url == "http://localhost:8001"
+        assert s.user == "root"
+        assert s.password == "surrealmemory"  # noqa: S105
+        assert s.namespace == "surreal_memory"
+        assert s.database == "default"
+
+    def test_from_env_reads_env_vars(self, monkeypatch):
+        from surreal_memory.storage.surrealdb.connection import SurrealSettings
+
+        monkeypatch.setenv("SURREALDB_URL", "http://custom:9999")
+        monkeypatch.setenv("SURREALDB_USER", "myuser")
+        monkeypatch.setenv("SURREALDB_PASS", "mypass")
+        monkeypatch.setenv("SURREALDB_NS", "mynamespace")
+        monkeypatch.setenv("SURREALDB_DB", "mydb")
+
+        s = SurrealSettings.from_env()
+        assert s.url == "http://custom:9999"
+        assert s.user == "myuser"
+        assert s.password == "mypass"  # noqa: S105
+        assert s.namespace == "mynamespace"
+        assert s.database == "mydb"
+
+    def test_settings_immutable(self, monkeypatch):
+        from surreal_memory.storage.surrealdb.connection import SurrealSettings
+
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        s = SurrealSettings.from_env()
+        with pytest.raises((AttributeError, TypeError)):
+            s.password = "changed"  # type: ignore[misc]  # noqa: S105
+
+
+class TestStorageAuthError:
+    def test_carries_hint(self):
+        from surreal_memory.storage.surrealdb.connection import StorageAuthError
+
+        err = StorageAuthError("auth failed", hint="set SURREALDB_PASS")
+        assert err.hint == "set SURREALDB_PASS"
+
+    def test_str_includes_message_and_hint(self):
+        from surreal_memory.storage.surrealdb.connection import StorageAuthError
+
+        err = StorageAuthError("auth failed", hint="fix this")
+        assert "auth failed" in str(err)
+        assert "fix this" in str(err)
+
+    def test_str_without_hint(self):
+        from surreal_memory.storage.surrealdb.connection import StorageAuthError
+
+        err = StorageAuthError("auth failed")
+        assert "auth failed" in str(err)
+        assert err.hint == ""
+
+    def test_is_exception(self):
+        from surreal_memory.storage.surrealdb.connection import StorageAuthError
+
+        with pytest.raises(StorageAuthError):
+            raise StorageAuthError("test")
+
+
+class TestIsCredentialError:
+    def test_true_for_class_named_not_allowed_error(self):
+        """Object whose class is named NotAllowedError → True."""
+        from surreal_memory.storage.surrealdb.connection import is_credential_error
+
+        class NotAllowedError(Exception):
+            pass
+
+        assert is_credential_error(NotAllowedError("some problem")) is True
+
+    def test_true_for_problem_with_authentication_string(self):
+        from surreal_memory.storage.surrealdb.connection import is_credential_error
+
+        assert is_credential_error(Exception("There was a problem with authentication")) is True
+
+    def test_true_for_not_allowed_with_auth_context(self):
+        from surreal_memory.storage.surrealdb.connection import is_credential_error
+
+        # "not allowed" + auth keyword → credential error
+        assert is_credential_error(Exception("signin not allowed for this user")) is True
+        assert is_credential_error(Exception("credentials not allowed")) is True
+
+    def test_false_for_not_allowed_without_auth_context(self):
+        """Pure permission/schema error — 'not allowed' without auth keyword must NOT match."""
+        from surreal_memory.storage.surrealdb.connection import is_credential_error
+
+        assert is_credential_error(Exception("Operation not allowed on this table")) is False
+        assert is_credential_error(Exception("SELECT not allowed on namespace::table")) is False
+
+    def test_false_for_plain_value_error(self):
+        from surreal_memory.storage.surrealdb.connection import is_credential_error
+
+        assert is_credential_error(ValueError("bad value")) is False
+
+    def test_false_for_401_token_error(self):
+        """401 token-expiry errors are handled by _is_auth_error; is_credential_error must not match them."""
+        from surreal_memory.storage.surrealdb.connection import is_credential_error
+
+        class TokenExpiredError(Exception):
+            status = 401
+
+        assert is_credential_error(TokenExpiredError("token expired")) is False
+
+    def test_false_for_runtime_error(self):
+        from surreal_memory.storage.surrealdb.connection import is_credential_error
+
+        assert is_credential_error(RuntimeError("connection refused")) is False
+
+
+class TestBuildMcpEnv:
+    def test_returns_required_keys(self, monkeypatch):
+        from surreal_memory.storage.surrealdb.connection import build_mcp_env
+
+        monkeypatch.delenv("SURREALDB_URL", raising=False)
+        monkeypatch.delenv("SURREALDB_USER", raising=False)
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        monkeypatch.delenv("SURREALDB_NS", raising=False)
+        monkeypatch.delenv("SURREALDB_DB", raising=False)
+
+        env = build_mcp_env()
+        assert "SURREAL_MEMORY_STORAGE" in env
+        assert env["SURREAL_MEMORY_STORAGE"] == "surrealdb"
+        assert "SURREALDB_URL" in env
+        assert "SURREALDB_USER" in env
+        assert "SURREALDB_PASS" in env
+        assert "SURREALDB_NS" in env
+        assert "SURREALDB_DB" in env
+
+    def test_defaults_password_is_surrealmemory(self, monkeypatch):
+        from surreal_memory.storage.surrealdb.connection import build_mcp_env
+
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        env = build_mcp_env()
+        assert env["SURREALDB_PASS"] == "surrealmemory"  # noqa: S105
+
+    def test_respects_env_override(self, monkeypatch):
+        from surreal_memory.storage.surrealdb.connection import build_mcp_env
+
+        monkeypatch.setenv("SURREALDB_PASS", "custompass")
+        env = build_mcp_env()
+        assert env["SURREALDB_PASS"] == "custompass"  # noqa: S105
+
+    def test_all_values_are_strings(self, monkeypatch):
+        from surreal_memory.storage.surrealdb.connection import build_mcp_env
+
+        monkeypatch.delenv("SURREALDB_URL", raising=False)
+        env = build_mcp_env()
+        for k, v in env.items():
+            assert isinstance(v, str), f"Key {k!r} has non-string value {v!r}"

--- a/tests/unit/test_surrealdb_store.py
+++ b/tests/unit/test_surrealdb_store.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+# surrealdb is an optional dependency not installed in the base test environment.
+# Inject a stub so that the lazy `from surrealdb import AsyncSurreal` inside
+# store.py succeeds and the mock can override it.
+if "surrealdb" not in sys.modules:
+    _fake_surrealdb = MagicMock()
+    sys.modules["surrealdb"] = _fake_surrealdb
+    sys.modules["surrealdb.errors"] = MagicMock()
 
 
 class TestInitializeAuthFailFast:
@@ -25,7 +34,7 @@ class TestInitializeAuthFailFast:
 
         storage = SurrealDBStorage(url="http://localhost:8001", password="wrongpass")  # noqa: S106
 
-        with patch("surrealdb.AsyncSurreal", return_value=mock_conn):
+        with patch("surrealdb.AsyncSurreal", return_value=mock_conn, create=True):
             with pytest.raises(StorageAuthError) as exc_info:
                 await storage.initialize()
 
@@ -47,7 +56,7 @@ class TestInitializeAuthFailFast:
 
         storage = SurrealDBStorage(url="http://myhost:8001", user="myuser", password="bad")  # noqa: S106
 
-        with patch("surrealdb.AsyncSurreal", return_value=mock_conn):
+        with patch("surrealdb.AsyncSurreal", return_value=mock_conn, create=True):
             with pytest.raises(StorageAuthError) as exc_info:
                 await storage.initialize()
 
@@ -64,7 +73,7 @@ class TestInitializeAuthFailFast:
 
         storage = SurrealDBStorage()
 
-        with patch("surrealdb.AsyncSurreal", return_value=mock_conn):
+        with patch("surrealdb.AsyncSurreal", return_value=mock_conn, create=True):
             with pytest.raises(ConnectionRefusedError):
                 await storage.initialize()
 
@@ -79,7 +88,7 @@ class TestInitializeAuthFailFast:
         storage = SurrealDBStorage()
 
         with (
-            patch("surrealdb.AsyncSurreal", return_value=mock_conn),
+            patch("surrealdb.AsyncSurreal", return_value=mock_conn, create=True),
             patch("surreal_memory.storage.surrealdb.store.ensure_schema", new_callable=AsyncMock),
         ):
             await storage.initialize()  # must not raise
@@ -101,7 +110,7 @@ class TestReconnectAuthFailFast:
 
         storage = SurrealDBStorage()
 
-        with patch("surrealdb.AsyncSurreal", return_value=mock_conn):
+        with patch("surrealdb.AsyncSurreal", return_value=mock_conn, create=True):
             with pytest.raises(StorageAuthError):
                 await storage._reconnect()
 

--- a/tests/unit/test_surrealdb_store.py
+++ b/tests/unit/test_surrealdb_store.py
@@ -1,0 +1,131 @@
+"""Tests for SurrealDBStorage auth fail-fast and default handling."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+class TestInitializeAuthFailFast:
+    """signin on bad credentials → StorageAuthError, not raw NotAllowedError."""
+
+    @pytest.mark.asyncio
+    async def test_signin_credential_error_raises_storage_auth_error(self):
+        from surreal_memory.storage.surrealdb.connection import StorageAuthError
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        class FakeNotAllowedError(Exception):
+            pass
+
+        mock_conn = AsyncMock()
+        mock_conn.signin.side_effect = FakeNotAllowedError(
+            "There was a problem with authentication"
+        )
+
+        storage = SurrealDBStorage(url="http://localhost:8001", password="wrongpass")  # noqa: S106
+
+        with patch("surrealdb.AsyncSurreal", return_value=mock_conn):
+            with pytest.raises(StorageAuthError) as exc_info:
+                await storage.initialize()
+
+        err = exc_info.value
+        assert "wrongpass" not in str(err), "Password must not appear in error message"
+        assert err.hint != "", "hint must be non-empty"
+        assert "SURREALDB_PASS" in err.hint
+
+    @pytest.mark.asyncio
+    async def test_signin_credential_error_includes_user_and_url(self):
+        from surreal_memory.storage.surrealdb.connection import StorageAuthError
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        class NotAllowedError(Exception):  # name triggers class-name fallback
+            pass
+
+        mock_conn = AsyncMock()
+        mock_conn.signin.side_effect = NotAllowedError("not allowed")
+
+        storage = SurrealDBStorage(url="http://myhost:8001", user="myuser", password="bad")  # noqa: S106
+
+        with patch("surrealdb.AsyncSurreal", return_value=mock_conn):
+            with pytest.raises(StorageAuthError) as exc_info:
+                await storage.initialize()
+
+        msg = str(exc_info.value)
+        assert "myuser" in msg
+        assert "myhost" in msg
+
+    @pytest.mark.asyncio
+    async def test_non_credential_exception_propagates_unchanged(self):
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        mock_conn = AsyncMock()
+        mock_conn.signin.side_effect = ConnectionRefusedError("connection refused")
+
+        storage = SurrealDBStorage()
+
+        with patch("surrealdb.AsyncSurreal", return_value=mock_conn):
+            with pytest.raises(ConnectionRefusedError):
+                await storage.initialize()
+
+    @pytest.mark.asyncio
+    async def test_initialize_success_does_not_raise(self):
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        mock_conn = AsyncMock()
+        mock_conn.signin.return_value = None
+        mock_conn.use.return_value = None
+
+        storage = SurrealDBStorage()
+
+        with (
+            patch("surrealdb.AsyncSurreal", return_value=mock_conn),
+            patch("surreal_memory.storage.surrealdb.store.ensure_schema", new_callable=AsyncMock),
+        ):
+            await storage.initialize()  # must not raise
+
+
+class TestReconnectAuthFailFast:
+    """_reconnect on bad credentials → StorageAuthError (not a loop)."""
+
+    @pytest.mark.asyncio
+    async def test_reconnect_credential_error_raises_storage_auth_error(self):
+        from surreal_memory.storage.surrealdb.connection import StorageAuthError
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        class NotAllowedError(Exception):  # name triggers class-name fallback
+            pass
+
+        mock_conn = AsyncMock()
+        mock_conn.signin.side_effect = NotAllowedError("not allowed")
+
+        storage = SurrealDBStorage()
+
+        with patch("surrealdb.AsyncSurreal", return_value=mock_conn):
+            with pytest.raises(StorageAuthError):
+                await storage._reconnect()
+
+
+class TestDefaultPasswordDry:
+    """Default password comes from connection.py (surrealmemory), not 'root'."""
+
+    def test_default_password_is_surrealmemory(self, monkeypatch):
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        s = SurrealDBStorage()
+        assert s._password == "surrealmemory"  # noqa: S105
+
+    def test_explicit_password_overrides_default(self, monkeypatch):
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        s = SurrealDBStorage(password="explicit")  # noqa: S106
+        assert s._password == "explicit"  # noqa: S105
+
+    def test_env_password_overrides_default(self, monkeypatch):
+        monkeypatch.setenv("SURREALDB_PASS", "envpass")
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        s = SurrealDBStorage()
+        assert s._password == "envpass"  # noqa: S105

--- a/tests/unit/test_unified_config.py
+++ b/tests/unit/test_unified_config.py
@@ -480,3 +480,50 @@ class TestSqliteBackendWarning:
             uc._warn_sqlite_backend()
         sqlite_warnings = [r for r in caplog.records if "sqlite" in r.message.lower()]
         assert len(sqlite_warnings) == 1
+
+
+class TestWarnMissingSurrealPass:
+    def test_warns_when_storage_surrealdb_and_no_pass(self, monkeypatch, caplog):
+        import surreal_memory.unified_config as uc
+
+        monkeypatch.setattr(uc, "_missing_surreal_pass_warned", False)
+        monkeypatch.setenv("SURREAL_MEMORY_STORAGE", "surrealdb")
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        with caplog.at_level("WARNING"):
+            uc._warn_missing_surreal_pass()
+        warnings = [r for r in caplog.records if "SURREALDB_PASS" in r.message]
+        assert len(warnings) == 1
+
+    def test_no_warning_when_pass_set(self, monkeypatch, caplog):
+        import surreal_memory.unified_config as uc
+
+        monkeypatch.setattr(uc, "_missing_surreal_pass_warned", False)
+        monkeypatch.setenv("SURREAL_MEMORY_STORAGE", "surrealdb")
+        monkeypatch.setenv("SURREALDB_PASS", "mypassword")
+        with caplog.at_level("WARNING"):
+            uc._warn_missing_surreal_pass()
+        warnings = [r for r in caplog.records if "SURREALDB_PASS" in r.message]
+        assert len(warnings) == 0
+
+    def test_no_warning_when_not_surrealdb_backend(self, monkeypatch, caplog):
+        import surreal_memory.unified_config as uc
+
+        monkeypatch.setattr(uc, "_missing_surreal_pass_warned", False)
+        monkeypatch.setenv("SURREAL_MEMORY_STORAGE", "sqlite")
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        with caplog.at_level("WARNING"):
+            uc._warn_missing_surreal_pass()
+        warnings = [r for r in caplog.records if "SURREALDB_PASS" in r.message]
+        assert len(warnings) == 0
+
+    def test_emits_only_once(self, monkeypatch, caplog):
+        import surreal_memory.unified_config as uc
+
+        monkeypatch.setattr(uc, "_missing_surreal_pass_warned", False)
+        monkeypatch.setenv("SURREAL_MEMORY_STORAGE", "surrealdb")
+        monkeypatch.delenv("SURREALDB_PASS", raising=False)
+        with caplog.at_level("WARNING"):
+            uc._warn_missing_surreal_pass()
+            uc._warn_missing_surreal_pass()
+        warnings = [r for r in caplog.records if "SURREALDB_PASS" in r.message]
+        assert len(warnings) == 1

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Release 2.3.2

Version bump PR. Merge after [#12](https://github.com/acidkill/surreal-memory/pull/12) lands on main.

### What's in this release

See [CHANGELOG.md](CHANGELOG.md) for full notes. Summary:

**Fixed:**
- SurrealDB auth fail-fast: `-32000 "failed unexpectedly"` → `-32001` with `SURREALDB_PASS` hint
- Default password unified (`root` → `surrealmemory`) — single source of truth in `connection.py`

**Added:**
- `storage/surrealdb/connection.py` — new module with `SurrealSettings`, `StorageAuthError`, `is_credential_error`, `build_mcp_env`
- Claude Desktop MCP support (`setup_mcp_claude_desktop`)
- `env` block in all MCP client configs (clean-install prevention)
- `smem doctor` SurrealDB checks: `SurrealDB connection` (CORE) + `MCP env completeness` (RECOMMENDED)

### Merge order

1. Merge PR [#12](https://github.com/acidkill/surreal-memory/pull/12) into `main`
2. Rebase this PR onto `main`
3. Merge this PR
4. Push tag `v2.3.2` → triggers CI → publishes PyPI + npm + VS Code + GitHub Release