### PR TITLE
fix: soft-forget excluded from recall immediately (#36 point 3)

### DIFF
--- a/src/surreal_memory/mcp/recall_handler.py
+++ b/src/surreal_memory/mcp/recall_handler.py
@@ -459,8 +459,10 @@ class RecallHandler:
         # Always post-filter when there are matches so soft-forgotten (expired)
         # memories are excluded from recall immediately — without waiting for
         # consolidation cleanup (issue #36). Trust/tier filters piggyback on the
-        # same single pass.
-        needs_post_filter = bool(result.fibers_matched)
+        # same single pass. ``fibers_matched`` is a ``list[str]`` in production
+        # (RetrievalResult); guard defensively so a non-list value can never make
+        # ``list()``/iteration raise and abort recall.
+        needs_post_filter = isinstance(result.fibers_matched, list) and bool(result.fibers_matched)
         if needs_post_filter:
             original_matched = list(result.fibers_matched)
             try:
@@ -470,8 +472,10 @@ class RecallHandler:
 
                     # Expiry filter (soft-forget): a memory whose typed_memory is
                     # past its expires_at must not surface in recall, even before
-                    # consolidation deletes it (issue #36).
-                    if tm is not None and tm.is_expired:
+                    # consolidation deletes it (issue #36). ``is_expired`` is a
+                    # bool property; compare with ``is True`` so only a genuine
+                    # expiry drops the fiber (never a truthy non-bool).
+                    if tm is not None and getattr(tm, "is_expired", False) is True:
                         continue
 
                     # Trust filter
@@ -490,12 +494,12 @@ class RecallHandler:
 
                     passing_ids.add(fid)
 
-                filtered_fibers = [f for f in result.fibers_matched if f in passing_ids]
-                result = (
-                    result._replace(fibers_matched=filtered_fibers)
-                    if hasattr(result, "_replace")
-                    else result
-                )
+                filtered_fibers = [f for f in original_matched if f in passing_ids]
+                # Only rewrite the result when the filter actually dropped a
+                # fiber; leaving it untouched otherwise keeps the original result
+                # object intact (avoids needless copies / mock corruption).
+                if len(filtered_fibers) < len(original_matched) and hasattr(result, "_replace"):
+                    result = result._replace(fibers_matched=filtered_fibers)
             except Exception:
                 logger.debug("Post-filter (trust/tier) failed (non-critical)", exc_info=True)
 

--- a/src/surreal_memory/mcp/recall_handler.py
+++ b/src/surreal_memory/mcp/recall_handler.py
@@ -20,6 +20,59 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+async def _rebuild_context_for_fibers(
+    result: Any,
+    fiber_ids: list[str],
+    storage: Any,
+    *,
+    max_tokens: int,
+    brain_id: str,
+    clean_for_prompt: bool,
+) -> Any:
+    """Rebuild ``result.context`` from ``fiber_ids`` via ``format_context``.
+
+    Used after post-filtering drops fibers (e.g. a soft-forgotten memory) so the
+    answer prose reflects the surviving set instead of the pre-filter one. Falls
+    back to the original result on any issue. Pure w.r.t. the DB (read-only).
+    """
+    from surreal_memory.engine.activation import ActivationResult
+    from surreal_memory.engine.retrieval_context import format_context
+
+    fibers_ordered: list[Any] = []
+    for fid in fiber_ids:
+        fiber = await storage.get_fiber(fid)
+        if fiber:
+            fibers_ordered.append(fiber)
+    if not fibers_ordered:
+        return result
+
+    acts: dict[str, ActivationResult] = {}
+    for co in getattr(result, "co_activations", []) or []:
+        for nid in co.neuron_ids:
+            acts.setdefault(
+                nid,
+                ActivationResult(
+                    neuron_id=nid,
+                    activation_level=co.binding_strength,
+                    hop_distance=0,
+                    path=[nid],
+                    source_anchor=nid,
+                ),
+            )
+
+    new_ctx, _ = await format_context(
+        storage=storage,
+        activations=acts,
+        fibers=fibers_ordered,
+        max_tokens=max_tokens,
+        brain_id=brain_id,
+        clean_for_prompt=clean_for_prompt,
+    )
+    if new_ctx and hasattr(result, "_replace"):
+        return result._replace(context=new_ctx)
+    return result
+
+
 async def _rerank_by_recency(fiber_ids: list[str], storage: Any) -> list[str]:
     """Re-order fiber IDs by recency (newest first).
 
@@ -403,12 +456,23 @@ class RecallHandler:
         recall_tier = args.get("tier")
         if recall_tier is not None:
             recall_tier = str(recall_tier).lower().strip()
-        needs_post_filter = (min_trust is not None or recall_tier) and result.fibers_matched
+        # Always post-filter when there are matches so soft-forgotten (expired)
+        # memories are excluded from recall immediately — without waiting for
+        # consolidation cleanup (issue #36). Trust/tier filters piggyback on the
+        # same single pass.
+        needs_post_filter = bool(result.fibers_matched)
         if needs_post_filter:
+            original_matched = list(result.fibers_matched)
             try:
                 passing_ids: set[str] = set()
                 for fid in result.fibers_matched:
                     tm = await storage.get_typed_memory(fid)
+
+                    # Expiry filter (soft-forget): a memory whose typed_memory is
+                    # past its expires_at must not surface in recall, even before
+                    # consolidation deletes it (issue #36).
+                    if tm is not None and tm.is_expired:
+                        continue
 
                     # Trust filter
                     if min_trust is not None:
@@ -434,6 +498,26 @@ class RecallHandler:
                 )
             except Exception:
                 logger.debug("Post-filter (trust/tier) failed (non-critical)", exc_info=True)
+
+            # If the filter dropped anything (e.g. a soft-forgotten memory) and no
+            # later stage rebuilds the answer text, regenerate context now so the
+            # excluded memory can't linger in the returned prose (issue #36).
+            fibers_were_dropped = len(result.fibers_matched) < len(original_matched)
+            will_rebuild_later = bool(args.get("prefer_recent")) or (
+                args.get("recall_token_budget") is not None
+            )
+            if fibers_were_dropped and recall_mode != "exact" and not will_rebuild_later:
+                try:
+                    result = await _rebuild_context_for_fibers(
+                        result,
+                        list(result.fibers_matched),
+                        storage,
+                        max_tokens=max_tokens,
+                        brain_id=brain_id,
+                        clean_for_prompt=clean_for_prompt,
+                    )
+                except Exception:
+                    logger.debug("Context rebuild after filter failed", exc_info=True)
 
         # Optional prefer_recent re-rank (agent-ergonomics).
         # Reorders surviving fibers newest-first AND rebuilds result.context so
@@ -822,7 +906,9 @@ class RecallHandler:
         limit = min(args.get("limit", 10), 200)
         fresh_only = args.get("fresh_only", False)
 
-        fibers = await storage.get_fibers(limit=limit * 2 if fresh_only else limit)
+        fibers = await storage.get_fibers(
+            limit=limit * 2 if fresh_only else limit, exclude_expired=True
+        )
         if not fibers:
             result: dict[str, Any] = {"context": "No memories stored yet.", "count": 0}
             onboarding = await self._check_onboarding()

--- a/src/surreal_memory/storage/base.py
+++ b/src/surreal_memory/storage/base.py
@@ -596,6 +596,7 @@ class NeuralStorage(ABC):
         limit: int = 10,
         order_by: Literal["created_at", "salience", "frequency"] = "created_at",
         descending: bool = True,
+        exclude_expired: bool = False,
     ) -> list[Fiber]:
         """
         Get fibers with ordering.
@@ -604,6 +605,7 @@ class NeuralStorage(ABC):
             limit: Maximum results
             order_by: Field to order by
             descending: Sort descending if True
+            exclude_expired: Drop fibers whose typed_memory is past expires_at
 
         Returns:
             List of fibers

--- a/src/surreal_memory/storage/memory_collections.py
+++ b/src/surreal_memory/storage/memory_collections.py
@@ -116,9 +116,18 @@ class InMemoryCollectionsMixin:
         limit: int = 10,
         order_by: Literal["created_at", "salience", "frequency"] = "created_at",
         descending: bool = True,
+        exclude_expired: bool = False,
     ) -> list[Fiber]:
         brain_id = self._get_brain_id()
         fibers = list(self._fibers[brain_id].values())
+
+        if exclude_expired:
+            # Soft-forget (issue #36): drop fibers whose typed_memory is past its
+            # expires_at before applying the limit, mirroring the SurrealDB store.
+            typed = self._typed_memories[brain_id]
+            fibers = [
+                f for f in fibers if not ((tm := typed.get(f.id)) is not None and tm.is_expired)
+            ]
 
         sort_keys = {
             "created_at": lambda f: f.created_at,

--- a/src/surreal_memory/storage/shared_store_collections.py
+++ b/src/surreal_memory/storage/shared_store_collections.py
@@ -123,12 +123,14 @@ class SharedFiberBrainMixin:
         limit: int = 10,
         order_by: Literal["created_at", "salience", "frequency"] = "created_at",
         descending: bool = True,
+        exclude_expired: bool = False,
     ) -> list[Fiber]:
         """Get fibers with ordering."""
         params = {
             "limit": limit,
             "order_by": order_by,
             "descending": descending,
+            "exclude_expired": exclude_expired,
         }
         result = await self._request("GET", "/memory/fibers", params=params)
         return [dict_to_fiber(f) for f in result.get("fibers", [])]

--- a/src/surreal_memory/storage/sqlite_fibers.py
+++ b/src/surreal_memory/storage/sqlite_fibers.py
@@ -511,6 +511,7 @@ class SQLiteFiberMixin:
         limit: int = 10,
         order_by: Literal["created_at", "salience", "frequency"] = "created_at",
         descending: bool = True,
+        exclude_expired: bool = False,
     ) -> list[Fiber]:
         limit = min(limit, 1000)
         conn = self._ensure_read_conn()
@@ -520,8 +521,25 @@ class SQLiteFiberMixin:
         _allowed_order = {"created_at", "salience", "frequency"}
         if order_by not in _allowed_order:
             order_by = "created_at"
-        query = f"SELECT * FROM fibers WHERE brain_id = ? ORDER BY {order_by} {order_dir} LIMIT ?"
 
-        async with conn.execute(query, (brain_id, limit)) as cursor:
+        params: list[Any] = [brain_id]
+        # Soft-forget (issue #36): drop fibers whose typed_memory is past its
+        # expires_at before the limit is applied, mirroring the SurrealDB store.
+        # expires_at is persisted as an ISO-8601 string, so a lexicographic
+        # comparison against the current UTC timestamp is chronologically correct.
+        expired_clause = ""
+        if exclude_expired:
+            expired_clause = (
+                " AND id NOT IN (SELECT fiber_id FROM typed_memories "
+                "WHERE brain_id = ? AND expires_at IS NOT NULL AND expires_at <= ?)"
+            )
+            params.extend([brain_id, utcnow().isoformat()])
+        params.append(limit)
+        query = (
+            f"SELECT * FROM fibers WHERE brain_id = ?{expired_clause} "
+            f"ORDER BY {order_by} {order_dir} LIMIT ?"
+        )
+
+        async with conn.execute(query, params) as cursor:
             rows = await cursor.fetchall()
             return [row_to_fiber(row) for row in rows]

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -971,11 +971,23 @@ class SurrealDBStorage(
         limit: int = 10,
         order_by: Literal["created_at", "salience", "frequency"] = "created_at",
         descending: bool = True,
+        exclude_expired: bool = False,
     ) -> list[Fiber]:
         brain_id = self._get_brain_id()
         order_dir = "DESC" if descending else "ASC"
+        # When requested, drop fibers whose typed_memory is past its expires_at
+        # (soft-forgotten) so they leave recall immediately, without waiting for
+        # consolidation cleanup (issue #36).
+        expired_clause = (
+            " AND id NOT IN (SELECT VALUE fiber_id FROM typed_memory "
+            "WHERE brain_id = $brain_id AND expires_at != NONE "
+            "AND expires_at <= time::now())"
+            if exclude_expired
+            else ""
+        )
         rows = await self._query(
-            f"SELECT * FROM fiber WHERE brain_id = $brain_id ORDER BY {order_by} {order_dir} LIMIT {int(limit)}",
+            f"SELECT * FROM fiber WHERE brain_id = $brain_id{expired_clause} "
+            f"ORDER BY {order_by} {order_dir} LIMIT {int(limit)}",
             brain_id=brain_id,
         )
         return [_row_to_fiber(r) for r in rows]

--- a/tests/unit/test_get_fibers_exclude_expired.py
+++ b/tests/unit/test_get_fibers_exclude_expired.py
@@ -1,0 +1,40 @@
+"""Issue #36: get_fibers(exclude_expired=True) drops soft-forgotten memories.
+
+Soft-forget sets typed_memory.expires_at=now; recall must exclude such fibers
+immediately (before consolidation cleanup) instead of only under hard delete.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+
+def _make_store() -> SurrealDBStorage:
+    """A SurrealDBStorage with _query/_get_brain_id stubbed (no real connection)."""
+    store = SurrealDBStorage.__new__(SurrealDBStorage)
+    store._query = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    store._get_brain_id = lambda: "default"  # type: ignore[method-assign,assignment]
+    return store
+
+
+@pytest.mark.asyncio
+async def test_exclude_expired_adds_typed_memory_filter() -> None:
+    store = _make_store()
+    await store.get_fibers(limit=5, exclude_expired=True)
+    sql = store._query.call_args.args[0]  # type: ignore[attr-defined]
+    assert "typed_memory" in sql
+    assert "expires_at" in sql
+    assert "time::now()" in sql
+
+
+@pytest.mark.asyncio
+async def test_default_keeps_all_fibers() -> None:
+    store = _make_store()
+    await store.get_fibers(limit=5)
+    sql = store._query.call_args.args[0]  # type: ignore[attr-defined]
+    assert "typed_memory" not in sql
+    assert "expires_at" not in sql

--- a/tests/unit/test_get_fibers_exclude_expired.py
+++ b/tests/unit/test_get_fibers_exclude_expired.py
@@ -6,10 +6,20 @@ immediately (before consolidation cleanup) instead of only under hard delete.
 
 from __future__ import annotations
 
+import tempfile
+from collections.abc import AsyncIterator
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
 
+from surreal_memory.core.brain import Brain
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.storage.base import NeuralStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
+from surreal_memory.storage.sqlite_store import SQLiteStorage
 from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
 
@@ -38,3 +48,82 @@ async def test_default_keeps_all_fibers() -> None:
     sql = store._query.call_args.args[0]  # type: ignore[attr-defined]
     assert "typed_memory" not in sql
     assert "expires_at" not in sql
+
+
+# ---------------------------------------------------------------------------
+# In-memory + SQLite backends: real (non-mock) exclude_expired behaviour.
+# ---------------------------------------------------------------------------
+
+
+async def _add_fiber(storage: NeuralStorage, content: str) -> Fiber:
+    """Create an anchor neuron + fiber and persist them."""
+    neuron = Neuron.create(type=NeuronType.CONCEPT, content=content)
+    await storage.add_neuron(neuron)
+    fiber = Fiber.create(
+        neuron_ids={neuron.id},
+        synapse_ids=set(),
+        anchor_neuron_id=neuron.id,
+        summary=content,
+    )
+    await storage.add_fiber(fiber)
+    return fiber
+
+
+async def _mark_expiry(storage: NeuralStorage, fiber_id: str, expires_in_days: int) -> None:
+    """Attach a typed_memory with a relative expiry (negative == already expired)."""
+    typed = TypedMemory.create(
+        fiber_id=fiber_id,
+        memory_type=MemoryType.FACT,
+        priority=Priority.NORMAL,
+        expires_in_days=expires_in_days,
+    )
+    await storage.add_typed_memory(typed)
+
+
+@pytest.fixture
+async def in_memory() -> InMemoryStorage:
+    storage = InMemoryStorage()
+    brain = Brain.create(name="test_brain")
+    await storage.save_brain(brain)
+    storage.set_brain(brain.id)
+    return storage
+
+
+@pytest.fixture
+async def sqlite() -> AsyncIterator[SQLiteStorage]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        storage = SQLiteStorage(Path(tmpdir) / "test.db")
+        await storage.initialize()
+        brain = Brain.create(name="test_brain")
+        await storage.save_brain(brain)
+        storage.set_brain(brain.id)
+        yield storage
+        await storage.close()
+
+
+async def _assert_exclude_expired(storage: NeuralStorage) -> None:
+    expired = await _add_fiber(storage, "expired memory")
+    fresh = await _add_fiber(storage, "fresh memory")
+    untyped = await _add_fiber(storage, "untyped memory")
+    await _mark_expiry(storage, expired.id, expires_in_days=-1)  # past -> expired
+    await _mark_expiry(storage, fresh.id, expires_in_days=30)  # future -> live
+
+    # Default keeps everything (no soft-forget filtering).
+    all_ids = {f.id for f in await storage.get_fibers(limit=100)}
+    assert all_ids == {expired.id, fresh.id, untyped.id}
+
+    # exclude_expired drops only the soft-forgotten fiber; live and un-typed stay.
+    kept_ids = {f.id for f in await storage.get_fibers(limit=100, exclude_expired=True)}
+    assert expired.id not in kept_ids
+    assert fresh.id in kept_ids
+    assert untyped.id in kept_ids
+
+
+@pytest.mark.asyncio
+async def test_in_memory_get_fibers_excludes_expired(in_memory: InMemoryStorage) -> None:
+    await _assert_exclude_expired(in_memory)
+
+
+@pytest.mark.asyncio
+async def test_sqlite_get_fibers_excludes_expired(sqlite: SQLiteStorage) -> None:
+    await _assert_exclude_expired(sqlite)


### PR DESCRIPTION
Implements **proposal point 3** from #36 (reported by @RobertSigmundsson). Follow-up to #38, which covered points 1 and 2.

## Problem

Soft-`forget` only sets `typed_memory.expires_at = now` ("cleaned up on next consolidation") — it does not touch the fiber or neuron. But recall reads **fibers**, which carry no `expires_at` and were never joined against `typed_memory`. So a soft-forgotten memory kept surfacing in recall until consolidation deleted it, forcing `hard=true` as the only reliable remedy.

## Changes

- **`get_fibers(exclude_expired=False)`** (SurrealDB store + base signature) — when true, drops fibers whose `typed_memory` is past `expires_at` via a `NOT IN` subquery. Used with `exclude_expired=True` on the context-injection recall path.
- **Main spreading-activation recall (`_recall`)** now always post-filters matched fibers to drop expired `typed_memory` entries, and **rebuilds the answer context** from the survivors (new `_rebuild_context_for_fibers` helper) so a forgotten memory can't linger in the returned prose (not just the id list).

## Test plan

- [x] `pytest tests/unit/test_get_fibers_exclude_expired.py` — 2 passed (exclusion clause present when requested, absent by default)
- [x] `ruff check` + `ruff format --check` clean; `mypy` clean on changed files (pre-existing optional-dep stub warnings unrelated)

Refs #36

---

## CI fix (follow-up `6c126a7`, 2026-07-07)

The previous head failed **Type Check** and **Test (3.11 / 3.12)** — two independent causes, both fixed:

1. **Type Check** — `get_fibers` in the in-memory, SQLite and shared stores still had the old 3-arg signature, incompatible with the `exclude_expired` param on `NeuralStorage` / the SurrealDB store (`Definition of "get_fibers" … incompatible with base class "NeuralStorage"` in `memory_store` / `shared_store` / `sqlite_store`).
2. **Test (10 recall tests)** — the now-always-on recall post-filter broke on mocked pipeline results: `list(result.fibers_matched)` raised on an `int` `fibers_matched`; a truthy `MagicMock` `is_expired` dropped every fiber; `result._replace(...)` on a `MagicMock` returned a garbage object.

**Fix**
- `recall_handler._recall`: post-filter only when `fibers_matched` is a real `list`; compare `is_expired is True`; rewrite the result only when a fiber is actually dropped. Production behaviour is unchanged (`RetrievalResult.fibers_matched` is always a `list`).
- Completed `exclude_expired` across the remaining backends: in-memory (filter before the limit), SQLite (`NOT IN typed_memories` subquery, ISO-8601 comparison), shared (forwarded to the remote as a query param).
- `test_get_fibers_exclude_expired.py`: added real in-memory + SQLite coverage next to the existing SurrealDB SQL assertions.

**Verification** — `mypy src/ --ignore-missing-imports` → `Success`; the 10 previously-failing recall tests + 4 new tests pass; `ruff check` + `ruff format --check` clean. (The SurrealDB/e2e suites error locally only because the optional `surrealdb` SDK is v2 vs the v3.1.1 dev container; identical set on the base commit, and skipped on CI.)
