### PR TITLE
fix(storage): strip table prefix in _to_surreal_id to prevent id doubling

### DIFF
--- a/src/surreal_memory/storage/surrealdb/projects.py
+++ b/src/surreal_memory/storage/surrealdb/projects.py
@@ -22,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 
 def _to_surreal_id(record_id: str) -> str:
+    if ":" in record_id:
+        record_id = record_id.rsplit(":", 1)[1]
     return record_id.replace("-", "_")
 
 

--- a/src/surreal_memory/storage/surrealdb/sources.py
+++ b/src/surreal_memory/storage/surrealdb/sources.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 
 
 def _to_surreal_id(record_id: str) -> str:
+    if ":" in record_id:
+        record_id = record_id.rsplit(":", 1)[1]
     return record_id.replace("-", "_")
 
 

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -51,7 +51,13 @@ def _is_auth_error(exc: Exception) -> bool:
 
 
 def _to_surreal_id(record_id: str) -> str:
-    """Convert a UUID to a valid SurrealDB record name (alphanumeric + _-)."""
+    """Convert a record ID to a valid SurrealDB record name (alphanumeric + _-).
+
+    Strips any existing table prefix (e.g. 'neuron:abc-123' -> 'abc_123')
+    to prevent doubling when the caller later prepends 'neuron:'.
+    """
+    if ":" in record_id:
+        record_id = record_id.rsplit(":", 1)[1]
     return record_id.replace("-", "_")
 
 


### PR DESCRIPTION
## Summary

`_to_surreal_id` only replaces `-` with `_`; it does not strip an existing table prefix. A caller passing a full record id (`neuron:abc-123`) ends up with `neuron:neuron:abc_123` once the table prefix is prepended again. There are three identical copies of the helper (store, sources, projects).

## Changes
- `storage/surrealdb/store.py`, `.../sources.py`, `.../projects.py`: strip any `table:` prefix before normalising.

## Type of Change
- [x] Bug fix (non-breaking)

## Note for the reviewer
The helper is duplicated in three modules; happy to follow up with a PR consolidating it into one shared util if you would like.

## CHANGELOG (### Fixed)
- `_to_surreal_id` strips an existing table prefix to prevent `neuron:neuron:...` id doubling (all three copies).

Context: #15
