### PR TITLE
docs: sync docs with PRs #39–42 (embedding dimension, semantic discovery, soft-forget, config-cache)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,12 @@ SURREAL_MEMORY_STORAGE=surrealdb
 # SURREAL_MEMORY_EMBEDDING_PROVIDER=gemini
 # SURREAL_MEMORY_EMBEDDING_MODEL=gemini-embedding-001
 # GEMINI_API_KEY=your-gemini-api-key
+#
+# Vector dimension for the embedding index. 0 = auto-derive from the provider (recommended).
+# Pin a non-zero value only to fix the HNSW index dimension to your model's output
+# (e.g. 384 / 768 / 1536 / 3072); a value that disagrees with the model silently breaks
+# semantic search. The vector index is (re)built to this dimension.
+# SURREAL_MEMORY_EMBEDDING_DIMENSION=0
 
 # --- Embedding (other providers) ---
 # Local, offline, NO API key (install the `embeddings` extra):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `smem doctor` **SurrealDB version check** (TIER_CORE; FAILs when the server is < 3.2.0).
 - `smem doctor --synapse-migration {status|retry|purge-backup}` to inspect, resume, or
   clean up the synapse→RELATE migration.
+- **Parametric embedding dimension** — the HNSW vector index (`idx_neuron_embedding`) is now built to
+  match the embedding provider's output dimension. New `SURREAL_MEMORY_EMBEDDING_DIMENSION` env /
+  `[embedding].dimension` config (`0` = auto-derive, the default). Fixes silently-broken semantic search
+  when the index dimension disagreed with the model.
+- **SurrealDB maturation storage** — maturation stages now persist on the SurrealDB backend (previously a
+  base no-op), so long-lived memories report their real semantic maturity instead of 0%.
 
 ### Changed
 
 - `docker-compose.surrealdb.yml` now runs `surrealdb/surrealdb:v3.2.0` with
   `--allow-experimental gql --allow-eval-query`. The datastore path must be given **before**
   the capability flags (the multi-valued `--allow-eval-query` would otherwise consume it).
+
+### Performance
+
+- **Semantic discovery** now ranks candidate pairs over each neuron's **stored** embedding instead of
+  re-embedding on every run (vectorised top-K with a pure-python fallback) and raises the candidate caps —
+  much cheaper and surfaces far more cross-domain links.
+- **Edge-first graph selection** on the dashboard graph endpoint picks the most-connected nodes and keeps
+  an edge only when both endpoints survive (`edge_cap=4000`), fixing the near-empty graph that
+  node-capping by id produced.
+
+### Fixed
+
+- **Soft `forget` is excluded from recall immediately.** A soft-forgotten memory (expired `typed_memory`)
+  no longer resurfaces in recall until the next consolidation — recall post-filters expired fibers and
+  rebuilds the answer context from the survivors.
+- **Config-cache refresh** — the REST process picks up new sync/embedding config after `set_config(...)`
+  without a restart.
+- **Rename-safe persistence** — cognitive/compression/review-schedule upserts and `consolidate` now target
+  the current brain id after a rename instead of silently no-op'ing against a stale id.
 
 ### Known behaviour
 

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -524,7 +524,7 @@ Edit an existing memory's type, content, or priority. Use when a memory was auto
 
 ### `smem_forget`
 
-Explicitly delete or close a specific memory. Soft delete by default (marks as expired) — a soft-forgotten memory is excluded from recall **immediately**, not just at the next consolidation. Use hard=true for permanent removal. Use for closing completed TODOs or removing outdated/incorrect memories.
+Explicitly delete or close a specific memory. Soft delete by default (marks as expired). Use hard=true for permanent removal. Use for closing completed TODOs or removing outdated/incorrect memories.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -524,7 +524,7 @@ Edit an existing memory's type, content, or priority. Use when a memory was auto
 
 ### `smem_forget`
 
-Explicitly delete or close a specific memory. Soft delete by default (marks as expired). Use hard=true for permanent removal. Use for closing completed TODOs or removing outdated/incorrect memories.
+Explicitly delete or close a specific memory. Soft delete by default (marks as expired) — a soft-forgotten memory is excluded from recall **immediately**, not just at the next consolidation. Use hard=true for permanent removal. Use for closing completed TODOs or removing outdated/incorrect memories.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,12 +33,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `smem doctor` **SurrealDB version check** (TIER_CORE; FAILs when the server is < 3.2.0).
 - `smem doctor --synapse-migration {status|retry|purge-backup}` to inspect, resume, or
   clean up the synapse→RELATE migration.
+- **Parametric embedding dimension** — the HNSW vector index (`idx_neuron_embedding`) is now built to
+  match the embedding provider's output dimension. New `SURREAL_MEMORY_EMBEDDING_DIMENSION` env /
+  `[embedding].dimension` config (`0` = auto-derive, the default). Fixes silently-broken semantic search
+  when the index dimension disagreed with the model.
+- **SurrealDB maturation storage** — maturation stages now persist on the SurrealDB backend (previously a
+  base no-op), so long-lived memories report their real semantic maturity instead of 0%.
 
 ### Changed
 
 - `docker-compose.surrealdb.yml` now runs `surrealdb/surrealdb:v3.2.0` with
   `--allow-experimental gql --allow-eval-query`. The datastore path must be given **before**
   the capability flags (the multi-valued `--allow-eval-query` would otherwise consume it).
+
+### Performance
+
+- **Semantic discovery** now ranks candidate pairs over each neuron's **stored** embedding instead of
+  re-embedding on every run (vectorised top-K with a pure-python fallback) and raises the candidate caps —
+  much cheaper and surfaces far more cross-domain links.
+- **Edge-first graph selection** on the dashboard graph endpoint picks the most-connected nodes and keeps
+  an edge only when both endpoints survive (`edge_cap=4000`), fixing the near-empty graph that
+  node-capping by id produced.
+
+### Fixed
+
+- **Soft `forget` is excluded from recall immediately.** A soft-forgotten memory (expired `typed_memory`)
+  no longer resurfaces in recall until the next consolidation — recall post-filters expired fibers and
+  rebuilds the answer context from the survivors.
+- **Config-cache refresh** — the REST process picks up new sync/embedding config after `set_config(...)`
+  without a restart.
+- **Rename-safe persistence** — cognitive/compression/review-schedule upserts and `consolidate` now target
+  the current brain id after a rename instead of silently no-op'ing against a stale id.
 
 ### Known behaviour
 

--- a/docs/getting-started/cli-reference.md
+++ b/docs/getting-started/cli-reference.md
@@ -394,6 +394,7 @@ smem doctor [OPTIONS]
 | `--json / -j` | boolean | No | `False` | Output as JSON |
 | `--fix` | boolean | No | `False` | Auto-fix available issues |
 | `--dev` | boolean | No | `False` | Include source checkout and contributor tooling checks |
+| `--synapse-migration` | text | No | — | Manage the synapse->RELATE migration: status \| retry \| purge-backup |
 
 ### `smem dashboard`
 

--- a/docs/guides/embedding-setup.md
+++ b/docs/guides/embedding-setup.md
@@ -218,6 +218,22 @@ These synapses allow spreading activation to traverse semantic connections durin
 - **0.6**: Moderate — catches more cross-language matches. Good starting point for multilingual.
 - **0.5**: Aggressive — more noise but catches loose associations.
 
+### Embedding Dimension
+
+The vector index (`idx_neuron_embedding`, HNSW) is built to a fixed **dimension** that must match your
+embedding provider's output (e.g. `all-MiniLM-L6-v2` = 384, `text-embedding-004`/`nomic-embed-text` = 768,
+`text-embedding-3-small` = 1536, `gemini-embedding-001`/`text-embedding-3-large` = 3072). By default the
+dimension is **auto-derived** from the active provider, so you normally set nothing.
+
+```toml
+[embedding]
+dimension = 0   # 0 = auto-derive from the provider (recommended)
+```
+
+Or via env: `SURREAL_MEMORY_EMBEDDING_DIMENSION=0`. Pin a non-zero value only if you deliberately want a
+fixed index dimension — a value that disagrees with the model's real output dimension silently breaks
+semantic search (the index and the stored vectors no longer match).
+
 ### Changing Provider Mid-Session
 
 You can change providers at any time. However, existing `SIMILAR_TO` synapses created by semantic discovery were computed with the old provider's embeddings. Run `smem consolidate` after switching to recompute with the new provider.


### PR DESCRIPTION
## Summary

Documentation was out of date relative to the recent PRs **#39–#43** — the feature/behaviour PRs #39–#42 all
merged into `main` **without touching `docs/` or any `*.md`**, the 2.6.0 `CHANGELOG` (added by #43) only covered
the synapse→RELATE work, and #43's new CLI flag was never regenerated into the CLI reference. This PR closes
those gaps. **Docs-only, source-of-truth-driven** — no code changes.

## What & why

| Source | Change that lacked docs | Doc update |
|---|---|---|
| **#40** | new `SURREAL_MEMORY_EMBEDDING_DIMENSION` env / `[embedding].dimension` (0 = auto); parametric HNSW index dimension; maturation now persists (fixed dashboard "0% semantic") | `.env.example` entry; new **Embedding Dimension** section in `docs/guides/embedding-setup.md`; CHANGELOG **Added** |
| **#42** | semantic discovery ranks over **stored** embeddings; edge-first dashboard graph selection (fixed near-empty graph) | CHANGELOG **Performance** |
| **#39** | soft-`forget` now excluded from recall **immediately** (previously lingered until consolidation) | CHANGELOG **Fixed** — the `smem_forget` tool reference is generated from source, so the behaviour note lives in the changelog (see follow-up below) |
| **#41** | config-cache refresh (REST picks up new config without restart); rename-safe upserts / consolidate target the current brain | CHANGELOG **Fixed** |
| **#43** | `smem doctor --synapse-migration` CLI flag was added but never regenerated into the CLI reference | regenerate `docs/getting-started/cli-reference.md` |

The 2.6.0 entry in both `CHANGELOG.md` and `docs/changelog.md` now carries the **Added / Performance / Fixed**
items above, so the release notes describe everything that shipped in 2.6.0 — not just the synapse migration.

## Files (5 changed vs `main`, +73 / −0 net)

- `.env.example` — document `SURREAL_MEMORY_EMBEDDING_DIMENSION`
- `docs/guides/embedding-setup.md` — new "Embedding Dimension" subsection (0 = auto; dimension must match provider)
- `CHANGELOG.md` + `docs/changelog.md` — expand the 2.6.0 entry (Added / Performance / Fixed)
- `docs/getting-started/cli-reference.md` — regenerated (adds `smem doctor --synapse-migration`)

> The branch has two commits: the second one regenerates the generated docs and **reverts an accidental
> hand-edit** of `docs/api/mcp-tools.md` (a generated file). Net effect on `mcp-tools.md` vs `main`: none.

## Verification

- `python scripts/gen_mcp_docs.py --check` and `python scripts/gen_cli_docs.py --check` → both **up-to-date**
  (this is the CI **Docs Freshness** gate).
- `mkdocs build --strict` → clean (nav + internal links validated).
- Content is additive prose in hand-maintained docs plus a regenerated CLI reference — no code touched.

## Follow-ups (out of scope here)

- To surface the #39 soft-`forget` "excluded from recall immediately" note **inside** the generated MCP tool
  reference, update the `smem_forget` tool description in source and regenerate (a code change — kept out of
  this docs-only PR).
- `CHANGELOG.md` has a second, older `## [2.6.0] — 2026-02-18` heading further down (a pre-existing duplicate
  version header unrelated to this release line) — worth a separate cleanup.
