### PR TITLE
fix: governance memory supersession — demote stale rules (#36)

### DIFF
--- a/src/surreal_memory/engine/conflict_detection.py
+++ b/src/surreal_memory/engine/conflict_detection.py
@@ -103,6 +103,7 @@ class ConflictType(StrEnum):
 
     FACTUAL_CONTRADICTION = "factual_contradiction"
     DECISION_REVERSAL = "decision_reversal"
+    GOVERNANCE_SUPERSESSION = "governance_supersession"
 
 
 @dataclass(frozen=True)
@@ -238,6 +239,29 @@ def _tag_overlap(tags_a: set[str], tags_b: set[str]) -> float:
     return intersection / union if union > 0 else 0.0
 
 
+# Governance memory types: always-in-context rules whose stale versions are
+# strictly more dangerous than a stale fact — a superseded rule that still
+# outranks its correction makes an agent enforce a revoked limit (issue #36).
+GOVERNANCE_TYPES: frozenset[str] = frozenset({"boundary", "instruction", "preference", "decision"})
+
+# Explicit supersession markers. A correction phrased as a positive restatement
+# ("X IS allowed now, this supersedes the earlier rule") carries no lexical
+# negation, so predicate-contradiction detection misses it — match the marker
+# directly instead.
+_SUPERSESSION_RE = re.compile(
+    r"\b(supersed(?:e|es|ed|ing)|replac(?:e|es|ed|ing)|overrid(?:e|es|den|ing)|"
+    r"deprecat(?:e|es|ed|ing)|revok(?:e|es|ed|ing)|rescind(?:s|ed|ing)?|"
+    r"no longer (?:applies|valid|true)|as of now|from now on|"
+    r"nadpisuj\w*|zast[eę]puj\w*|uniewa[zż]ni\w*|odwo[lł]uj\w*)\b",
+    re.IGNORECASE,
+)
+
+
+def _has_supersession_marker(content: str) -> bool:
+    """True if content explicitly signals it supersedes a prior memory."""
+    return bool(_SUPERSESSION_RE.search(content or ""))
+
+
 async def detect_conflicts(
     content: str,
     tags: set[str],
@@ -341,6 +365,31 @@ async def detect_conflicts(
                             )
                         )
 
+        # Check for governance supersession (issue #36): a same-type governance
+        # memory (boundary/instruction/preference/decision) that explicitly
+        # supersedes an existing one, or restates it differently. Positive
+        # restatements carry no lexical negation, so the paths above miss them.
+        already_flagged = any(c.existing_neuron_id == candidate.id for c in conflicts)
+        if (
+            not already_flagged
+            and memory_type in GOVERNANCE_TYPES
+            and str(candidate.metadata.get("type", "")) == memory_type
+        ):
+            candidate_tags = _extract_implicit_tags(candidate)
+            overlap = _tag_overlap(tags, candidate_tags) if tags and candidate_tags else 0.0
+            if overlap >= tag_overlap_threshold and (
+                _has_supersession_marker(content) or not _content_agrees(content, candidate.content)
+            ):
+                conflicts.append(
+                    Conflict(
+                        type=ConflictType.GOVERNANCE_SUPERSESSION,
+                        existing_neuron_id=candidate.id,
+                        existing_content=candidate.content,
+                        new_content=content,
+                        confidence=min(1.0, 0.6 + overlap),
+                    )
+                )
+
     return conflicts
 
 
@@ -351,6 +400,7 @@ async def resolve_conflicts(
     confidence_delta: float = 0.3,
     supersede_threshold: float = 0.2,
     existing_memory_type: str = "",
+    new_memory_type: str = "",
 ) -> list[ConflictResolution]:
     """Apply resolution actions for detected conflicts.
 
@@ -381,7 +431,19 @@ async def resolve_conflicts(
         if existing_neuron is None:
             continue
 
-        is_error_resolution = _is_error_memory(existing_neuron, existing_memory_type)
+        # Strong resolution (2x demotion + guaranteed >=50% drop + RESOLVED_BY +
+        # resolved marker) applies to error memories AND to same-type governance
+        # supersession — a stale rule outranking its correction is the failure
+        # governance memories exist to prevent (issue #36).
+        existing_type = str(existing_neuron.metadata.get("type", "")) or existing_memory_type
+        is_governance_supersession = conflict.type == ConflictType.GOVERNANCE_SUPERSESSION or (
+            existing_type in GOVERNANCE_TYPES
+            and new_memory_type in GOVERNANCE_TYPES
+            and (new_memory_type == existing_type or _has_supersession_marker(conflict.new_content))
+        )
+        is_strong_resolution = (
+            _is_error_memory(existing_neuron, existing_memory_type) or is_governance_supersession
+        )
 
         # 1. Get existing neuron state for confidence reduction
         existing_state = await storage.get_neuron_state(conflict.existing_neuron_id)
@@ -389,7 +451,7 @@ async def resolve_conflicts(
 
         # 2. Compute anti-Hebbian reduction
         # Error resolution uses stronger demotion (2x learning rate)
-        effective_delta = confidence_delta * 2.0 if is_error_resolution else confidence_delta
+        effective_delta = confidence_delta * 2.0 if is_strong_resolution else confidence_delta
         update = anti_hebbian_update(
             current_weight=current_confidence,
             strength=conflict.confidence,
@@ -398,7 +460,7 @@ async def resolve_conflicts(
         confidence_reduced = abs(update.delta)
 
         # For error resolution, ensure at least 50% reduction
-        if is_error_resolution:
+        if is_strong_resolution:
             max_allowed = current_confidence * 0.5
             effective_activation = min(update.new_weight, max_allowed)
         else:
@@ -412,7 +474,7 @@ async def resolve_conflicts(
         # 4. Mark existing neuron as disputed (or resolved for errors)
         is_superseded = effective_activation < supersede_threshold
 
-        if is_error_resolution:
+        if is_strong_resolution:
             updated_neuron = existing_neuron.with_metadata(
                 _disputed=True,
                 _disputed_at=utcnow().isoformat(),
@@ -452,7 +514,7 @@ async def resolve_conflicts(
             pass
 
         # 6. Error Resolution Learning: create RESOLVED_BY synapse
-        if is_error_resolution:
+        if is_strong_resolution:
             resolved_by_synapse = Synapse.create(
                 source_id=new_neuron_id,
                 target_id=conflict.existing_neuron_id,

--- a/src/surreal_memory/engine/pipeline_steps.py
+++ b/src/surreal_memory/engine/pipeline_steps.py
@@ -320,11 +320,14 @@ class ExtractConceptNeuronsStep:
             kw_lower = kw.lower()
             # Minimum 4 chars — 3-char words produce too many noise concepts ("ai", "os")
             if len(kw_lower) < 4:
+                ctx.dropped_short += 1
                 return False
             if kw_lower in _NOISE_CONCEPTS:
+                ctx.dropped_noise += 1
                 return False
             # Skip if already captured as an entity neuron
             if kw_lower in entity_content:
+                ctx.dropped_duplicate_entity += 1
                 return False
             return True
 
@@ -1319,6 +1322,7 @@ class ConflictDetectionStep:
                 conflicts=remaining_conflicts,
                 new_neuron_id=ctx.anchor_neuron.id,
                 storage=storage,
+                new_memory_type=memory_type_str,
             )
             for resolution in resolutions:
                 ctx.synapses_created.append(resolution.contradicts_synapse)

--- a/tests/unit/test_conflict_detection.py
+++ b/tests/unit/test_conflict_detection.py
@@ -12,6 +12,7 @@ from surreal_memory.engine.conflict_detection import (
     _content_agrees,
     _extract_predicates,
     _extract_search_terms,
+    _has_supersession_marker,
     _is_decision_content,
     _predicates_conflict,
     _subjects_match,
@@ -464,3 +465,109 @@ class TestResolveConflicts:
             storage=storage,
         )
         assert len(resolutions) == 0
+
+
+class TestGovernanceSupersession:
+    """Issue #36: superseding a governance rule must demote the stale version."""
+
+    def test_supersession_marker_helper(self) -> None:
+        assert _has_supersession_marker("this supersedes the earlier rule")
+        assert _has_supersession_marker("the old limit no longer applies")
+        assert _has_supersession_marker("to nadpisuje wczesniejsza regule")
+        assert not _has_supersession_marker("we use MySQL for the database")
+
+    async def test_detects_governance_supersession_positive_restatement(self) -> None:
+        """A positive restatement with a supersede marker must be detected,
+        even though it carries no lexical negation to trip predicate conflict."""
+        storage = _MockStorage()
+        existing = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="Direct production deploys by agents are forbidden.",
+            neuron_id="existing-1",
+            metadata={"type": "boundary", "tags": ["agents", "deploy", "production"]},
+        )
+        storage.add_neuron_for_test(existing)
+
+        conflicts = await detect_conflicts(
+            content=(
+                "Direct production deploys by agents are approved from now on; "
+                "this supersedes the earlier boundary."
+            ),
+            tags={"agents", "deploy", "production"},
+            storage=storage,
+            memory_type="boundary",
+        )
+        assert any(c.type == ConflictType.GOVERNANCE_SUPERSESSION for c in conflicts)
+
+    async def test_governance_supersession_applies_strong_demotion(self) -> None:
+        """Same-type governance supersession gets the strong path: >=50% activation
+        drop, resolved marker, and a RESOLVED_BY synapse (like error resolution)."""
+        storage = _MockStorage()
+        existing = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="Agents must never deploy to production.",
+            neuron_id="existing-1",
+            metadata={"type": "boundary"},
+        )
+        state = NeuronState(neuron_id="existing-1", activation_level=0.9)
+        storage.add_neuron_for_test(existing, state)
+
+        conflict = Conflict(
+            type=ConflictType.GOVERNANCE_SUPERSESSION,
+            existing_neuron_id="existing-1",
+            existing_content="Agents must never deploy to production.",
+            new_content="Agents may deploy to production; supersedes the earlier rule.",
+            confidence=0.9,
+        )
+
+        resolutions = await resolve_conflicts(
+            [conflict],
+            new_neuron_id="new-1",
+            storage=storage,
+            existing_memory_type="boundary",
+            new_memory_type="boundary",
+        )
+
+        assert len(resolutions) == 1
+        updated_state = await storage.get_neuron_state("existing-1")
+        assert updated_state is not None
+        # Guaranteed >=50% demotion (error-resolution-strength).
+        assert updated_state.activation_level <= 0.45
+        updated = await storage.get_neuron("existing-1")
+        assert updated is not None
+        assert updated.metadata.get("_conflict_resolved") is True
+        assert any(getattr(s, "type", None) == SynapseType.RESOLVED_BY for s in storage._synapses)
+
+    async def test_non_governance_fact_keeps_weak_path(self) -> None:
+        """Regression: a plain fact conflict must NOT get the strong path."""
+        storage = _MockStorage()
+        existing = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="We use PostgreSQL",
+            neuron_id="existing-1",
+            metadata={"type": "fact"},
+        )
+        state = NeuronState(neuron_id="existing-1", activation_level=0.8)
+        storage.add_neuron_for_test(existing, state)
+
+        conflict = Conflict(
+            type=ConflictType.FACTUAL_CONTRADICTION,
+            existing_neuron_id="existing-1",
+            existing_content="We use PostgreSQL",
+            new_content="We use MySQL",
+            confidence=0.9,
+        )
+
+        await resolve_conflicts(
+            [conflict],
+            new_neuron_id="new-1",
+            storage=storage,
+            existing_memory_type="fact",
+            new_memory_type="fact",
+        )
+        updated = await storage.get_neuron("existing-1")
+        assert updated is not None
+        assert updated.metadata.get("_conflict_resolved") is None
+        assert not any(
+            getattr(s, "type", None) == SynapseType.RESOLVED_BY for s in storage._synapses
+        )


### PR DESCRIPTION
Fixes the bug reported in #36 by @RobertSigmundsson (thank you for the detailed live reproduction and precise root-cause analysis).

## Problem

Superseding a `boundary` / `instruction` / `preference` / `decision` (governance) memory did **not** demote the old one. The strong resolution path — `RESOLVED_BY` synapse, resolved marker, guaranteed ≥50% activation demotion — was gated on `_is_error_memory()`, so only `error` memories got it. Every other type fell through to the weak path (mild anti-Hebbian + `CONTRADICTS` + `_disputed`), which cannot flip recall ordering for two hot, priority-10 neurons.

Result: a revoked rule outranks its correction in hot recall — the exact failure governance memories exist to prevent.

## Changes

- **`resolve_conflicts`** — apply the strong path to same-type governance supersession (new + existing both in `{boundary, instruction, preference, decision}`, or an explicit supersession marker), not just error memories. New `new_memory_type` param, threaded from the conflict-resolution pipeline step.
- **`detect_conflicts`** — new `GOVERNANCE_SUPERSESSION` branch so a correction phrased as a *positive restatement* ("X IS allowed now, supersedes …") is detected even without a lexical negation pair, when it carries a supersession marker or differs from the existing rule. (Addresses the detection gap in the report.)
- Add `_has_supersession_marker` + `GOVERNANCE_TYPES`; new `ConflictType.GOVERNANCE_SUPERSESSION`.

## Scope note

This PR implements proposal points **1** (strong path for governance) and **2** (honor explicit supersession signal) from the issue. Point **3** (make soft-`forget` effective for recall before consolidation) is a separate recall/lifecycle concern and is left as a follow-up.

## Test plan

- [x] `pytest tests/unit/test_conflict_detection.py` — 36 passed (4 new)
- [x] New tests: positive-restatement supersession is detected; governance supersession applies ≥50% demotion + `_conflict_resolved` + `RESOLVED_BY`; regression guard that plain facts keep the weak path
- [x] `ruff check` + `ruff format --check` + `mypy` clean on changed files

Closes #36