### PR TITLE
fix: FLEXIBLE object fields — migration dropped synapses with metadata (v2.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.1] — 2026-07-07
+
+### Fixed
+
+- **CRITICAL: the v7→v8 synapse migration silently dropped every synapse with
+  non-empty `metadata`.** The v8 `synapse` RELATION table is `SCHEMAFULL`, but its
+  `metadata` field was defined as a plain `TYPE object`, which rejects arbitrary
+  nested keys (e.g. `{"_dedup": true}`). On a real database the migration therefore
+  skipped the majority of edges as "data loss" and `store.initialize()` aborted at
+  the verification step. The field is now `TYPE object FLEXIBLE`, so nested metadata
+  is preserved and the migration completes losslessly. Originals are always kept in
+  `synapse_migration_backup` and the pre-migration data was never modified, so **no
+  data was lost** — but a 2.6.0 upgrade could not complete. **Upgrade to 2.6.1
+  before migrating an existing database.**
+- The migration's `converting` phase now always rebuilds the RELATION table from the
+  complete backup on entry (including on resume), so a migration interrupted by the
+  above bug recovers every row instead of resuming past the ones it skipped.
+- **The same `SCHEMAFULL` + plain-`TYPE object` gap affected every table with a
+  `metadata`/`config` object field on a *fresh* database** — `neuron`, `fiber`,
+  `brain` (config + metadata), `typed_memory`, `source`, `alerts` and
+  `brain_versions`. Any write carrying a nested key (e.g. a structured `context`)
+  would have been rejected. All object fields are now `TYPE object FLEXIBLE`.
+
 ## [2.6.0] — 2026-07-07
 
 ### BREAKING

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.1] — 2026-07-07
+
+### Fixed
+
+- **CRITICAL: the v7→v8 synapse migration silently dropped every synapse with
+  non-empty `metadata`.** The v8 `synapse` RELATION table is `SCHEMAFULL`, but its
+  `metadata` field was defined as a plain `TYPE object`, which rejects arbitrary
+  nested keys (e.g. `{"_dedup": true}`). On a real database the migration therefore
+  skipped the majority of edges as "data loss" and `store.initialize()` aborted at
+  the verification step. The field is now `TYPE object FLEXIBLE`, so nested metadata
+  is preserved and the migration completes losslessly. Originals are always kept in
+  `synapse_migration_backup` and the pre-migration data was never modified, so **no
+  data was lost** — but a 2.6.0 upgrade could not complete. **Upgrade to 2.6.1
+  before migrating an existing database.**
+- The migration's `converting` phase now always rebuilds the RELATION table from the
+  complete backup on entry (including on resume), so a migration interrupted by the
+  above bug recovers every row instead of resuming past the ones it skipped.
+- **The same `SCHEMAFULL` + plain-`TYPE object` gap affected every table with a
+  `metadata`/`config` object field on a *fresh* database** — `neuron`, `fiber`,
+  `brain` (config + metadata), `typed_memory`, `source`, `alerts` and
+  `brain_versions`. Any write carrying a nested key (e.g. a structured `context`)
+  would have been rejected. All object fields are now `TYPE object FLEXIBLE`.
+
 ## [2.6.0] — 2026-07-07
 
 ### BREAKING

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.6.0"
+version = "2.6.1"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.6.0"
+__version__ = "2.6.1"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/storage/surrealdb/migrations.py
+++ b/src/surreal_memory/storage/surrealdb/migrations.py
@@ -370,22 +370,37 @@ async def _phase_copying(conn: Any, state: dict[str, Any]) -> None:
 
 
 async def _phase_converting(conn: Any, state: dict[str, Any]) -> None:
-    """Drop the flat table, (re)define the RELATION table, replay backup as edges."""
-    # Only rebuild the table on the FIRST entry to this phase (cursor is None):
-    # a resume mid-phase must NOT drop the partially-migrated edge table.
-    if not state.get("cursor"):
-        await conn.query("REMOVE TABLE IF EXISTS synapse")
-        for ddl in SYNAPSE_V8_DDL:
-            try:
-                await conn.query(ddl)
-            except Exception as exc:
-                # Tolerate only "already exists" (idempotent re-run). A real DDL
-                # error (syntax/permissions) must abort — inserting into a
-                # half-defined table would corrupt silently.
-                if not _already_exists(exc):
-                    raise
+    """Drop the flat table, (re)define the RELATION table, replay backup as edges.
 
-    after = _cursor_record(state.get("cursor"), BACKUP_TABLE)
+    Rebuilds the RELATION table from the COMPLETE backup on every entry — including
+    on a resume. Two reasons this full re-scan is correct and necessary:
+
+    * INSERT RELATION uses explicit ids, so re-inserting is idempotent (the table is
+      dropped first, so there is nothing to clash with anyway).
+    * Resuming from a saved cursor would permanently lose any row that a buggy
+      earlier build SKIPPED *behind* that cursor (e.g. every synapse with non-empty
+      ``metadata`` before the FLEXIBLE fix). Re-scanning from the start, against the
+      freshly-redefined v8 schema, is what makes those rows recoverable.
+    """
+    await conn.query("REMOVE TABLE IF EXISTS synapse")
+    for ddl in SYNAPSE_V8_DDL:
+        try:
+            await conn.query(ddl)
+        except Exception as exc:
+            # Tolerate only "already exists" (idempotent re-run). A real DDL
+            # error (syntax/permissions) must abort — inserting into a
+            # half-defined table would corrupt silently.
+            if not _already_exists(exc):
+                raise
+
+    # Fresh full pass over the backup (the source of truth); reset counters so
+    # `verifying` compares against a clean, complete conversion.
+    state["converted"] = 0
+    state["skipped"] = 0
+    state["cursor"] = None
+    await _save_state(conn, state)
+
+    after: Any | None = None
     while True:
         rows = await _page(conn, BACKUP_TABLE, after, BATCH_SIZE)
         if not rows:

--- a/src/surreal_memory/storage/surrealdb/schema.py
+++ b/src/surreal_memory/storage/surrealdb/schema.py
@@ -21,7 +21,7 @@ DEFINE FIELD brain_id        ON neuron TYPE string;
 DEFINE FIELD type            ON neuron TYPE string;
 DEFINE FIELD content         ON neuron TYPE string;
 DEFINE FIELD content_hash    ON neuron TYPE int DEFAULT 0;
-DEFINE FIELD metadata        ON neuron TYPE object DEFAULT {};
+DEFINE FIELD metadata        ON neuron TYPE object FLEXIBLE DEFAULT {};
 DEFINE FIELD embedding_vec   ON neuron TYPE option<array<float>>;
 DEFINE FIELD ephemeral       ON neuron TYPE bool DEFAULT false;
 DEFINE FIELD created_at      ON neuron TYPE datetime DEFAULT time::now();
@@ -81,7 +81,7 @@ DEFINE FIELD summary         ON fiber TYPE option<string>;
 DEFINE FIELD essence         ON fiber TYPE option<string>;
 DEFINE FIELD auto_tags       ON fiber TYPE array<string> DEFAULT [];
 DEFINE FIELD agent_tags      ON fiber TYPE array<string> DEFAULT [];
-DEFINE FIELD metadata        ON fiber TYPE object DEFAULT {};
+DEFINE FIELD metadata        ON fiber TYPE object FLEXIBLE DEFAULT {};
 DEFINE FIELD compression_tier ON fiber TYPE int DEFAULT 0;
 DEFINE FIELD pinned           ON fiber TYPE bool DEFAULT false;
 DEFINE FIELD created_at       ON fiber TYPE datetime DEFAULT time::now();
@@ -93,8 +93,8 @@ DEFINE INDEX idx_fiber_anchor ON fiber FIELDS brain_id, anchor_neuron_id;
 DEFINE TABLE brain SCHEMAFULL;
 DEFINE FIELD id          ON brain TYPE string;
 DEFINE FIELD name        ON brain TYPE string;
-DEFINE FIELD config      ON brain TYPE object DEFAULT {};
-DEFINE FIELD metadata    ON brain TYPE object DEFAULT {};
+DEFINE FIELD config      ON brain TYPE object FLEXIBLE DEFAULT {};
+DEFINE FIELD metadata    ON brain TYPE object FLEXIBLE DEFAULT {};
 DEFINE FIELD created_at  ON brain TYPE datetime DEFAULT time::now();
 DEFINE FIELD updated_at  ON brain TYPE datetime DEFAULT time::now();
 -- Removed unique index on name - multiple brains can have same name
@@ -145,7 +145,7 @@ DEFINE FIELD source        ON typed_memory TYPE option<string>;
 DEFINE FIELD project_id    ON typed_memory TYPE option<string>;
 DEFINE FIELD expires_at    ON typed_memory TYPE option<datetime>;
 DEFINE FIELD tier          ON typed_memory TYPE string DEFAULT 'warm';
-DEFINE FIELD metadata      ON typed_memory TYPE object DEFAULT {};
+DEFINE FIELD metadata      ON typed_memory TYPE object FLEXIBLE DEFAULT {};
 DEFINE FIELD created_at    ON typed_memory TYPE datetime DEFAULT time::now();
 DEFINE FIELD updated_at    ON typed_memory TYPE datetime DEFAULT time::now();
 DEFINE INDEX idx_typed_brain ON typed_memory FIELDS brain_id;
@@ -171,7 +171,7 @@ DEFINE FIELD effective_date ON source TYPE option<datetime>;
 DEFINE FIELD expires_at     ON source TYPE option<datetime>;
 DEFINE FIELD status         ON source TYPE string DEFAULT 'active';
 DEFINE FIELD file_hash      ON source TYPE string DEFAULT '';
-DEFINE FIELD metadata       ON source TYPE object DEFAULT {};
+DEFINE FIELD metadata       ON source TYPE object FLEXIBLE DEFAULT {};
 DEFINE FIELD created_at     ON source TYPE datetime DEFAULT time::now();
 DEFINE FIELD updated_at     ON source TYPE datetime DEFAULT time::now();
 DEFINE INDEX idx_source_brain ON source FIELDS brain_id;
@@ -190,7 +190,7 @@ DEFINE FIELD created_at         ON alerts TYPE datetime DEFAULT time::now();
 DEFINE FIELD seen_at            ON alerts TYPE option<datetime>;
 DEFINE FIELD acknowledged_at    ON alerts TYPE option<datetime>;
 DEFINE FIELD resolved_at        ON alerts TYPE option<datetime>;
-DEFINE FIELD metadata           ON alerts TYPE object DEFAULT {};
+DEFINE FIELD metadata           ON alerts TYPE object FLEXIBLE DEFAULT {};
 DEFINE INDEX idx_alerts_brain   ON alerts FIELDS brain_id;
 DEFINE INDEX idx_alerts_status  ON alerts FIELDS brain_id, status;
 
@@ -277,7 +277,7 @@ DEFINE FIELD fiber_count     ON brain_versions TYPE int DEFAULT 0;
 DEFINE FIELD snapshot_hash   ON brain_versions TYPE string DEFAULT '';
 DEFINE FIELD snapshot_data   ON brain_versions TYPE string DEFAULT '';
 DEFINE FIELD created_at      ON brain_versions TYPE datetime DEFAULT time::now();
-DEFINE FIELD metadata        ON brain_versions TYPE object DEFAULT {};
+DEFINE FIELD metadata        ON brain_versions TYPE object FLEXIBLE DEFAULT {};
 DEFINE INDEX idx_versions_brain  ON brain_versions FIELDS brain_id;
 DEFINE INDEX idx_versions_number ON brain_versions FIELDS brain_id, version_number;
 
@@ -403,7 +403,12 @@ SYNAPSE_V8_DDL: list[str] = [
     "DEFINE FIELD type ON synapse TYPE string",
     "DEFINE FIELD weight ON synapse TYPE float DEFAULT 1.0",
     "DEFINE FIELD direction ON synapse TYPE string DEFAULT 'forward'",
-    "DEFINE FIELD metadata ON synapse TYPE object DEFAULT {}",
+    # FLEXIBLE is REQUIRED: synapse metadata carries arbitrary nested keys
+    # (e.g. {"_dedup": true}). On a SCHEMAFULL table a plain `TYPE object` field
+    # rejects any undefined nested key ("Found field 'metadata._dedup', but no
+    # such field exists"), which silently skipped every synapse with non-empty
+    # metadata during the v7->v8 migration. FLEXIBLE (after TYPE) allows nested keys.
+    "DEFINE FIELD metadata ON synapse TYPE object FLEXIBLE DEFAULT {}",
     "DEFINE FIELD created_at ON synapse TYPE datetime DEFAULT time::now()",
     "DEFINE FIELD last_activated ON synapse TYPE option<datetime>",
     "DEFINE FIELD reinforced_count ON synapse TYPE int DEFAULT 0",

--- a/tests/integration/test_surrealdb_synapse_migration.py
+++ b/tests/integration/test_surrealdb_synapse_migration.py
@@ -89,15 +89,23 @@ async def _seed_v7(conn, seeder: SurrealDBStorage, brain_id: str) -> dict[str, d
         "e_self": (a, a, "related_to", 1.0),  # self-loop
         "e_orphan": (a, "missingneuron", "related_to", 1.0),  # orphan endpoint
         "e_dash": (a, d, "related_to", 2.0),  # dashed neuron id endpoint
+        "e_meta": (b, c, "alias", 1.0),  # non-empty NESTED metadata (regression guard)
     }
+    # Nested metadata keys (e.g. {"_dedup": true}) are the regression guard for the
+    # v2.6.1 FLEXIBLE fix: a SCHEMAFULL RELATION table with a plain `TYPE object`
+    # metadata field rejected undefined nested keys, so v2.6.0 silently SKIPPED every
+    # synapse with non-empty metadata. This row must survive with its metadata intact.
+    metas: dict[str, dict] = {"e_meta": {"_dedup": True, "note": {"nested": "keeps"}}}
     expected: dict[str, dict] = {}
     for sid, (src, tgt, styp, weight) in specs.items():
         ss = _to_surreal_id(src)
         st = _to_surreal_id(tgt)
+        meta = metas.get(sid, {})
         await conn.query(
             f"CREATE synapse:{sid} SET brain_id=$b, type=$t, source_id=$s, target_id=$g, "
-            "weight=$w, direction='uni', created_at=time::now(), reinforced_count=0",
-            {"b": brain_id, "t": styp, "s": ss, "g": st, "w": weight},
+            "weight=$w, direction='uni', created_at=time::now(), reinforced_count=0, "
+            "metadata=$m",
+            {"b": brain_id, "t": styp, "s": ss, "g": st, "w": weight, "m": meta},
         )
         expected[sid] = {
             "id": sid.replace("_", "-"),
@@ -105,6 +113,7 @@ async def _seed_v7(conn, seeder: SurrealDBStorage, brain_id: str) -> dict[str, d
             "target_id": st.replace("_", "-"),
             "type": styp,
             "weight": weight,
+            "metadata": meta,
         }
 
     # a fiber referencing the seeded synapse ids
@@ -164,6 +173,11 @@ async def test_v7_upgrade_preserves_count_ids_endpoints_export_and_merkle() -> N
         assert got.target_id == exp["target_id"]
         assert got.type.value == exp["type"]
         assert got.weight == exp["weight"]
+        assert got.metadata == exp["metadata"], f"metadata lost for {eid}"
+
+    # regression (v2.6.1 FLEXIBLE fix): a synapse with NESTED metadata survives with
+    # its keys intact — on v2.6.0 this row was silently skipped (count would drop).
+    assert by_id["e-meta"].metadata == {"_dedup": True, "note": {"nested": "keeps"}}
 
     # self-loop / orphan specifically survive
     assert by_id["e-self"].source_id == by_id["e-self"].target_id

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.6.0"
+        assert surreal_memory.__version__ == "2.6.1"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_surrealdb_migrations.py
+++ b/tests/unit/test_surrealdb_migrations.py
@@ -312,8 +312,10 @@ class TestLock:
 # --------------------------------------------------------------------------- #
 class TestResume:
     @pytest.mark.asyncio
-    async def test_resume_from_converting_skips_copying_and_remove(self, monkeypatch):
-        """A resume mid-converting must NOT re-copy and must NOT drop the table."""
+    async def test_resume_from_converting_rebuilds_without_recopy(self, monkeypatch):
+        """A resume mid-converting must NOT re-copy, but MUST rebuild the RELATION
+        table from the complete backup (dropping any partial/buggy conversion) so
+        rows a prior attempt skipped behind its cursor are recovered."""
         backup_rows = [
             {
                 "id": _rid(M.BACKUP_TABLE, "e0"),
@@ -347,8 +349,8 @@ class TestResume:
         assert not any("INSERT IGNORE INTO synapse_migration_backup" in s for s in sqls), (
             "must not re-copy"
         )
-        assert not any("REMOVE TABLE IF EXISTS synapse" in s for s in sqls), (
-            "must not drop table on mid-phase resume"
+        assert any("REMOVE TABLE IF EXISTS synapse" in s for s in sqls), (
+            "resume must rebuild the RELATION table from the complete backup"
         )
         assert any("INSERT RELATION INTO synapse" in s for s in sqls)
         assert any("UPSERT schema_meta:version SET version" in s for s in sqls)

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

**CRITICAL hotfix for v2.6.0.** The v7→v8 synapse→RELATE migration silently dropped the majority of a real database's synapses. Discovered while upgrading a live brain (174,592 synapses); 86% carried nested `metadata` and were lost.

## Root cause

The v8 `synapse` RELATION table is `SCHEMAFULL`, but its `metadata` field was `DEFINE FIELD metadata ON synapse TYPE object DEFAULT {}` — a plain object field. On a SCHEMAFULL table this **rejects any undefined nested key** (`"Found field 'metadata._dedup', but no such field exists"`), so `INSERT RELATION` failed for every synapse with non-empty metadata. The migration logged them as "SKIPPED (data loss)" and then aborted at the verification step. Originals were always safe in `synapse_migration_backup`, so **no data was actually lost** — but a 2.6.0 upgrade could not complete.

The **same gap exists on every other SCHEMAFULL table** with a `metadata`/`config` object field (`neuron`, `fiber`, `brain`, `typed_memory`, `source`, `alerts`, `brain_versions`) — a latent bug on **fresh** databases: any write with a nested metadata key would be rejected. Existing databases escape it only because their tables predate the SCHEMAFULL definitions.

## Fix

- All object fields are now `TYPE object FLEXIBLE` (synapse + the 7 other tables).
- The migration's `converting` phase now **always rebuilds** the RELATION table from the complete backup on entry (including on resume), so a database left half-converted by a 2.6.0 attempt recovers every skipped row instead of resuming past them.
- Integration test now seeds a synapse with nested metadata (`{"_dedup": true, ...}`) and asserts it survives — this fails on 2.6.0, passes on 2.6.1.
- Version → 2.6.1 (all 9 places) + CHANGELOG.

## Verification

- **Full-scale, real data (copy):** migrated all **174,592** synapses, **0 skipped**, 150,430 metadata objects preserved, per-brain counts identical, `synapse` is native RELATION. No server hang.
- `make verify` green: **5800 passed**, coverage 68.89%; lint / format / typecheck / security clean.
- The live production database was restored losslessly during discovery (no data lost).