### PR TITLE
fix: add smem-hook-env wrapper to repo + doctor check for missing wrapper

### DIFF
--- a/scripts/smem-hook-env
+++ b/scripts/smem-hook-env
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# smem-hook-env — LOCAL ops helper (NOT part of the shipped surreal_memory package).
+#
+# Wraps a surreal-memory Claude Code hook command, sourcing the project .env first
+# so the hook process gets SURREALDB_PASS etc. Without it the hooks run with a bare
+# environment -> StorageAuthError -> silent no-op (this was the run-004 bug).
+# Secrets stay in .env per CLAUDE.md; this wrapper only exports them into the child.
+#
+# Install:
+#   cp scripts/smem-hook-env ~/.local/bin/smem-hook-env && chmod +x ~/.local/bin/smem-hook-env
+# Reference from ~/.claude/settings.json hooks, e.g.:
+#   "command": "smem-hook-env smem-hook-post-tool-use"
+#
+# .env resolution order (first match wins):
+#   1. $SMEM_ENV_FILE                (explicit override)
+#   2. <this-script-dir>/../.env     (when run straight from the repo checkout)
+#   3. ~/repos/surreal-memory/.env   (default checkout location on this machine)
+set -a
+_smem_env=""
+if [ -n "${SMEM_ENV_FILE:-}" ]; then
+  _smem_env="$SMEM_ENV_FILE"
+else
+  _here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  for _cand in "$_here/../.env" "$HOME/repos/surreal-memory/.env"; do
+    if [ -f "$_cand" ]; then _smem_env="$_cand"; break; fi
+  done
+fi
+[ -n "$_smem_env" ] && [ -f "$_smem_env" ] && . "$_smem_env"
+set +a
+exec "$@"

--- a/src/surreal_memory/cli/doctor.py
+++ b/src/surreal_memory/cli/doctor.py
@@ -720,6 +720,27 @@ def _check_hooks() -> dict[str, Any]:
                     found.append(event)
                     break
 
+    # If hooks are wired through the smem-hook-env wrapper, that wrapper must be
+    # resolvable on PATH — otherwise every hook fails with "command not found"
+    # (regression seen when the local wrapper script went missing).
+    uses_wrapper = any(
+        "smem-hook-env" in hook.get("command", "")
+        for event in expected
+        for entry in hooks_section.get(event, [])
+        for hook in entry.get("hooks", [])
+    )
+    if uses_wrapper and shutil.which("smem-hook-env") is None:
+        return {
+            "name": "Hooks",
+            "status": WARN,
+            "detail": "hooks call 'smem-hook-env' but it is not on PATH (hooks will fail)",
+            "fix": (
+                "Install it: cp scripts/smem-hook-env ~/.local/bin/ "
+                "&& chmod +x ~/.local/bin/smem-hook-env"
+            ),
+            "fixable": False,
+        }
+
     if len(found) == len(expected):
         return {
             "name": "Hooks",

--- a/tests/unit/test_doctor_enhanced.py
+++ b/tests/unit/test_doctor_enhanced.py
@@ -47,6 +47,79 @@ class TestCheckHooks:
             assert result["status"] == OK
             assert "3/3" in result["detail"]
 
+    def test_wrapper_referenced_but_missing_on_path(self, tmp_path: Path) -> None:
+        """Hooks wired through smem-hook-env warn if the wrapper is not on PATH."""
+        settings = {
+            "hooks": {
+                "PreCompact": [
+                    {
+                        "hooks": [
+                            {"type": "command", "command": "smem-hook-env smem-hook-pre-compact"}
+                        ]
+                    }
+                ],
+                "Stop": [
+                    {"hooks": [{"type": "command", "command": "smem-hook-env smem-hook-stop"}]}
+                ],
+                "PostToolUse": [
+                    {
+                        "hooks": [
+                            {"type": "command", "command": "smem-hook-env smem-hook-post-tool-use"}
+                        ]
+                    }
+                ],
+            }
+        }
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text(json.dumps(settings), encoding="utf-8")
+
+        with (
+            patch("surreal_memory.cli.doctor.Path.home", return_value=tmp_path),
+            patch("surreal_memory.cli.doctor.shutil.which", return_value=None),
+        ):
+            result = _check_hooks()
+            assert result["status"] == WARN
+            assert "smem-hook-env" in result["detail"]
+
+    def test_wrapper_referenced_and_present(self, tmp_path: Path) -> None:
+        """Hooks wired through smem-hook-env pass when the wrapper resolves on PATH."""
+        settings = {
+            "hooks": {
+                "PreCompact": [
+                    {
+                        "hooks": [
+                            {"type": "command", "command": "smem-hook-env smem-hook-pre-compact"}
+                        ]
+                    }
+                ],
+                "Stop": [
+                    {"hooks": [{"type": "command", "command": "smem-hook-env smem-hook-stop"}]}
+                ],
+                "PostToolUse": [
+                    {
+                        "hooks": [
+                            {"type": "command", "command": "smem-hook-env smem-hook-post-tool-use"}
+                        ]
+                    }
+                ],
+            }
+        }
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text(json.dumps(settings), encoding="utf-8")
+
+        with (
+            patch("surreal_memory.cli.doctor.Path.home", return_value=tmp_path),
+            patch(
+                "surreal_memory.cli.doctor.shutil.which",
+                return_value="/home/user/.local/bin/smem-hook-env",
+            ),
+        ):
+            result = _check_hooks()
+            assert result["status"] == OK
+            assert "3/3" in result["detail"]
+
     def test_missing_hooks(self, tmp_path: Path) -> None:
         settings = {
             "hooks": {


### PR DESCRIPTION
## Problem

The `smem-hook-env` wrapper — which sources the project `.env` so the smem
Claude Code hooks get `SURREALDB_PASS` etc. (without it: `StorageAuthError` →
silent no-op) — lived only in `~/.local/bin` and vanished. All 4 smem hooks
(`SessionStart`, `PreCompact`, `Stop`, `PostToolUse`) then failed with
`/bin/sh: smem-hook-env: command not found` on every event.

## Changes

- **`scripts/smem-hook-env`** — canonical, path-generic source for the wrapper.
  Resolves `.env` via `$SMEM_ENV_FILE` → `<script-dir>/../.env` →
  `~/repos/surreal-memory/.env`. Install by copying to a dir on `PATH`. It is a
  local ops helper and is deliberately **not** part of the shipped package
  (`setup.py` wires hooks without a wrapper).
- **`doctor` `_check_hooks`** — now WARNs when hooks reference `smem-hook-env`
  but it is not resolvable on `PATH`, with an install hint. This is a branch on
  the existing check, **not** a new check, so `total` stays 16 (and
  `_check_hooks` is mocked in the count test).
- **Tests** — two cases: wrapper referenced but missing on PATH → WARN; wrapper
  referenced and present → OK.

## Test plan

- [x] `pytest tests/unit/test_doctor_enhanced.py tests/unit/test_dx_wizard.py` — 73 passed
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] Live `smem doctor` → `[OK] Hooks 3/3` with wrapper installed