### PR TITLE
fix(consolidation): never auto-prune pinned isolated neurons

### DIFF
--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -598,6 +598,14 @@ class ConsolidationEngine:
             states = await self._storage.get_neuron_states_batch(batch_ids)
 
             for neuron in batch:
+                # Never auto-prune pinned neurons, whether isolated (orphan) or
+                # dead. The dead-neuron path already honored pinned, but the
+                # orphan path short-circuited above it, so pinned isolated
+                # neurons were permanently deleted. Hoist the guard so it
+                # protects both paths.
+                if neuron.id in pinned_neuron_ids:
+                    continue
+
                 is_orphan = (
                     neuron.id not in connected_neuron_ids and neuron.id not in fiber_neuron_ids
                 )
@@ -606,9 +614,7 @@ class ConsolidationEngine:
                     orphan_ids.append(neuron.id)
                     continue
 
-                # Dead neuron: has connections but never accessed, old enough, not pinned
-                if neuron.id in pinned_neuron_ids:
-                    continue
+                # Dead neuron: has connections but never accessed, old enough
                 state = states.get(neuron.id)
                 freq = state.access_frequency if state else 0
                 if freq > 0:

--- a/tests/unit/test_invariants.py
+++ b/tests/unit/test_invariants.py
@@ -178,6 +178,38 @@ class TestOrphanDefinitionConsistency:
         expected_rate = 2 / 9
         assert report.orphan_rate == pytest.approx(expected_rate, abs=0.01)
 
+    @pytest.mark.asyncio
+    async def test_pinned_orphan_not_pruned(self, mixed_storage: InMemoryStorage) -> None:
+        """A pinned isolated neuron must survive consolidation prune.
+
+        Regression: the orphan path short-circuited before the pinned guard,
+        so pinned isolated neurons were permanently deleted while connected-but-
+        dead neurons were protected. Pinning must protect both.
+        """
+
+        # InMemoryStorage has no pin store; expose pinned ids the way the engine
+        # probes for them (hasattr check on get_pinned_neuron_ids).
+        async def _pinned() -> set[str]:
+            return {"n-orphan-1"}
+
+        mixed_storage.get_pinned_neuron_ids = _pinned  # type: ignore[attr-defined]
+
+        config = ConsolidationConfig(
+            prune_min_inactive_days=0.0,
+            prune_weight_threshold=1.0,
+            prune_isolated_neurons=True,
+        )
+        engine = ConsolidationEngine(mixed_storage, config)
+        await engine.run(strategies=[ConsolidationStrategy.PRUNE], dry_run=False)
+
+        # Pinned orphan survives; the unpinned orphan is still pruned.
+        assert await mixed_storage.get_neuron("n-orphan-1") is not None, (
+            "Pinned isolated neuron must not be pruned"
+        )
+        assert await mixed_storage.get_neuron("n-orphan-2") is None, (
+            "Unpinned orphan should still be pruned"
+        )
+
 
 # ── 2. Sanity smoke: health metrics match raw counts ─────────────
 


### PR DESCRIPTION
## Summary

In `_prune`, the orphan path (neurons with no synapses and not in any fiber) deleted any persistent neuron immediately, short-circuiting above the guards the dead-neuron path applies. The dead path skips pinned neurons; the orphan path did not. So a pinned isolated neuron was permanently deleted on the next consolidation, while a pinned connected-but-dead neuron was protected. Pinning should mean "never auto-delete" regardless of connectivity.

We hit this on a live brain and lost a batch of pinned isolated memories (recovered from backup, so no drama, but that is what prompted the fix).

## Fix

Hoist the pinned guard above the orphan/dead branch so it protects both. The dead path's now-redundant pinned check is removed. Adds `test_pinned_orphan_not_pruned`: a pinned orphan survives PRUNE while an unpinned orphan is still pruned (fails without the fix).

## Scope

Intentionally just the pinned guard, which we consider an outright bug and which does not change pruning of unpinned orphans (your existing orphan invariant tests stay green). The broader design question, whether fresh isolated neurons should also get an age/access grace like dead neurons do, is raised separately in a Discussion, not assumed here.

## Type of Change
- [x] Bug fix (non-breaking)

## CHANGELOG (### Fixed)
- Never auto-prune pinned isolated (orphan) neurons; the pinned guard now covers both the orphan and dead-neuron prune paths.

Context: #15
