### PR TITLE
feat(embedding): support base_url override for GeminiEmbedding

### DIFF
--- a/src/surreal_memory/engine/embedding/gemini_embedding.py
+++ b/src/surreal_memory/engine/embedding/gemini_embedding.py
@@ -61,7 +61,21 @@ class GeminiEmbedding(EmbeddingProvider):
                     "Install it with: pip install 'surreal-memory[embeddings-gemini]'"
                 ) from exc
 
-            self._client = genai.Client(api_key=self._api_key)
+            # Optional gateway routing: honour GOOGLE_GEMINI_BASE_URL (the
+            # SDK env var) but build the client explicitly, because our
+            # gateway path already pins the API version — api_version must be
+            # emptied or the SDK doubles it ('/v1beta/v1beta/...').
+            base_url = os.getenv("GOOGLE_GEMINI_BASE_URL")
+            if base_url:
+                self._client = genai.Client(
+                    api_key=self._api_key,
+                    http_options={
+                        "base_url": base_url,
+                        "api_version": os.getenv("GOOGLE_GEMINI_API_VERSION", ""),
+                    },
+                )
+            else:
+                self._client = genai.Client(api_key=self._api_key)
 
         return self._client
 


### PR DESCRIPTION
## Summary

`_ensure_client()` builds `genai.Client(api_key=...)` with no way to point it at a proxy. Deployments that route all LLM/embedding traffic through a gateway (cost control, audit, egress policy) cannot use it. This adds an optional base-url override.

## Changes
- `engine/embedding/gemini_embedding.py`: pass `http_options(base_url=..., api_version=...)` to the client when the env is set.

## Env var
Honours `GOOGLE_GEMINI_BASE_URL` + `GOOGLE_GEMINI_API_VERSION` (the SDK's own env names; we found that `http_options{base_url}` alone double-prefixes the API version, giving `/v1beta/v1beta/...`). Happy to rename if you prefer a `SURREAL_MEMORY_`-prefixed variable.

## Type of Change
- [x] New feature (non-breaking)

## Testing
- [x] Live gateway reindex 21/21 through our LiteLLM proxy.

## Note
Touches `gemini_embedding.py` (same as the embed_batch PR); rebases cleanly after it.

## CHANGELOG (### Added)
- `GeminiEmbedding` honours a base-url override so embedding traffic can route through a proxy/gateway.

Context: #15
