### PR TITLE
fix(storage): drop write-only connects_to and index synapse source_id/target_id

### DIFF
--- a/src/surreal_memory/storage/surrealdb/schema.py
+++ b/src/surreal_memory/storage/surrealdb/schema.py
@@ -54,10 +54,15 @@ DEFINE FIELD created_at        ON neuron_state TYPE datetime DEFAULT time::now()
 DEFINE INDEX idx_state_neuron  ON neuron_state FIELDS brain_id, neuron_id UNIQUE;
 
 -- Synapses (graph edges between neurons)
+-- Edge endpoints live in source_id/target_id (the fields the store reads and
+-- writes); they are declared here so the schema matches what is persisted, and
+-- the source/target indexes below cover the columns lookups actually use.
 DEFINE TABLE synapse SCHEMAFULL;
 DEFINE FIELD id           ON synapse TYPE string;
 DEFINE FIELD brain_id     ON synapse TYPE string;
 DEFINE FIELD type         ON synapse TYPE string;
+DEFINE FIELD source_id    ON synapse TYPE string;
+DEFINE FIELD target_id    ON synapse TYPE string;
 DEFINE FIELD weight       ON synapse TYPE float DEFAULT 1.0;
 DEFINE FIELD direction    ON synapse TYPE string DEFAULT 'forward';
 DEFINE FIELD metadata     ON synapse TYPE object DEFAULT {{}};
@@ -65,12 +70,8 @@ DEFINE FIELD created_at   ON synapse TYPE datetime DEFAULT time::now();
 DEFINE FIELD last_activated    ON synapse TYPE option<datetime>;
 DEFINE FIELD reinforced_count  ON synapse TYPE int DEFAULT 0;
 DEFINE INDEX idx_synapse_brain ON synapse FIELDS brain_id;
-DEFINE INDEX idx_synapse_source ON synapse FIELDS brain_id, out;
-DEFINE INDEX idx_synapse_target ON synapse FIELDS brain_id, in;
-
--- Synapse edge connections (for graph traversal)
-DEFINE TABLE connects_to SCHEMAFULL;
-DEFINE FIELD brain_id ON connects_to TYPE string;
+DEFINE INDEX idx_synapse_source ON synapse FIELDS brain_id, source_id;
+DEFINE INDEX idx_synapse_target ON synapse FIELDS brain_id, target_id;
 
 -- Fibers (memory clusters / signal pathways)
 DEFINE TABLE fiber SCHEMAFULL;

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -211,8 +211,9 @@ class SurrealDBStorage(
 ):
     """SurrealDB-backed storage for Surreal-Memory.
 
-    Multi-model: documents (neurons), graphs (synapses via RELATE),
-    and vector search (HNSW via embedding_vec) all in one database.
+    Multi-model: documents (neurons), graphs (synapses linking neurons via
+    source_id/target_id), and vector search (HNSW via embedding_vec) all in
+    one database.
 
     Usage:
         storage = SurrealDBStorage(url="http://localhost:8001", ...)
@@ -564,12 +565,6 @@ class SurrealDBStorage(
             brain_id=brain_id,
             nid=sid,
         )
-        # Delete related edges
-        await self._query(
-            "DELETE connects_to WHERE out = $src OR in = $tgt",
-            src=f"neuron:{sid}",
-            tgt=f"neuron:{sid}",
-        )
         # Delete state
         await self._query(f"DELETE neuron_state:{sid}")
 
@@ -648,17 +643,6 @@ class SurrealDBStorage(
             "reinforced_count": synapse.reinforced_count,
         }
         await conn.insert("synapse", record_data)
-
-        # Create graph edge for traversal
-        try:
-            await self._query(
-                "RELATE neuron:$src -> connects_to -> neuron:$tgt SET brain_id = $brain_id",
-                src=ss,
-                tgt=st,
-                brain_id=brain_id,
-            )
-        except Exception:
-            pass
 
         await self._record_change_internal("synapse", synapse.id, "insert", synapse)
         return synapse.id

--- a/tests/unit/test_synapse_document_model.py
+++ b/tests/unit/test_synapse_document_model.py
@@ -1,0 +1,37 @@
+"""Regression tests for the synapse document model.
+
+Synapse edges are persisted as document fields (source_id/target_id) on the
+synapse table; the redundant write-only connects_to RELATE has been removed and
+the source/target indexes now cover the columns lookups actually use.
+See Discussion #15 (option A).
+"""
+
+from __future__ import annotations
+
+import re
+
+from surreal_memory.storage.surrealdb.schema import SCHEMA_SQL
+
+# Collapse runs of horizontal whitespace so assertions do not depend on the
+# column alignment used in the schema source.
+_NORM = re.sub(r"[ \t]+", " ", SCHEMA_SQL)
+
+
+class TestSynapseDocumentModel:
+    def test_source_target_fields_declared(self) -> None:
+        assert "DEFINE FIELD source_id ON synapse TYPE string;" in _NORM
+        assert "DEFINE FIELD target_id ON synapse TYPE string;" in _NORM
+
+    def test_indexes_cover_source_and_target(self) -> None:
+        assert "DEFINE INDEX idx_synapse_source ON synapse FIELDS brain_id, source_id;" in _NORM
+        assert "DEFINE INDEX idx_synapse_target ON synapse FIELDS brain_id, target_id;" in _NORM
+
+    def test_indexes_drop_unpopulated_out_in(self) -> None:
+        # out/in were never written (synapse is not a RELATION table), so the old
+        # indexes covered empty columns and every source/target lookup full-scanned.
+        assert "idx_synapse_source ON synapse FIELDS brain_id, out" not in _NORM
+        assert "idx_synapse_target ON synapse FIELDS brain_id, in" not in _NORM
+
+    def test_connects_to_table_removed(self) -> None:
+        # connects_to was write-only and the RELATE never parsed, so nothing read it.
+        assert "connects_to" not in SCHEMA_SQL


### PR DESCRIPTION
## Summary

This implements option A from #15 (tidy the document model). Three related, backward-compatible changes to the synapse area:

1. Drop the `connects_to` edge table. `add_synapse` issued `RELATE neuron:$src -> connects_to -> neuron:$tgt` (in a try/except) and `delete_neuron` cleaned it up, but nothing in `src/` ever traverses `->connects_to->` (grep returns zero). It was write-only. In fact it never even wrote: the `neuron:$src` form (a parameter in the record-id position of a record literal) does not parse, the except swallowed the error, and our live brain has 0 connects_to rows after thousands of synapse inserts. So this removes a per-insert round-trip that did nothing.

2. Declare `source_id` / `target_id` on `synapse`. These are the fields `add_synapse` writes and `get_synapses` filters on, but they were not in the SCHEMAFULL definition. Declaring them makes the schema match what is persisted (1609 synapses in our brain carry them).

3. Point the source/target indexes at the populated columns. `idx_synapse_source` / `idx_synapse_target` were defined on `out` / `in`, which only a RELATION table fills. `synapse` is a normal table, so those columns are always empty and the indexes covered nothing: every `WHERE source_id = ...` / `target_id = ...` lookup full-scanned. They now index `source_id` / `target_id`.

## On the SCHEMAFULL parser (deliberately out of scope)

While here we noticed `ensure_schema` splits `SCHEMA_SQL` on `;` and drops any fragment starting with `--`. Since every `DEFINE TABLE ... SCHEMAFULL` is preceded by a comment, those table-level statements are dropped and tables run SCHEMALESS (confirmed: `INFO FOR TABLE synapse` shows no source_id/target_id in the field registry, yet they persist). That is the other half of the "two bugs cancelling out" from #15, and it is why the undeclared fields worked. It affects every table, not just synapse, so we did not touch the parser here: fixing it would activate SCHEMAFULL across ~25 tables at once. Declaring source_id/target_id makes synapse correct either way. Happy to raise the parser as its own thread.

## Changes
- `storage/surrealdb/schema.py`: declare `source_id`/`target_id` on synapse; repoint `idx_synapse_source`/`idx_synapse_target`; remove the `connects_to` table.
- `storage/surrealdb/store.py`: remove the `connects_to` RELATE in `add_synapse` and its cleanup in `delete_neuron`; fix the class docstring.
- `tests/unit/test_synapse_document_model.py`: regression test.

## Type of Change
- [x] Bug fix / cleanup (non-breaking)

## Testing
- [x] ruff, mypy, unit suite green.
- [x] Verified against our live brain: connects_to = 0 rows; 1609 synapses carry source_id/target_id; the old indexes were on the empty out/in columns.

## Note for existing deployments
`ensure_schema` swallows "index already exists", so on an existing DB the two indexes keep their old `out`/`in` definition until rebuilt (`REMOVE INDEX` + re-run, or `REBUILD INDEX`). Fresh installs get the corrected indexes directly. Say the word if you would prefer the schema use `OVERWRITE` for these two.

## CHANGELOG (### Fixed)
- Drop the write-only `connects_to` table (the RELATE never parsed and nothing traversed it) and persist synapse edges via the `source_id`/`target_id` document fields, now declared in the schema and covered by the source/target indexes (previously on the never-populated `out`/`in`, so lookups full-scanned).

Context: #15
