### PR TITLE
feat(storage): add optional limit to get_synapses

### DIFF
--- a/src/surreal_memory/storage/base.py
+++ b/src/surreal_memory/storage/base.py
@@ -304,6 +304,7 @@ class NeuralStorage(ABC):
         target_id: str | None = None,
         type: SynapseType | None = None,
         min_weight: float | None = None,
+        limit: int | None = None,
     ) -> list[Synapse]:
         """
         Find synapses matching criteria.
@@ -313,6 +314,7 @@ class NeuralStorage(ABC):
             target_id: Filter by target neuron
             type: Filter by synapse type
             min_weight: Filter by minimum weight
+            limit: Optional cap on number of returned synapses
 
         Returns:
             List of matching synapses

--- a/src/surreal_memory/storage/memory_store.py
+++ b/src/surreal_memory/storage/memory_store.py
@@ -251,6 +251,7 @@ class InMemoryStorage(
         target_id: str | None = None,
         type: SynapseType | None = None,
         min_weight: float | None = None,
+        limit: int | None = None,
     ) -> list[Synapse]:
         brain_id = self._get_brain_id()
         results: list[Synapse] = []
@@ -266,6 +267,8 @@ class InMemoryStorage(
                 continue
             results.append(synapse)
 
+        if limit is not None:
+            return results[:limit]
         return results
 
     async def get_synapses_for_neurons(

--- a/src/surreal_memory/storage/shared_store.py
+++ b/src/surreal_memory/storage/shared_store.py
@@ -316,6 +316,7 @@ class SharedStorage(SharedFiberBrainMixin, NeuralStorage):
         target_id: str | None = None,
         type: SynapseType | None = None,
         min_weight: float | None = None,
+        limit: int | None = None,
     ) -> list[Synapse]:
         """Find synapses matching criteria."""
         params: dict[str, Any] = {}
@@ -327,9 +328,14 @@ class SharedStorage(SharedFiberBrainMixin, NeuralStorage):
             params["type"] = type.value
         if min_weight is not None:
             params["min_weight"] = min_weight
+        if limit is not None:
+            params["limit"] = limit
 
         result = await self._request("GET", "/memory/synapses", params=params)
-        return [dict_to_synapse(s) for s in result.get("synapses", [])]
+        synapses = [dict_to_synapse(s) for s in result.get("synapses", [])]
+        if limit is not None:
+            return synapses[:limit]
+        return synapses
 
     async def update_synapse(self, synapse: Synapse) -> None:
         """Update an existing synapse."""

--- a/src/surreal_memory/storage/sqlite_synapses.py
+++ b/src/surreal_memory/storage/sqlite_synapses.py
@@ -100,6 +100,7 @@ class SQLiteSynapseMixin:
         target_id: str | None = None,
         type: SynapseType | None = None,
         min_weight: float | None = None,
+        limit: int | None = None,
     ) -> list[Synapse]:
         conn = self._ensure_read_conn()
         brain_id = self._get_brain_id()
@@ -123,7 +124,11 @@ class SQLiteSynapseMixin:
             query += " AND weight >= ?"
             params.append(min_weight)
 
-        query += " LIMIT 10000"
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(limit)
+        else:
+            query += " LIMIT 10000"
 
         async with conn.execute(query, params) as cursor:
             rows = await cursor.fetchall()

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -680,6 +680,7 @@ class SurrealDBStorage(
         target_id: str | None = None,
         type: SynapseType | None = None,
         min_weight: float | None = None,
+        limit: int | None = None,
     ) -> list[Synapse]:
         brain_id = self._get_brain_id()
         conditions = ["brain_id = $brain_id"]
@@ -699,7 +700,10 @@ class SurrealDBStorage(
             params["min_weight"] = min_weight
 
         where = " AND ".join(conditions)
-        rows = await self._query(f"SELECT * FROM synapse WHERE {where}", **params)
+        query_str = f"SELECT * FROM synapse WHERE {where}"
+        if limit is not None:
+            query_str += f" LIMIT {limit}"
+        rows = await self._query(query_str, **params)
         return [_row_to_synapse(r) for r in rows]
 
     async def update_synapse(self, synapse: Synapse) -> None:


### PR DESCRIPTION
## Summary

`get_synapses(...)` issues `SELECT * FROM synapse WHERE ...` with no cap. Hot paths fetch unbounded sets: consolidation (all synapses of a brain), dream/enrichment (entire type families), hippocampal replay (per-neuron, and hub neurons can have thousands of edges). An optional `limit` mirroring `find_neurons(limit=...)` keeps memory/latency bounded on dense graphs. Default `None` preserves existing behaviour.

## Changes
- `storage/base.py`: add `limit: int | None = None` to the `get_synapses` protocol signature + docstring.
- `storage/surrealdb/store.py`: thread `limit` into the query as a `LIMIT` clause.

## Type of Change
- [x] New feature (non-breaking)

## CHANGELOG (### Added)
- `get_synapses(..., limit=None)`, an optional cap on returned synapses, mirroring `find_neurons`.

Context: #15
