### PR TITLE
fix(core): add FORWARD/BACKWARD to Direction enum (matches _row_to_synapse default)

### DIFF
--- a/src/surreal_memory/core/synapse.py
+++ b/src/surreal_memory/core/synapse.py
@@ -94,6 +94,8 @@ class Direction(StrEnum):
 
     UNIDIRECTIONAL = "uni"  # One-way: source -> target
     BIDIRECTIONAL = "bi"  # Two-way: source <-> target
+    FORWARD = "forward"  # legacy rows; also _row_to_synapse default in surrealdb store
+    BACKWARD = "backward"  # legacy rows: target -> source
 
 
 # Synapse types that are typically bidirectional


### PR DESCRIPTION
## Summary

`_row_to_synapse` defaults `direction='forward'`, but `'forward'`/`'backward'` are not members of the `Direction` enum (`uni`/`bi`). Reading any synapse that hits the default path is a latent `ValueError`.

## Changes
- `core/synapse.py`: add `FORWARD = "forward"` and `BACKWARD = "backward"` to `Direction`.

## Type of Change
- [x] Bug fix (non-breaking)

## CHANGELOG (### Fixed)
- Add `FORWARD`/`BACKWARD` to the `Direction` enum so the existing `'forward'` default in `_row_to_synapse` is valid (was a latent `ValueError`).

Context: #15
