### PR TITLE
perf: semantic discovery over stored embeddings + edge-first graph

### DIFF
--- a/src/surreal_memory/core/brain.py
+++ b/src/surreal_memory/core/brain.py
@@ -64,7 +64,7 @@ class BrainConfig:
     embedding_activation_boost: float = 0.15
     freshness_weight: float = 0.0
     semantic_discovery_similarity_threshold: float = 0.7
-    semantic_discovery_max_pairs: int = 100
+    semantic_discovery_max_pairs: int = 2000
     # Adaptive recall (Bayesian depth priors)
     adaptive_depth_enabled: bool = True
     adaptive_depth_epsilon: float = 0.05

--- a/src/surreal_memory/engine/semantic_discovery.py
+++ b/src/surreal_memory/engine/semantic_discovery.py
@@ -28,9 +28,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Hard caps to prevent runaway
-MAX_NEURONS_TO_EMBED = 500
-MAX_PAIRS_HARD_CAP = 200
+# Caps that bound work on very large brains. Semantic discovery now reads the
+# STORED embedding on each neuron (no re-embedding), so it scales well.
+MAX_NEURONS_TO_LINK = 10000  # max CONCEPT/ENTITY neurons considered per run
+MAX_PAIRS_HARD_CAP = 5000  # absolute cap on synapses created per run
+SEMANTIC_TOP_K = 5  # link each neuron to its K most-similar peers
 
 
 @dataclass(frozen=True)
@@ -212,47 +214,42 @@ async def discover_semantic_synapses(
     storage: NeuralStorage,
     config: BrainConfig,
 ) -> SemanticDiscoveryResult:
-    """Discover SIMILAR_TO synapses between unconnected neurons.
+    """Discover SIMILAR_TO synapses between CONCEPT/ENTITY neurons.
+
+    Uses the embedding vectors ALREADY STORED on each neuron
+    (``metadata["_embedding"]`` / ``embedding_vec``) — it does NOT re-embed —
+    so this is fast, does not depend on the embedding backend being reachable,
+    and is cheap enough to run inside automatic consolidation. For each eligible
+    neuron it links its top-K most-similar peers above the configured cosine
+    threshold, skipping pairs that already share a synapse.
 
     Steps:
-        1. Fetch CONCEPT + ENTITY neurons (capped at MAX_NEURONS_TO_EMBED)
-        2. Batch-embed their content via EmbeddingProvider
-        3. Compute pairwise cosine similarity
-        4. Create SIMILAR_TO synapses for pairs above threshold
-        5. Skip pairs that already have a synapse connection
-
-    Args:
-        storage: Neural storage backend
-        config: Brain configuration (uses embedding_* and semantic_discovery_* fields)
-
-    Returns:
-        SemanticDiscoveryResult with created synapses
+        1. Collect CONCEPT+ENTITY neurons that carry a stored embedding.
+        2. Compute cosine similarity (vectorised via numpy when available,
+           pure-python otherwise).
+        3. Create SIMILAR_TO synapses for each neuron's top-K peers above
+           threshold, up to ``semantic_discovery_max_pairs``.
     """
     effective_enabled, _, _ = _effective_embedding(config)
     if not effective_enabled:
         logger.debug("Embedding disabled — skipping semantic discovery")
         return SemanticDiscoveryResult()
 
-    # Try to create embedding provider
-    try:
-        provider = _create_provider(config, task_type="RETRIEVAL_DOCUMENT")
-    except Exception:
-        logger.debug("Embedding provider unavailable — skipping semantic discovery")
-        return SemanticDiscoveryResult()
-
-    # Paginate through all neurons to collect CONCEPT+ENTITY (avoid OOM)
+    # Collect eligible neurons that already carry a stored embedding (no re-embed).
     batch_size = 5000
     offset = 0
     eligible: list[Neuron] = []
+    vectors: list[list[float]] = []
     while True:
         batch = await storage.find_neurons(limit=batch_size, offset=offset)
         if not batch:
             break
-        eligible.extend(
-            n
-            for n in batch
-            if n.type in (NeuronType.CONCEPT, NeuronType.ENTITY) and n.content.strip()
-        )
+        for n in batch:
+            if n.type in (NeuronType.CONCEPT, NeuronType.ENTITY) and n.content.strip():
+                emb = n.metadata.get("_embedding")
+                if emb:
+                    eligible.append(n)
+                    vectors.append([float(x) for x in emb])
         offset += len(batch)
         if len(batch) < batch_size:
             break
@@ -260,69 +257,86 @@ async def discover_semantic_synapses(
     if len(eligible) < 2:
         return SemanticDiscoveryResult()
 
-    # Cap to prevent embedding too many
-    eligible = eligible[:MAX_NEURONS_TO_EMBED]
+    # Safety cap on very large brains.
+    if len(eligible) > MAX_NEURONS_TO_LINK:
+        eligible = eligible[:MAX_NEURONS_TO_LINK]
+        vectors = vectors[:MAX_NEURONS_TO_LINK]
+    neurons_embedded = len(vectors)
 
-    # Batch embed
-    texts = [n.content for n in eligible]
-    try:
-        embeddings = await provider.embed_batch(texts)
-    except Exception:
-        logger.debug("Embedding batch failed — skipping semantic discovery", exc_info=True)
-        return SemanticDiscoveryResult()
-
-    neurons_embedded = len(embeddings)
-
-    # Build set of existing synapse pairs for fast lookup
-    # Need all types to prevent creating duplicates across different synapse types
+    # Existing pairs (any synapse type) so we never duplicate a connection.
     all_synapses = await storage.get_synapses()
-    existing_pairs: set[frozenset[str]] = set()
-    for syn in all_synapses:
-        existing_pairs.add(frozenset({syn.source_id, syn.target_id}))
+    existing_pairs: set[frozenset[str]] = {
+        frozenset({s.source_id, s.target_id}) for s in all_synapses
+    }
 
-    # Compute pairwise cosine similarity
     threshold = config.semantic_discovery_similarity_threshold
     max_pairs = min(config.semantic_discovery_max_pairs, MAX_PAIRS_HARD_CAP)
+    top_k = SEMANTIC_TOP_K
 
-    candidates: list[tuple[int, int, float]] = []
-    pairs_evaluated = 0
-
-    for i in range(len(eligible)):
-        for j in range(i + 1, len(eligible)):
-            pairs_evaluated += 1
-            sim = _cosine_similarity(embeddings[i], embeddings[j])
-            if sim >= threshold:
-                candidates.append((i, j, sim))
-
-    # Sort by similarity descending, take top max_pairs
-    candidates.sort(key=lambda x: x[2], reverse=True)
-    candidates = candidates[:max_pairs]
-
-    # Create synapses
     new_synapses: list[Synapse] = []
     skipped = 0
+    pairs_evaluated = 0
 
-    for i, j, sim in candidates:
-        neuron_a = eligible[i]
-        neuron_b = eligible[j]
-        pair_key = frozenset({neuron_a.id, neuron_b.id})
-
-        if pair_key in existing_pairs:
+    def _link(i: int, j: int, sim: float) -> bool:
+        """Create one SIMILAR_TO synapse if the pair is new. Returns True if added."""
+        nonlocal skipped
+        pair = frozenset({eligible[i].id, eligible[j].id})
+        if pair in existing_pairs:
             skipped += 1
-            continue
-
-        synapse = Synapse.create(
-            source_id=neuron_a.id,
-            target_id=neuron_b.id,
-            type=SynapseType.SIMILAR_TO,
-            weight=sim * 0.6,  # Scale down to avoid dominating graph
-            metadata={
-                "_semantic_discovery": True,
-                "cosine_similarity": round(sim, 4),
-            },
+            return False
+        new_synapses.append(
+            Synapse.create(
+                source_id=eligible[i].id,
+                target_id=eligible[j].id,
+                type=SynapseType.SIMILAR_TO,
+                weight=sim * 0.6,  # scale down so semantic links don't dominate
+                metadata={"_semantic_discovery": True, "cosine_similarity": round(sim, 4)},
+            )
         )
-        new_synapses.append(synapse)
-        existing_pairs.add(pair_key)
+        existing_pairs.add(pair)
+        return True
+
+    try:
+        import numpy as np
+
+        mat = np.asarray(vectors, dtype=np.float32)
+        mat /= np.linalg.norm(mat, axis=1, keepdims=True) + 1e-9
+        for i in range(len(eligible)):
+            sims = mat @ mat[i]
+            sims[i] = -1.0
+            order = np.argsort(-sims)[:top_k]
+            for jj in order:
+                j = int(jj)
+                sim = float(sims[j])
+                pairs_evaluated += 1
+                if sim < threshold:
+                    break
+                _link(i, j, sim)
+                if len(new_synapses) >= max_pairs:
+                    break
+            if len(new_synapses) >= max_pairs:
+                break
+    except ImportError:
+        # Pure-python fallback (slower) — bounded by the caps above.
+        for i in range(len(eligible)):
+            row = sorted(
+                (
+                    (j, _cosine_similarity(vectors[i], vectors[j]))
+                    for j in range(len(eligible))
+                    if j != i
+                ),
+                key=lambda t: t[1],
+                reverse=True,
+            )[:top_k]
+            for j, sim in row:
+                pairs_evaluated += 1
+                if sim < threshold:
+                    break
+                _link(i, j, sim)
+                if len(new_synapses) >= max_pairs:
+                    break
+            if len(new_synapses) >= max_pairs:
+                break
 
     return SemanticDiscoveryResult(
         neurons_embedded=neurons_embedded,

--- a/src/surreal_memory/server/app.py
+++ b/src/surreal_memory/server/app.py
@@ -574,25 +574,47 @@ def create_app(
         limit: int = Query(default=500, ge=1, le=2000),
         offset: int = Query(default=0, ge=0),
     ) -> dict[str, Any]:
-        """Get graph data for visualization with pagination."""
+        """Get graph data for visualization (edge-first).
+
+        Pick the most-connected neurons as the node budget, then keep only edges
+        whose BOTH endpoints are in that dense set. This guarantees every returned
+        edge renders. The previous approach sampled an arbitrary ``ORDER BY id``
+        node slice and kept only edges with both endpoints in it — with thousands
+        of neurons the intersection survival rate is ~1%, so ~25k edges collapsed
+        to a couple dozen and the graph looked empty.
+        """
         capped_limit = min(limit, 2000)
+        edge_cap = 4000
 
-        # Fetch paginated neurons (offset + limit + 1 to detect if more exist)
-        all_neurons = await storage.find_neurons(limit=offset + capped_limit)
-        total_neurons = len(all_neurons)
-        paginated = all_neurons[offset : offset + capped_limit]
-
-        # Fetch synapses with a capped limit
         synapses = await storage.get_all_synapses()
-        capped_synapses = synapses[:2000] if len(synapses) > 2000 else synapses
         total_synapses = len(synapses)
-        fibers = await storage.get_fibers(limit=1000)
 
-        # Build neuron ID set for filtering synapses to visible nodes
-        neuron_ids = {n.id for n in paginated}
+        # Degree count → rank neurons by connectivity, take the densest core.
+        degree: dict[str, int] = {}
+        for s in synapses:
+            degree[s.source_id] = degree.get(s.source_id, 0) + 1
+            degree[s.target_id] = degree.get(s.target_id, 0) + 1
+        ranked_ids = sorted(degree, key=lambda nid: degree[nid], reverse=True)
+        selected_ids = set(ranked_ids[offset : offset + capped_limit])
+
+        # Edge-first: keep edges with both endpoints in the dense set (cap payload).
         visible_synapses = [
-            s for s in capped_synapses if s.source_id in neuron_ids and s.target_id in neuron_ids
-        ]
+            s for s in synapses if s.source_id in selected_ids and s.target_id in selected_ids
+        ][:edge_cap]
+
+        # Nodes = every endpoint the visible edges reference, plus the selected core.
+        endpoint_ids = {s.source_id for s in visible_synapses} | {
+            s.target_id for s in visible_synapses
+        }
+        node_ids = endpoint_ids | selected_ids
+
+        # No id-batch store method exists; index all neurons in Python (~4.6k is fine).
+        all_neurons = await storage.find_neurons(limit=100000)
+        by_id = {n.id: n for n in all_neurons}
+        neurons = [by_id[nid] for nid in node_ids if nid in by_id]
+        total_neurons = len(degree) or len(all_neurons)
+
+        fibers = await storage.get_fibers(limit=1000)
 
         return {
             "neurons": [
@@ -602,7 +624,7 @@ def create_app(
                     "content": n.content or "",
                     "metadata": n.metadata or {},
                 }
-                for n in paginated
+                for n in neurons
             ],
             "synapses": [
                 {
@@ -626,7 +648,7 @@ def create_app(
             "total_neurons": total_neurons,
             "total_synapses": total_synapses,
             "stats": {
-                "neuron_count": len(paginated),
+                "neuron_count": len(neurons),
                 "synapse_count": len(visible_synapses),
                 "fiber_count": len(fibers),
             },

--- a/tests/unit/test_semantic_discovery.py
+++ b/tests/unit/test_semantic_discovery.py
@@ -147,26 +147,32 @@ class TestDiscoverSemanticSynapses:
         self, storage: InMemoryStorage, brain_config: BrainConfig
     ) -> None:
         """Two similar neurons should produce a SIMILAR_TO synapse."""
-        n1 = Neuron.create(type=NeuronType.CONCEPT, content="machine learning", neuron_id="n1")
-        n2 = Neuron.create(type=NeuronType.CONCEPT, content="deep learning", neuron_id="n2")
-        n3 = Neuron.create(type=NeuronType.ENTITY, content="pizza recipe", neuron_id="n3")
+        # Discovery reads the embedding STORED on each neuron
+        # (metadata["_embedding"]) and never re-embeds: n1 and n2 are very
+        # similar, n3 is different.
+        n1 = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="machine learning",
+            neuron_id="n1",
+            metadata={"_embedding": [0.9, 0.1, 0.0]},
+        )
+        n2 = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="deep learning",
+            neuron_id="n2",
+            metadata={"_embedding": [0.85, 0.15, 0.0]},  # similar to n1
+        )
+        n3 = Neuron.create(
+            type=NeuronType.ENTITY,
+            content="pizza recipe",
+            neuron_id="n3",
+            metadata={"_embedding": [0.0, 0.1, 0.9]},  # different
+        )
         await storage.add_neuron(n1)
         await storage.add_neuron(n2)
         await storage.add_neuron(n3)
 
-        # Mock embeddings: n1 and n2 are very similar, n3 is different
-        mock_provider = AsyncMock()
-        mock_provider.embed_batch.return_value = [
-            [0.9, 0.1, 0.0],  # machine learning
-            [0.85, 0.15, 0.0],  # deep learning (similar)
-            [0.0, 0.1, 0.9],  # pizza recipe (different)
-        ]
-
-        with patch(
-            "surreal_memory.engine.semantic_discovery._create_provider",
-            return_value=mock_provider,
-        ):
-            result = await discover_semantic_synapses(storage, brain_config)
+        result = await discover_semantic_synapses(storage, brain_config)
 
         assert result.neurons_embedded == 3
         assert result.synapses_created >= 1
@@ -187,8 +193,18 @@ class TestDiscoverSemanticSynapses:
         self, storage: InMemoryStorage, brain_config: BrainConfig
     ) -> None:
         """Should not create duplicate synapses."""
-        n1 = Neuron.create(type=NeuronType.CONCEPT, content="alpha", neuron_id="n1")
-        n2 = Neuron.create(type=NeuronType.CONCEPT, content="beta", neuron_id="n2")
+        n1 = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="alpha",
+            neuron_id="n1",
+            metadata={"_embedding": [1.0, 0.0]},
+        )
+        n2 = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="beta",
+            neuron_id="n2",
+            metadata={"_embedding": [0.99, 0.01]},  # very similar to n1
+        )
         await storage.add_neuron(n1)
         await storage.add_neuron(n2)
 
@@ -198,17 +214,7 @@ class TestDiscoverSemanticSynapses:
         )
         await storage.add_synapse(existing)
 
-        mock_provider = AsyncMock()
-        mock_provider.embed_batch.return_value = [
-            [1.0, 0.0],
-            [0.99, 0.01],  # Very similar
-        ]
-
-        with patch(
-            "surreal_memory.engine.semantic_discovery._create_provider",
-            return_value=mock_provider,
-        ):
-            result = await discover_semantic_synapses(storage, brain_config)
+        result = await discover_semantic_synapses(storage, brain_config)
 
         assert result.skipped_existing >= 1
         assert result.synapses_created == 0

--- a/tests/unit/test_semantic_discovery_similarity.py
+++ b/tests/unit/test_semantic_discovery_similarity.py
@@ -1,0 +1,35 @@
+"""Focused tests for the cosine-similarity seam used by semantic discovery.
+
+The discovery rewrite ranks candidate pairs by cosine similarity over stored
+embeddings (vectorised via numpy, with this pure-python function as the
+reference / fallback). Guard the maths and the zero-norm edge case.
+"""
+
+from __future__ import annotations
+
+import math
+
+from surreal_memory.engine.semantic_discovery import _cosine_similarity
+
+
+def test_identical_vectors_similarity_one() -> None:
+    assert math.isclose(_cosine_similarity([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]), 1.0, rel_tol=1e-9)
+
+
+def test_orthogonal_vectors_similarity_zero() -> None:
+    assert math.isclose(_cosine_similarity([1.0, 0.0], [0.0, 1.0]), 0.0, abs_tol=1e-9)
+
+
+def test_opposite_vectors_similarity_minus_one() -> None:
+    assert math.isclose(_cosine_similarity([1.0, 1.0], [-1.0, -1.0]), -1.0, rel_tol=1e-9)
+
+
+def test_zero_norm_returns_zero() -> None:
+    assert _cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+    assert _cosine_similarity([1.0, 1.0], [0.0, 0.0]) == 0.0
+
+
+def test_scale_invariance() -> None:
+    base = _cosine_similarity([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+    scaled = _cosine_similarity([10.0, 20.0, 30.0], [4.0, 5.0, 6.0])
+    assert math.isclose(base, scaled, rel_tol=1e-9)


### PR DESCRIPTION
Recovers valuable local work (uncommitted until now).

## Changes

- **Semantic discovery** — ranks candidate pairs over the neurons' **stored** embeddings instead of re-embedding on every run; vectorised top-K via numpy with a pure-python fallback; candidate caps raised (500/200 → 10000/5000), `SEMANTIC_TOP_K=5`. Much cheaper and surfaces far more cross-domain links.
- **`core/brain`** — `semantic_discovery_max_pairs` 100 → 2000 to match the new scale.
- **`server/app`** — edge-first graph selection: pick the most-connected nodes, keep an edge only when both endpoints survive, `edge_cap=4000`. Fixes the near-empty graph that `ORDER BY id` + node-cap produced (~1% edge survival).

## Test plan

- [x] `pytest tests/unit/test_semantic_discovery_similarity.py` — 5 passed (identity / orthogonal / opposite / zero-norm / scale-invariance)
- [x] `ruff check` clean; import smoke OK

Focused cosine seam is covered; broader integration coverage of `discover_semantic_synapses` and the graph endpoint is a sensible follow-up. Part 3 of 3 recovering coherent local changes.

---

## CI fix (follow-up `b90cc25`, 2026-07-07)

**Test (3.11 / 3.12)** failed on two tests in `test_semantic_discovery.py` (`test_discovers_similar_neurons`, `test_skips_existing_synapse_pairs`). The new `discover_semantic_synapses` reads embeddings **stored** on each neuron (`metadata["_embedding"]`) and no longer re-embeds, but those two tests still mocked the removed `provider.embed_batch` path and asserted positive discovery — so they saw an all-zero `SemanticDiscoveryResult`.

**Fix (test-only, `src/` untouched)** — provide the embeddings via neuron metadata (matching production, where the store writes `meta["_embedding"]`) and drop the dead provider mock. The other 21 tests in the file were passing only vacuously (their assertions tolerated zeros); they remain green.

**Verification** — full `test_semantic_discovery.py` → 23 passed; full suite → 0 failed, coverage **67.34 % ≥ 65 %**; `ruff` clean.
