### PR TITLE
fix(deps): pin surrealdb SDK to >=2.0.0,<3.0.0 (code uses 2.x API)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ server = [
     "httpx>=0.24",
 ]
 surrealdb = [
-    "surrealdb>=0.4.0",
+    "surrealdb>=2.0.0,<3.0.0",
 ]
 encryption = [
     "cryptography>=46.0.5",


### PR DESCRIPTION
## Summary

The `surrealdb` optional-dependency floor is `>=0.4.0`, but the code already uses the 2.x SDK API (`AsyncSurreal`, `signin({...})`, `insert`, `merge`, `RecordID.table_name`). A stale 0.x/1.x install resolves "successfully" and then fails at runtime with cryptic `AttributeError`s instead of a clean dependency conflict.

## Changes
- `pyproject.toml`: `surrealdb>=0.4.0` to `surrealdb>=2.0.0,<3.0.0`.

## Type of Change
- [x] Bug fix (non-breaking)

## Testing
- [x] In our deployment the 2.x-only API paths (store.py, connection.py) are exercised live.

## CHANGELOG (### Fixed)
- Pin `surrealdb` SDK to `>=2.0.0,<3.0.0`; the code uses the 2.x API and the old `>=0.4.0` floor allowed incompatible installs that fail with opaque `AttributeError`s.

Context: #15
