### PR TITLE
fix(schema): default synapse.brain_id to 'default'

### DIFF
--- a/src/surreal_memory/storage/surrealdb/schema.py
+++ b/src/surreal_memory/storage/surrealdb/schema.py
@@ -56,7 +56,7 @@ DEFINE INDEX idx_state_neuron  ON neuron_state FIELDS brain_id, neuron_id UNIQUE
 -- Synapses (graph edges between neurons)
 DEFINE TABLE synapse SCHEMAFULL;
 DEFINE FIELD id           ON synapse TYPE string;
-DEFINE FIELD brain_id     ON synapse TYPE string;
+DEFINE FIELD brain_id     ON synapse TYPE string DEFAULT 'default';
 DEFINE FIELD type         ON synapse TYPE string;
 DEFINE FIELD weight       ON synapse TYPE float DEFAULT 1.0;
 DEFINE FIELD direction    ON synapse TYPE string DEFAULT 'forward';


### PR DESCRIPTION
## Summary

`synapse.brain_id` is declared with no `DEFAULT`, so a writer that omits it gets NONE-coercion. This mirrors the `neuron` convention of defaulting to `'default'`.

## Changes
- `storage/surrealdb/schema.py`: `DEFINE FIELD brain_id ON synapse TYPE string` to `... DEFAULT 'default'`.

## Type of Change
- [x] Bug fix (non-breaking)

## Note
Touches `schema.py` (same as the literal `{{}}` PR); rebases cleanly after it.

## CHANGELOG (### Fixed)
- Default `synapse.brain_id` to `'default'` (was undeclared, so NONE-coercion when a writer omits it).

Context: #15
