### PR TITLE
fix(storage): neuron_state record-id mismatch broke activation persistence

### DIFF
--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -589,8 +589,8 @@ class SurrealDBStorage(
             brain_id=brain_id,
             nid=sid,
         )
-        # Delete state
-        await self._query(f"DELETE neuron_state:{sid}")
+        # Delete state (record id is state_<sid>, matching the writer in add_neuron)
+        await self._query(f"DELETE neuron_state:state_{sid}")
 
         try:
             await conn.delete(f"neuron:{sid}")
@@ -616,7 +616,7 @@ class SurrealDBStorage(
         conn = self._ensure_conn()
         sid = _to_surreal_id(neuron_id)
         try:
-            result = await conn.select(f"neuron_state:{sid}")
+            result = await conn.select(f"neuron_state:state_{sid}")
             if result:
                 return _row_to_neuron_state(result[0] if isinstance(result, list) else result)
         except Exception:
@@ -640,7 +640,7 @@ class SurrealDBStorage(
         if state.refractory_until:
             update_data["refractory_until"] = state.refractory_until
 
-        await conn.merge(f"neuron_state:{sid}", update_data)
+        await conn.merge(f"neuron_state:state_{sid}", update_data)
 
     # ================================================================
     # Synapse Operations


### PR DESCRIPTION
## Summary

Re-scope of #16 down to **just** the `neuron_state` record-id fix. The rest of #16 was an integration branch carrying deployment-specific code; the other atomic PRs (#17–#27) are already merged.

`add_neuron` writes the activation-state record as `neuron_state:state_<sid>`, but `get_neuron_state`, `update_neuron_state` and the delete path addressed `neuron_state:<sid>` **without** the `state_` prefix. So every `get_neuron_state` missed and returned `None`, every update/merge was a silent no-op, and the batch helpers (which delegate to these) cascaded empty. `recall → reinforce` read empty states and wrote nothing back, so `access_frequency` / `last_activated` / `activation_level` stayed at 0 and the whole **activation → decay → tiering → consolidation loop was dormant**.

## Fix

Three reader call sites now address `neuron_state:state_<sid>`, matching the writer in `add_neuron`.

## Credit

Originally reported and fixed by @RobertSigmundsson in #16; re-scoped here to the `neuron_state` change only (co-authored).

## Type of Change
- [x] Bug fix (non-breaking)