### PR TITLE
fix: update doctor check count assertion after adding 2 new checks

### DIFF
--- a/tests/unit/test_dx_wizard.py
+++ b/tests/unit/test_dx_wizard.py
@@ -220,15 +220,17 @@ class TestDoctor:
             patch("surreal_memory.cli.doctor._check_surface") as m11,
             patch("surreal_memory.cli.doctor._check_config_freshness") as m12,
             patch("surreal_memory.cli.doctor._check_pro_plugin") as m13,
+            patch("surreal_memory.cli.doctor._check_surrealdb_connection") as m14,
+            patch("surreal_memory.cli.doctor._check_mcp_env_completeness") as m15,
         ):
             m1.return_value = {"name": "Python", "status": "ok", "detail": "ok"}
             m2.return_value = {"name": "Config", "status": "fail", "detail": "missing"}
-            for m in [m3, m4, m5, m6, m7, m7b, m8, m9, m10, m11, m12, m13]:
+            for m in [m3, m4, m5, m6, m7, m7b, m8, m9, m10, m11, m12, m13, m14, m15]:
                 m.return_value = {"name": "test", "status": "ok", "detail": "ok"}
 
             result = run_doctor(json_output=True)
             assert result["failed"] == 1
-            assert result["passed"] == 13
+            assert result["passed"] == 15
 
     def test_run_doctor_dev_adds_dev_checks(self) -> None:
         from surreal_memory.cli.doctor import run_doctor


### PR DESCRIPTION
## Summary

- Patches `test_run_doctor_with_failures` to mock the two new doctor checks added in 7e50893: `_check_surrealdb_connection` and `_check_mcp_env_completeness`
- Updates the `passed` count assertion from 13 → 15 to match the actual number of checks in `run_doctor()`

## Root cause

7e50893 added two new health checks to `doctor.py` as part of the SurrealDB auth fail-fast feature, but did not update the mock count in `test_run_doctor_with_failures`. The test was patching 14 checks and asserting `passed == 13`, while `run_doctor()` now calls 16 checks — the 2 unpatched new ones returned real results and inflated the count.

## Test plan

- [x] `uv run pytest tests/unit/test_dx_wizard.py::TestDoctor::test_run_doctor_with_failures` → PASSED
- [x] `uv run pytest tests/unit/test_dx_wizard.py -v` → all pass
- [x] `uv run ruff check tests/unit/test_dx_wizard.py` → clean