### PR TITLE
fix: rename-safe persistence merges + config-cache refresh

### DIFF
--- a/src/surreal_memory/cli/commands/tools.py
+++ b/src/surreal_memory/cli/commands/tools.py
@@ -565,8 +565,12 @@ def consolidate(
             typer.echo("(dry run - no changes will be saved)")
 
         storage = await get_storage(config, brain_name=brain_name)
-        brain_obj = await storage.get_brain(brain_name)
-        brain_id = brain_obj.id if brain_obj else brain_name
+        # Neurons/synapses are keyed by brain_id == the brain NAME. The brain
+        # record's ``id`` is a legacy UUID that does NOT match the stored
+        # brain_id, so using it here made consolidation operate on an empty
+        # brain (zero rows matched → every strategy reported 0). Always run
+        # against the name.
+        brain_id = brain_name
 
         cons_config = ConsolidationConfig(
             prune_weight_threshold=prune_threshold,

--- a/src/surreal_memory/mcp/sync_handler.py
+++ b/src/surreal_memory/mcp/sync_handler.py
@@ -478,6 +478,11 @@ class SyncToolHandler:
 
                 self.config = dc_replace(self.config, sync=new_sync)
                 self.config.save()
+                from surreal_memory.unified_config import set_config
+
+                set_config(
+                    self.config
+                )  # refresh REST get_config() singleton (mirror activate path)
 
                 result: dict[str, Any] = {
                     "status": "updated",

--- a/src/surreal_memory/server/routes/dashboard_api.py
+++ b/src/surreal_memory/server/routes/dashboard_api.py
@@ -970,6 +970,11 @@ async def update_sync_config(
 
     updated = dc_replace(config, sync=new_sync)
     updated.save()
+    from surreal_memory.unified_config import set_config
+
+    set_config(
+        updated
+    )  # refresh cached get_config() singleton so this process serves fresh sync config
 
     api_key_display = "(not set)"
     if new_sync.api_key and len(new_sync.api_key) >= 12:
@@ -1067,6 +1072,9 @@ async def update_config(body: ConfigUpdateRequest) -> dict[str, Any]:
 
     updated = dc_replace(config, embedding=new_embedding)
     updated.save()
+    from surreal_memory.unified_config import set_config
+
+    set_config(updated)  # refresh cached get_config() singleton
 
     return {"status": "updated", "embedding": new_embedding.to_dict()}
 

--- a/src/surreal_memory/storage/surrealdb/cognitive.py
+++ b/src/surreal_memory/storage/surrealdb/cognitive.py
@@ -118,7 +118,9 @@ class SurrealDBCognitiveMixin:
             neuron_id=neuron_id,
         )
         if existing:
-            await conn.merge(f"cognitive_state:{sid}", record_data)
+            # Merge by existing record id (not recomputed sid) — survives a brain
+            # rename where the id keeps the old brain prefix (else silent no-op).
+            await conn.merge(existing[0]["id"], record_data)
         else:
             insert_data = dict(record_data)
             insert_data["id"] = sid

--- a/src/surreal_memory/storage/surrealdb/compression.py
+++ b/src/surreal_memory/storage/surrealdb/compression.py
@@ -74,7 +74,9 @@ class SurrealDBCompressionMixin:
             fiber_id=fiber_id,
         )
         if existing:
-            await conn.merge(f"compression_backups:{sid}", record_data)
+            # Merge by existing record id (not recomputed sid) — survives a brain
+            # rename where the id keeps the old brain prefix (else silent no-op).
+            await conn.merge(existing[0]["id"], record_data)
         else:
             insert_data = dict(record_data)
             insert_data["id"] = sid
@@ -186,7 +188,9 @@ class SurrealDBCompressionMixin:
             neuron_id=neuron_id,
         )
         if existing:
-            await conn.merge(f"neuron_snapshots:{sid}", record_data)
+            # Merge by existing record id (not recomputed sid) — survives a brain
+            # rename where the id keeps the old brain prefix (else silent no-op).
+            await conn.merge(existing[0]["id"], record_data)
         else:
             insert_data = dict(record_data)
             insert_data["id"] = sid

--- a/src/surreal_memory/storage/surrealdb/review_schedules.py
+++ b/src/surreal_memory/storage/surrealdb/review_schedules.py
@@ -79,7 +79,11 @@ class SurrealDBReviewSchedulesMixin:
             fiber_id=schedule.fiber_id,
         )
         if existing:
-            await conn.merge(f"review_schedules:{sid}", record_data)
+            # Merge by the EXISTING record id, not the recomputed sid: a brain
+            # rename updates the brain_id FIELD but not the record id, so the id
+            # may still carry the old brain prefix. Recomputing the sid here would
+            # target a non-existent record and the update would silently no-op.
+            await conn.merge(existing[0]["id"], record_data)
         else:
             insert_data = dict(record_data)
             insert_data["id"] = sid


### PR DESCRIPTION
Recovers local fixes for two **silent no-op** classes surfaced during the live brain rename/unification on phobos.

## Changes

- **Rename-safe upserts** — `cognitive.py`, `compression.py`, `review_schedules.py` now `merge` on the real `existing[0]["id"]` instead of a recomputed `sid`. After a brain rename the recomputed id was stale, so the merge silently did nothing.
- **Consolidate targets the right brain** — `cli/commands/tools.py` uses `brain_id = brain_name` rather than the legacy UUID `brain_obj.id`, otherwise consolidation ran against an empty brain (0 rows).
- **Config-cache refresh** — `sync_handler.py` / `dashboard_api.py` call `set_config(...)` after persisting so the cached `get_config()` singleton refreshes and the REST process picks up new sync/embedding config without a restart.

## Test plan

- [x] `ruff check` clean; import smoke of all changed modules OK
- [x] Verified live on the phobos deployment: the `consolidate` `brain_id` fix is exactly what made consolidation act on the unified `default` brain during the repair

These are DB-behavioural one-liners (rename/upsert semantics); covered by live verification rather than new unit tests. Part 2 of 3 recovering coherent local changes.