### PR TITLE
feat: SurrealDB maturation storage + parametric embedding dimension

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ embeddings = [
 ]
 embeddings-openai = [
     "openai>=1.0",
+    "numpy>=1.24",  # vectorised cosine for semantic-link consolidation (pure-python fallback exists)
 ]
 embeddings-openrouter = [
     "openai>=1.0",

--- a/src/surreal_memory/storage/surrealdb/maturation.py
+++ b/src/surreal_memory/storage/surrealdb/maturation.py
@@ -1,0 +1,211 @@
+"""SurrealDB memory-maturation storage mixin (STM -> Working -> Episodic -> Semantic).
+
+The maturation subsystem tracks each fiber's progress through the memory stages so
+that ``_compute_consolidation_ratio`` (= semantic maturations / fibers) and the
+``mature`` consolidation strategy work. Without this mixin the SurrealDB store fell
+through to the no-op defaults in ``storage/base.py`` — ``save_maturation`` silently
+dropped every write and ``find_maturations`` always returned ``[]`` — so the dashboard
+reported "0 semantic" regardless of processing. Mirrors ``review_schedules.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from surreal_memory.engine.memory_stages import MaturationRecord, MemoryStage
+from surreal_memory.utils.timeutils import utcnow
+
+logger = logging.getLogger(__name__)
+
+
+def _to_surreal_id(record_id: str) -> str:
+    if ":" in record_id:
+        record_id = record_id.rsplit(":", 1)[1]
+    return record_id.replace("-", "_")
+
+
+def _parse_datetime(val: Any) -> datetime | None:
+    if val is None:
+        return None
+    if isinstance(val, datetime):
+        return val.replace(tzinfo=None) if val.tzinfo is not None else val
+    if isinstance(val, str):
+        try:
+            parsed = datetime.fromisoformat(val.replace("Z", "+00:00"))
+            return parsed.replace(tzinfo=None) if parsed.tzinfo is not None else parsed
+        except (ValueError, AttributeError):
+            return None
+    return None
+
+
+def _row_to_maturation(row: dict[str, Any]) -> MaturationRecord:
+    ts_raw = row.get("reinforcement_timestamps") or []
+    timestamps = tuple(str(t) for t in ts_raw) if isinstance(ts_raw, (list, tuple)) else ()
+    entered = _parse_datetime(row.get("stage_entered_at")) or utcnow()
+    return MaturationRecord(
+        fiber_id=str(row["fiber_id"]),
+        brain_id=str(row["brain_id"]),
+        stage=MemoryStage(str(row.get("stage", "stm"))),
+        stage_entered_at=entered,
+        rehearsal_count=int(row.get("rehearsal_count", 0)),
+        reinforcement_timestamps=timestamps,
+    )
+
+
+class SurrealDBMaturationMixin:
+    """Mixin providing maturation CRUD for SurrealDBStorage."""
+
+    def _ensure_conn(self) -> Any:
+        raise NotImplementedError
+
+    def _get_brain_id(self) -> str:
+        raise NotImplementedError
+
+    async def _query(self, sql: str, **params: Any) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    async def save_maturation(self, record: MaturationRecord) -> None:
+        """Upsert a maturation record keyed by (brain_id, fiber_id)."""
+        brain_id = self._get_brain_id()
+        conn = self._ensure_conn()
+        sid = f"{_to_surreal_id(brain_id)}_{_to_surreal_id(record.fiber_id)}"
+
+        record_data: dict[str, Any] = {
+            "fiber_id": record.fiber_id,
+            "brain_id": brain_id,
+            "stage": record.stage.value,
+            "stage_entered_at": record.stage_entered_at,
+            "rehearsal_count": int(record.rehearsal_count),
+            "reinforcement_timestamps": list(record.reinforcement_timestamps),
+        }
+
+        existing = await self._query(
+            "SELECT id FROM maturation WHERE brain_id = $brain_id AND fiber_id = $fiber_id LIMIT 1",
+            brain_id=brain_id,
+            fiber_id=record.fiber_id,
+        )
+        try:
+            if existing:
+                # Merge by the existing record id (not the recomputed sid) so a
+                # post-rename brain prefix mismatch can't silently no-op the write.
+                await conn.merge(existing[0]["id"], record_data)
+            else:
+                insert_data = dict(record_data)
+                insert_data["id"] = sid
+                await conn.insert("maturation", insert_data)
+        except Exception:
+            # Fiber may have been deleted between read and write (parity with SQLite).
+            logger.debug("Skipping maturation save for fiber %s", record.fiber_id)
+
+    async def get_maturation(self, fiber_id: str) -> MaturationRecord | None:
+        brain_id = self._get_brain_id()
+        rows = await self._query(
+            "SELECT * FROM maturation WHERE brain_id = $brain_id AND fiber_id = $fiber_id LIMIT 1",
+            brain_id=brain_id,
+            fiber_id=fiber_id,
+        )
+        return _row_to_maturation(rows[0]) if rows else None
+
+    async def find_maturations(
+        self,
+        stage: MemoryStage | None = None,
+        min_rehearsal_count: int = 0,
+    ) -> list[MaturationRecord]:
+        brain_id = self._get_brain_id()
+        conditions = ["brain_id = $brain_id"]
+        params: dict[str, Any] = {"brain_id": brain_id}
+
+        if stage is not None:
+            conditions.append("stage = $stage")
+            params["stage"] = stage.value
+        if min_rehearsal_count > 0:
+            conditions.append("rehearsal_count >= $min_rc")
+            params["min_rc"] = int(min_rehearsal_count)
+
+        where = " AND ".join(conditions)
+        rows = await self._query(
+            f"SELECT * FROM maturation WHERE {where} LIMIT 5000",
+            **params,
+        )
+        return [_row_to_maturation(r) for r in rows]
+
+    async def cleanup_orphaned_maturations(self) -> int:
+        """Delete maturation rows whose fiber no longer exists."""
+        brain_id = self._get_brain_id()
+        existing_rows = await self._query(
+            "SELECT id, fiber_id FROM maturation WHERE brain_id = $brain_id",
+            brain_id=brain_id,
+        )
+        if not existing_rows:
+            return 0
+        fiber_rows = await self._query(
+            "SELECT id FROM fiber WHERE brain_id = $brain_id",
+            brain_id=brain_id,
+        )
+        live_fibers = {str(r["id"]).rsplit(":", 1)[-1] for r in fiber_rows}
+
+        conn = self._ensure_conn()
+        removed = 0
+        for row in existing_rows:
+            fid = str(row.get("fiber_id", ""))
+            if _to_surreal_id(fid) not in live_fibers and fid not in live_fibers:
+                rid = str(row.get("id", ""))
+                if rid:
+                    await conn.delete(rid)
+                    removed += 1
+        return removed
+
+    async def backfill_maturations(self) -> dict[str, int]:
+        """One-time: create maturation rows for existing fibers that lack one.
+
+        Seeds each fiber's stage from its REAL age (``time_start``/``created_at``),
+        not ``now``, so historical memories land at their age-appropriate stage
+        immediately instead of restarting the maturation clock. Fibers that already
+        have a maturation row are skipped, so this is idempotent and safe to re-run.
+
+        Stage thresholds mirror ``engine.memory_stages`` (STM>30min Working,
+        >4h Episodic, >=7d Semantic). The episodic->semantic spacing gate
+        (distinct reinforcement days) is forward-looking for NEW memories; for this
+        one-time backfill of memories that predate the maturation subsystem, age in
+        the brain is the consolidation signal.
+        """
+        from surreal_memory.engine.memory_stages import (
+            _EPISODIC_TO_SEMANTIC,
+            _STM_TO_WORKING,
+            _WORKING_TO_EPISODIC,
+        )
+
+        brain_id = self._get_brain_id()
+        existing = {m.fiber_id for m in await self.find_maturations()}
+        fibers = await self.get_fibers(limit=100000)  # type: ignore[attr-defined]
+        now = utcnow()
+        counts = {"stm": 0, "working": 0, "episodic": 0, "semantic": 0, "skipped": 0}
+
+        for fiber in fibers:
+            if fiber.id in existing:
+                counts["skipped"] += 1
+                continue
+            base = fiber.time_start or fiber.created_at or now
+            if base.tzinfo is not None:
+                base = base.replace(tzinfo=None)
+            age = now - base
+            if age >= _EPISODIC_TO_SEMANTIC:
+                stage, entered = MemoryStage.SEMANTIC, base + _EPISODIC_TO_SEMANTIC
+            elif age >= _WORKING_TO_EPISODIC:
+                stage, entered = MemoryStage.EPISODIC, base + _WORKING_TO_EPISODIC
+            elif age >= _STM_TO_WORKING:
+                stage, entered = MemoryStage.WORKING, base + _STM_TO_WORKING
+            else:
+                stage, entered = MemoryStage.SHORT_TERM, base
+            await self.save_maturation(
+                MaturationRecord(
+                    fiber_id=fiber.id,
+                    brain_id=brain_id,
+                    stage=stage,
+                    stage_entered_at=entered,
+                )
+            )
+            counts[stage.value] += 1
+        return counts

--- a/src/surreal_memory/storage/surrealdb/schema.py
+++ b/src/surreal_memory/storage/surrealdb/schema.py
@@ -7,7 +7,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 -- ============================================================
@@ -36,7 +36,8 @@ DEFINE INDEX idx_neuron_brain    ON neuron FIELDS brain_id;
 DEFINE INDEX idx_neuron_type     ON neuron FIELDS brain_id, type;
 DEFINE INDEX idx_neuron_hash     ON neuron FIELDS brain_id, content_hash;
 DEFINE INDEX idx_neuron_content  ON neuron FIELDS brain_id, content;
-DEFINE INDEX idx_neuron_embedding ON neuron FIELDS embedding_vec HNSW DIMENSION 3072 DIST COSINE;
+-- idx_neuron_embedding (HNSW) is defined dynamically in ensure_schema() with the
+-- configured embedding dimension, so the vector index always matches the model.
 
 -- Neuron activation states
 DEFINE TABLE neuron_state SCHEMAFULL;
@@ -263,6 +264,18 @@ DEFINE INDEX idx_review_brain   ON review_schedules FIELDS brain_id;
 DEFINE INDEX idx_review_fiber   ON review_schedules FIELDS brain_id, fiber_id UNIQUE;
 DEFINE INDEX idx_review_due     ON review_schedules FIELDS brain_id, next_review;
 
+-- Memory maturation (STM -> Working -> Episodic -> Semantic, one record per fiber)
+DEFINE TABLE maturation SCHEMAFULL;
+DEFINE FIELD fiber_id                 ON maturation TYPE string;
+DEFINE FIELD brain_id                 ON maturation TYPE string;
+DEFINE FIELD stage                    ON maturation TYPE string DEFAULT 'stm';
+DEFINE FIELD stage_entered_at         ON maturation TYPE datetime DEFAULT time::now();
+DEFINE FIELD rehearsal_count          ON maturation TYPE int DEFAULT 0;
+DEFINE FIELD reinforcement_timestamps ON maturation TYPE array<string> DEFAULT [];
+DEFINE INDEX idx_maturation_brain     ON maturation FIELDS brain_id;
+DEFINE INDEX idx_maturation_fiber     ON maturation FIELDS brain_id, fiber_id UNIQUE;
+DEFINE INDEX idx_maturation_stage     ON maturation FIELDS brain_id, stage;
+
 -- Brain versions (snapshot/checkpoint history with compressed snapshots)
 DEFINE TABLE brain_versions SCHEMAFULL;
 DEFINE FIELD id              ON brain_versions TYPE string;
@@ -389,12 +402,31 @@ DEFINE INDEX idx_tevt_time    ON tool_events FIELDS brain_id, created_at;
 """
 
 
-async def ensure_schema(conn: Any) -> None:
-    """Apply schema to SurrealDB. Safe to call multiple times."""
-    logger.info("Applying SurrealDB schema (v%d)...", SCHEMA_VERSION)
+async def ensure_schema(conn: Any, embedding_dim: int = 3072) -> None:
+    """Apply schema to SurrealDB. Safe to call multiple times.
+
+    The neuron embedding HNSW index dimension is parameterized by
+    ``embedding_dim`` so the vector index always matches the configured
+    embedding model (e.g. 1024 for bge-m3 via a local OpenAI-compatible
+    server, 3072 for Gemini). SurrealDB rejects vectors whose length differs
+    from the index dimension, so this MUST equal the provider's output
+    dimension.
+
+    Note: a plain ``DEFINE INDEX`` errors when the index already exists (and
+    the error is swallowed below), so this does NOT change the dimension of an
+    EXISTING index — it only sets it correctly on first creation. Changing the
+    dimension of a populated index requires an explicit ``REMOVE INDEX`` +
+    re-``DEFINE`` migration.
+    """
+    dim = int(embedding_dim) if embedding_dim and int(embedding_dim) > 0 else 3072
+    logger.info("Applying SurrealDB schema (v%d, embedding_dim=%d)...", SCHEMA_VERSION, dim)
     statements = [
         s.strip() for s in SCHEMA_SQL.split(";") if s.strip() and not s.strip().startswith("--")
     ]
+    statements.append(
+        "DEFINE INDEX idx_neuron_embedding ON neuron "
+        f"FIELDS embedding_vec HNSW DIMENSION {dim} DIST COSINE"
+    )
     for stmt in statements:
         try:
             await conn.query(stmt + ";")

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -25,6 +25,7 @@ from surreal_memory.storage.surrealdb.cognitive import SurrealDBCognitiveMixin
 from surreal_memory.storage.surrealdb.compression import SurrealDBCompressionMixin
 from surreal_memory.storage.surrealdb.depth_priors import SurrealDBDepthPriorsMixin
 from surreal_memory.storage.surrealdb.keyword_entity import SurrealDBKeywordEntityMixin
+from surreal_memory.storage.surrealdb.maturation import SurrealDBMaturationMixin
 from surreal_memory.storage.surrealdb.projects import SurrealDBProjectsMixin
 from surreal_memory.storage.surrealdb.review_schedules import SurrealDBReviewSchedulesMixin
 from surreal_memory.storage.surrealdb.schema import ensure_schema
@@ -225,6 +226,7 @@ class SurrealDBStorage(
     SurrealDBAlertsMixin,
     SurrealDBCognitiveMixin,
     SurrealDBReviewSchedulesMixin,
+    SurrealDBMaturationMixin,
     SurrealDBVersionsMixin,
     SurrealDBKeywordEntityMixin,
     SurrealDBCompressionMixin,
@@ -292,7 +294,7 @@ class SurrealDBStorage(
                 ) from exc
             raise
         await self._conn.use(self._namespace, self._database)
-        await ensure_schema(self._conn)
+        await ensure_schema(self._conn, self._embedding_dim)
         logger.info(
             "SurrealDB connected: %s ns=%s db=%s",
             self._url,

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -114,6 +114,11 @@ class EmbeddingSettings:
     provider: str = "sentence_transformer"
     model: str = "all-MiniLM-L6-v2"
     similarity_threshold: float = 0.7
+    # Explicit embedding vector dimension. 0 = auto (derive from provider/model).
+    # Set this when the provider/model is not in a built-in dimension table
+    # (e.g. a local OpenAI-compatible server serving bge-m3 → 1024); it drives
+    # the SurrealDB HNSW index dimension so the index always matches the vectors.
+    dimension: int = 0
 
     _VALID_PROVIDERS: ClassVar[tuple[str, ...]] = (
         "sentence_transformer",
@@ -143,6 +148,7 @@ class EmbeddingSettings:
             "provider": self.provider,
             "model": self.model,
             "similarity_threshold": self.similarity_threshold,
+            "dimension": self.dimension,
         }
 
     @classmethod
@@ -152,6 +158,7 @@ class EmbeddingSettings:
             provider=str(data.get("provider", "sentence_transformer")),
             model=str(data.get("model", "all-MiniLM-L6-v2")),
             similarity_threshold=float(data.get("similarity_threshold", 0.7)),
+            dimension=int(data.get("dimension", 0) or 0),
         )
 
 
@@ -177,6 +184,7 @@ def _load_embedding_settings(data: dict[str, Any]) -> EmbeddingSettings:
         SURREAL_MEMORY_EMBEDDING_PROVIDER             -> provider
         SURREAL_MEMORY_EMBEDDING_MODEL                -> model
         SURREAL_MEMORY_EMBEDDING_SIMILARITY_THRESHOLD -> similarity_threshold
+        SURREAL_MEMORY_EMBEDDING_DIMENSION            -> dimension
 
     Only env vars that are actually set (non-empty) override the file values.
     """
@@ -208,11 +216,72 @@ def _load_embedding_settings(data: dict[str, Any]) -> EmbeddingSettings:
                 env_threshold,
             )
 
+    dimension = base.dimension
+    env_dimension = os.environ.get("SURREAL_MEMORY_EMBEDDING_DIMENSION")
+    if env_dimension is not None and env_dimension.strip():
+        try:
+            dimension = int(env_dimension)
+        except ValueError:
+            logging.getLogger(__name__).warning(
+                "Invalid SURREAL_MEMORY_EMBEDDING_DIMENSION=%r — ignoring",
+                env_dimension,
+            )
+
     return EmbeddingSettings(
         enabled=enabled,
         provider=provider,
         model=model,
         similarity_threshold=similarity_threshold,
+        dimension=dimension,
+    )
+
+
+def _load_sync_settings(data: dict[str, Any]) -> SyncConfig:
+    """Build SyncConfig from config.toml, letting env vars override.
+
+    Env precedence (env wins over config.toml, config.toml wins over defaults):
+        SURREAL_MEMORY_HUB_URL       -> hub_url
+        SURREAL_MEMORY_API_KEY       -> api_key
+        SURREAL_MEMORY_SYNC_ENABLED  -> enabled (truthy parse)
+        SURREAL_MEMORY_SYNC_AUTO     -> auto_sync (truthy parse)
+
+    This makes a sync hub configured purely via the environment (docker-compose
+    or the MCP client env) visible to the dashboard/Overview without first
+    writing a ``[sync]`` block to config.toml — mirroring the embedding/storage
+    env-override layers. Values are re-validated through ``SyncConfig.from_dict``
+    so env-provided hub_url/api_key get the same format sanitisation.
+    """
+    base = SyncConfig.from_dict(data)
+
+    hub_url = base.hub_url
+    env_hub = os.environ.get("SURREAL_MEMORY_HUB_URL")
+    if env_hub is not None and env_hub.strip():
+        hub_url = env_hub.strip()
+
+    api_key = base.api_key
+    env_key = os.environ.get("SURREAL_MEMORY_API_KEY")
+    if env_key is not None and env_key.strip():
+        api_key = env_key.strip()
+
+    enabled = base.enabled
+    env_enabled = _env_truthy(os.environ.get("SURREAL_MEMORY_SYNC_ENABLED"))
+    if env_enabled is not None:
+        enabled = env_enabled
+
+    auto_sync = base.auto_sync
+    env_auto = _env_truthy(os.environ.get("SURREAL_MEMORY_SYNC_AUTO"))
+    if env_auto is not None:
+        auto_sync = env_auto
+
+    return SyncConfig.from_dict(
+        {
+            "enabled": enabled,
+            "hub_url": hub_url,
+            "api_key": api_key,
+            "auto_sync": auto_sync,
+            "sync_interval_seconds": base.sync_interval_seconds,
+            "conflict_strategy": base.conflict_strategy,
+        }
     )
 
 
@@ -1402,7 +1471,7 @@ class UnifiedConfig:
             tiers=TierConfig.from_dict(data.get("tiers", {})),
             watcher=WatcherConfig.from_dict(data.get("watcher", {})),
             device_id=raw_device_id,
-            sync=SyncConfig.from_dict(sync_data),
+            sync=_load_sync_settings(sync_data),
             storage_backend=_validate_storage_backend(
                 os.environ.get("SURREAL_MEMORY_STORAGE")
                 or str(data.get("storage_backend") or sync_data.get("storage_backend") or "sqlite")
@@ -1450,6 +1519,7 @@ class UnifiedConfig:
             f'provider = "{self.embedding.provider}"',
             f'model = "{self.embedding.model}"',
             f"similarity_threshold = {self.embedding.similarity_threshold}",
+            f"dimension = {self.embedding.dimension}",
             "",
             "# Auto-capture settings for MCP server",
             "[auto]",
@@ -2104,11 +2174,17 @@ async def _get_surrealdb_storage(config: UnifiedConfig, name: str) -> NeuralStor
         _surrealdb_storage.set_brain(name)
         return _surrealdb_storage
 
+    # Resolve the embedding vector dimension that the SurrealDB HNSW index must
+    # match. Priority: explicit config.embedding.dimension (e.g. a local
+    # OpenAI-compatible bge-m3 server → 1024) > known Gemini model dim > 3072.
     emb_dim = 3072  # Gemini 2.0 default
-    if config.embedding.enabled and config.embedding.model:
-        from surreal_memory.engine.embedding.gemini_embedding import _MODEL_DIMENSIONS
+    if config.embedding.enabled:
+        if config.embedding.dimension and config.embedding.dimension > 0:
+            emb_dim = int(config.embedding.dimension)
+        elif config.embedding.model:
+            from surreal_memory.engine.embedding.gemini_embedding import _MODEL_DIMENSIONS
 
-        emb_dim = _MODEL_DIMENSIONS.get(config.embedding.model, 3072)
+            emb_dim = _MODEL_DIMENSIONS.get(config.embedding.model, 3072)
 
     _warn_missing_surreal_pass()
 

--- a/tests/unit/test_surrealdb_maturation.py
+++ b/tests/unit/test_surrealdb_maturation.py
@@ -1,0 +1,102 @@
+"""Regression tests for the SurrealDB maturation mixin.
+
+Guards two RUN-004 fixes:
+1. ``save_maturation`` upserts by the EXISTING record id, not a recomputed
+   ``{brain}_{fiber}`` sid. A brain rename updates the ``brain_id`` field but not
+   the record id, so recomputing the id would target a non-existent record and
+   the write would silently no-op (this is what broke review/maturation writes
+   on the renamed ``default`` brain).
+2. ``_row_to_maturation`` round-trips stage, rehearsal data, and the
+   ``reinforcement_timestamps`` array faithfully.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from surreal_memory.engine.memory_stages import MaturationRecord, MemoryStage
+from surreal_memory.storage.surrealdb.maturation import (
+    SurrealDBMaturationMixin,
+    _row_to_maturation,
+)
+
+
+class _MaturationHarness(SurrealDBMaturationMixin):
+    """Minimal concrete mixin wiring the three abstract hooks to test doubles."""
+
+    def __init__(self, conn: MagicMock, brain_id: str, query_result: list) -> None:
+        self._conn = conn
+        self._brain = brain_id
+        self._query_result = query_result
+
+    def _ensure_conn(self) -> MagicMock:
+        return self._conn
+
+    def _get_brain_id(self) -> str:
+        return self._brain
+
+    async def _query(self, sql: str, **params: object) -> list:
+        return self._query_result
+
+
+@pytest.mark.asyncio
+async def test_save_maturation_merges_by_existing_record_id() -> None:
+    """Existing row with a stale (pre-rename) record id must still be updated."""
+    conn = MagicMock()
+    conn.merge = AsyncMock()
+    conn.insert = AsyncMock()
+    # Record id still carries the OLD brain prefix after a rename to "default".
+    stale_id = "maturation:`my_brain.v2_abc_123`"
+    harness = _MaturationHarness(conn, "default", query_result=[{"id": stale_id}])
+
+    await harness.save_maturation(
+        MaturationRecord(fiber_id="abc-123", brain_id="default", stage=MemoryStage.SEMANTIC)
+    )
+
+    conn.merge.assert_awaited_once()
+    # Must target the EXISTING id, NOT the recomputed "maturation:default_abc_123".
+    assert conn.merge.call_args[0][0] == stale_id
+    conn.insert.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_save_maturation_inserts_when_absent() -> None:
+    """No existing row → insert with the computed deterministic id."""
+    conn = MagicMock()
+    conn.merge = AsyncMock()
+    conn.insert = AsyncMock()
+    harness = _MaturationHarness(conn, "default", query_result=[])
+
+    await harness.save_maturation(
+        MaturationRecord(fiber_id="abc-123", brain_id="default", stage=MemoryStage.WORKING)
+    )
+
+    conn.insert.assert_awaited_once()
+    inserted = conn.insert.call_args[0][1]
+    assert inserted["id"] == "default_abc_123"
+    assert inserted["stage"] == "working"
+    conn.merge.assert_not_called()
+
+
+def test_row_to_maturation_roundtrip() -> None:
+    row = {
+        "fiber_id": "abc-123",
+        "brain_id": "default",
+        "stage": "semantic",
+        "stage_entered_at": "2026-06-20T00:00:00Z",
+        "rehearsal_count": 3,
+        "reinforcement_timestamps": ["2026-06-20T00:00:00", "2026-06-21T00:00:00"],
+    }
+
+    rec = _row_to_maturation(row)
+
+    assert rec.fiber_id == "abc-123"
+    assert rec.brain_id == "default"
+    assert rec.stage is MemoryStage.SEMANTIC
+    assert rec.rehearsal_count == 3
+    assert rec.reinforcement_timestamps == (
+        "2026-06-20T00:00:00",
+        "2026-06-21T00:00:00",
+    )

--- a/tests/unit/test_sync_config_persistence.py
+++ b/tests/unit/test_sync_config_persistence.py
@@ -1,0 +1,120 @@
+"""Regression tests for cloud-sync config persistence (RUN-004).
+
+Pins the three defects fixed in RUN-004 so the panel "Cloud Sync: not
+configured" bug cannot regress:
+
+  1. Dead env vars: SyncConfig now honors SURREAL_MEMORY_HUB_URL / _API_KEY /
+     _SYNC_ENABLED / _SYNC_AUTO via ``_load_sync_settings`` (was TOML-only, so a
+     hub configured only via compose/MCP env was invisible to Overview).
+  2. Stale singleton: a caller that ``save()``s must also ``set_config()`` so
+     ``get_config()`` in the SAME process serves fresh values without a restart.
+  3. On-disk persistence survives a reload.
+
+No mocks: real ``save()``/``load()``/``get_config()``/``set_config()`` against an
+isolated ``SURREAL_MEMORY_DIR`` (tmp). Sync config is a config.toml + in-process
+singleton concern, independent of the storage backend, so it is tested at the
+config layer (the storage-backed stories are covered by the live-DB suite).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import pytest
+
+from surreal_memory.unified_config import (
+    SyncConfig,
+    _load_sync_settings,
+    get_config,
+    set_config,
+)
+
+_SYNC_ENV_VARS = (
+    "SURREAL_MEMORY_HUB_URL",
+    "SURREAL_MEMORY_API_KEY",
+    "SURREAL_MEMORY_SYNC_ENABLED",
+    "SURREAL_MEMORY_SYNC_AUTO",
+)
+
+
+@pytest.fixture
+def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point config dir + singleton at a throwaway tmp dir so the real
+    ``~/.surrealmemory/config.toml`` is never touched, and clear sync env vars
+    so an ambient hub config does not leak into the assertions."""
+    monkeypatch.setenv("SURREAL_MEMORY_DIR", str(tmp_path))
+    for var in _SYNC_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    # Prime the module singleton bound to the tmp dir.
+    set_config(get_config(reload=True))
+    return tmp_path
+
+
+class TestSyncEnvOverride:
+    """Defect 1: sync config must honor environment variables."""
+
+    def test_hub_url_from_env_when_toml_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SURREAL_MEMORY_HUB_URL", "https://hub.example.workers.dev")
+        assert _load_sync_settings({}).hub_url == "https://hub.example.workers.dev"
+
+    def test_api_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SURREAL_MEMORY_API_KEY", "nmk_env_key_123")
+        assert _load_sync_settings({}).api_key == "nmk_env_key_123"
+
+    def test_env_wins_over_toml(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SURREAL_MEMORY_HUB_URL", "https://env.example.workers.dev")
+        cfg = _load_sync_settings({"hub_url": "https://toml.example.workers.dev"})
+        assert cfg.hub_url == "https://env.example.workers.dev"
+
+    def test_toml_used_when_env_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SURREAL_MEMORY_HUB_URL", raising=False)
+        cfg = _load_sync_settings({"hub_url": "https://toml.example.workers.dev"})
+        assert cfg.hub_url == "https://toml.example.workers.dev"
+
+    def test_sync_enabled_truthy_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SURREAL_MEMORY_SYNC_ENABLED", "true")
+        assert _load_sync_settings({}).enabled is True
+
+    def test_invalid_env_hub_url_sanitized_to_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # SyncConfig.from_dict rejects non-http(s) hub_url — env values are
+        # re-validated through it, so a bad env value becomes "".
+        monkeypatch.setenv("SURREAL_MEMORY_HUB_URL", "ftp://bad-scheme")
+        assert _load_sync_settings({}).hub_url == ""
+
+
+class TestSyncSingletonAndPersistence:
+    """Defects 2 & 3: same-process freshness after save()+set_config(), and
+    on-disk persistence across a reload."""
+
+    def test_set_config_makes_get_config_fresh_in_process(self, isolated_config: Path) -> None:
+        cfg = get_config()
+        assert cfg.sync.hub_url == ""  # not configured initially
+
+        new_sync = SyncConfig.from_dict(
+            {
+                "hub_url": "https://hub.example.workers.dev",
+                "api_key": "nmk_persist_123",
+                "enabled": True,
+            }
+        )
+        updated = dataclasses.replace(cfg, sync=new_sync)
+        updated.save()
+        set_config(updated)  # the fix — without this, get_config() stayed stale
+
+        # SAME process, no reload: must serve the fresh value.
+        assert get_config().sync.hub_url == "https://hub.example.workers.dev"
+        assert get_config().sync.api_key == "nmk_persist_123"
+        # Overview's "configured" predicate is bool(sync.hub_url):
+        assert bool(get_config().sync.hub_url) is True
+
+    def test_persists_across_reload(self, isolated_config: Path) -> None:
+        cfg = get_config()
+        new_sync = SyncConfig.from_dict(
+            {"hub_url": "https://hub.example.workers.dev", "api_key": "nmk_reload_123"}
+        )
+        dataclasses.replace(cfg, sync=new_sync).save()
+
+        reloaded = get_config(reload=True)  # fresh read from disk
+        assert reloaded.sync.hub_url == "https://hub.example.workers.dev"
+        assert reloaded.sync.api_key == "nmk_reload_123"


### PR DESCRIPTION
Recovers valuable local work that underpinned the live phobos brain repair (uncommitted until now).

## What & why

- **Maturation storage mixin** — `SurrealDBMaturationMixin` (save/find/get maturation) wired into the store, plus a `maturation` table and `SCHEMA_VERSION` bump. Without it the SurrealDB backend fell through to a base no-op, so maturation stages never persisted and the dashboard reported **0% semantic** even for months-old data.
- **Parametric HNSW dimension** — `idx_neuron_embedding` moved into `ensure_schema(conn, embedding_dim)` with a parameterized `DIMENSION`, so the vector index always matches the embedding provider's output dimension. A mismatch (e.g. 3072-index vs a 1024 model) silently broke semantic search.
- **Embedding dimension config** — `EmbeddingSettings.dimension` (0 = auto) + `SURREAL_MEMORY_EMBEDDING_DIMENSION` env; env-override sync-settings loader; both threaded into storage init.
- **numpy** added to the `embeddings-openai` extra.

## Test plan

- [x] `pytest tests/unit/test_surrealdb_maturation.py tests/unit/test_sync_config_persistence.py` — 11 passed
- [x] `ruff check` clean on changed files; import smoke of store/maturation/unified_config OK

Part 1 of 3 recovering coherent local changes (storage/config foundation).