### PR TITLE
feat: config-driven cross-encoder reranking (2.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] — 2026-07-07
+
+### Added
+
+- **Cross-encoder reranking is now a fully wired, config-driven recall stage.**
+  Spreading activation over-fetches candidates, which are then reranked by a
+  cross-encoder scoring `(query, memory)` relevance; the final ordering blends the
+  reranker score with the activation level (`blend_weight`, default `0.7`). Enable
+  it in `config.toml`:
+
+  ```toml
+  [reranker]
+  enabled = true
+  endpoint = "http://127.0.0.1:11435/v1"   # OpenAI-compatible /rerank (e.g. llamastash)
+  model_name = "BAAI/bge-reranker-v2-m3"
+  blend_weight = 0.7
+  ```
+
+- **HTTP reranking over an OpenAI-compatible `/rerank` server** (`HttpReranker`).
+  The new `[reranker].endpoint` runs the cross-encoder on a shared inference server
+  (e.g. llamastash / llama.cpp on GPU) instead of loading an in-process
+  sentence-transformers model — reranking then needs no `torch` dependency. When
+  the endpoint is unset it falls back to the `SURREAL_MEMORY_RERANKER_ENDPOINT`
+  env var, then to a local `CrossEncoder`. Raw llama.cpp relevance logits are
+  min-max normalised within the candidate set before blending. Reranking never
+  breaks recall: any error falls back to the spreading-activation ordering.
+
+### Fixed
+
+- **Per-brain `BrainConfig` was never persisted.** `save_brain` stored a copy of the
+  brain *metadata* in the `config` column, and `get_brain`/`find_brain_by_name` never
+  loaded it, so every brain came back with a **default** config. This made the
+  reranker — and any non-default per-brain retrieval knob — dead code. The full
+  `BrainConfig` is now serialised on save and restored on load (unknown keys are
+  dropped for forward/backward compatibility; legacy pre-2.7.0 rows that stored
+  metadata in the `config` column fall back to defaults). `config.toml [reranker]` is
+  also layered onto already-stored brains on connect, so enabling reranking takes
+  effect without recreating a brain.
+
 ## [2.6.1] — 2026-07-07
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] — 2026-07-07
+
+### Added
+
+- **Cross-encoder reranking is now a fully wired, config-driven recall stage.**
+  Spreading activation over-fetches candidates, which are then reranked by a
+  cross-encoder scoring `(query, memory)` relevance; the final ordering blends the
+  reranker score with the activation level (`blend_weight`, default `0.7`). Enable
+  it in `config.toml`:
+
+  ```toml
+  [reranker]
+  enabled = true
+  endpoint = "http://127.0.0.1:11435/v1"   # OpenAI-compatible /rerank (e.g. llamastash)
+  model_name = "BAAI/bge-reranker-v2-m3"
+  blend_weight = 0.7
+  ```
+
+- **HTTP reranking over an OpenAI-compatible `/rerank` server** (`HttpReranker`).
+  The new `[reranker].endpoint` runs the cross-encoder on a shared inference server
+  (e.g. llamastash / llama.cpp on GPU) instead of loading an in-process
+  sentence-transformers model — reranking then needs no `torch` dependency. When
+  the endpoint is unset it falls back to the `SURREAL_MEMORY_RERANKER_ENDPOINT`
+  env var, then to a local `CrossEncoder`. Raw llama.cpp relevance logits are
+  min-max normalised within the candidate set before blending. Reranking never
+  breaks recall: any error falls back to the spreading-activation ordering.
+
+### Fixed
+
+- **Per-brain `BrainConfig` was never persisted.** `save_brain` stored a copy of the
+  brain *metadata* in the `config` column, and `get_brain`/`find_brain_by_name` never
+  loaded it, so every brain came back with a **default** config. This made the
+  reranker — and any non-default per-brain retrieval knob — dead code. The full
+  `BrainConfig` is now serialised on save and restored on load (unknown keys are
+  dropped for forward/backward compatibility; legacy pre-2.7.0 rows that stored
+  metadata in the `config` column fall back to defaults). `config.toml [reranker]` is
+  also layered onto already-stored brains on connect, so enabling reranking takes
+  effect without recreating a brain.
+
 ## [2.6.1] — 2026-07-07
 
 ### Fixed

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.6.1"
+version = "2.7.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.6.1"
+__version__ = "2.7.0"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/core/brain.py
+++ b/src/surreal_memory/core/brain.py
@@ -127,6 +127,9 @@ class BrainConfig:
     reranker_blend_weight: float = 0.7  # Reranker weight (SA gets 1 - this)
     reranker_min_score: float = 0.15
     reranker_max_candidates: int = 30  # Safety cap on overfetch
+    reranker_endpoint: str = (
+        ""  # OpenAI-compatible /rerank base URL (llamastash); empty = in-process CrossEncoder
+    )
     # Temporal binding (session-level auto-linking)
     temporal_binding_enabled: bool = True
     temporal_binding_window_seconds: float = 300.0  # 5-minute window

--- a/src/surreal_memory/engine/reranker.py
+++ b/src/surreal_memory/engine/reranker.py
@@ -10,7 +10,10 @@ Install: pip install surreal-memory[reranker]
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import urllib.request
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -36,9 +39,18 @@ def _check_cross_encoder() -> bool:
     return _CROSS_ENCODER_AVAILABLE
 
 
+def _rerank_endpoint() -> str:
+    """Base URL of an OpenAI-compatible ``/rerank`` endpoint (e.g. llama.cpp /
+    llamastash, ``http://127.0.0.1:11435/v1``). When set, reranking is served over
+    HTTP instead of loading an in-process sentence-transformers CrossEncoder — no
+    torch dependency and the model runs on the shared inference server (GPU)."""
+    return os.environ.get("SURREAL_MEMORY_RERANKER_ENDPOINT", "").strip()
+
+
 def reranker_available() -> bool:
-    """Check if reranker dependencies are installed."""
-    return _check_cross_encoder()
+    """Reranking is available when an HTTP endpoint is configured OR the local
+    sentence-transformers CrossEncoder is installed."""
+    return bool(_rerank_endpoint()) or _check_cross_encoder()
 
 
 @dataclass(frozen=True)
@@ -151,6 +163,86 @@ class CrossEncoderReranker:
         return filtered[:limit]
 
 
+class HttpReranker:
+    """Rerank over an OpenAI-compatible ``/rerank`` endpoint (llama.cpp / llamastash).
+
+    Scores (query, document) pairs via HTTP rather than loading a model in-process.
+    llama.cpp returns raw relevance logits (unbounded, commonly negative), so the
+    batch is min-max normalised *within the candidate set* — a global sigmoid would
+    collapse those logits toward 0 and erase the reranker's discrimination in the
+    blend. The blended score keeps the SA activation as a floor.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        model_name: str,
+        blend_weight: float = 0.7,
+        max_candidates: int = 30,
+        timeout: float = 15.0,
+    ) -> None:
+        self._endpoint = endpoint.rstrip("/")
+        self._model = model_name
+        self._blend_weight = min(max(blend_weight, 0.0), 1.0)
+        self._max_candidates = min(max_candidates, 100)
+        self._timeout = timeout
+
+    def _raw_scores(self, query: str, documents: list[str]) -> list[float]:
+        payload = json.dumps({"model": self._model, "query": query, "documents": documents}).encode(
+            "utf-8"
+        )
+        req = urllib.request.Request(  # noqa: S310 - fixed local llamastash endpoint
+            f"{self._endpoint}/rerank",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=self._timeout) as resp:  # noqa: S310
+            data = json.loads(resp.read().decode("utf-8"))
+        by_index = {int(r["index"]): float(r["relevance_score"]) for r in data.get("results", [])}
+        return [by_index.get(i, float("-inf")) for i in range(len(documents))]
+
+    def rerank(
+        self,
+        query: str,
+        candidates: list[tuple[str, str, float]],
+        limit: int,
+    ) -> list[RerankedResult]:
+        if not candidates:
+            return []
+        candidates = candidates[: self._max_candidates]
+        documents = [content for _, content, _ in candidates]
+        raw = self._raw_scores(query, documents)
+        norm = _minmax(raw)
+        sa_weight = 1.0 - self._blend_weight
+        results: list[RerankedResult] = []
+        for (neuron_id, _, activation), norm_score, raw_score in zip(
+            candidates, norm, raw, strict=True
+        ):
+            blended = self._blend_weight * norm_score + sa_weight * activation
+            results.append(
+                RerankedResult(
+                    neuron_id=neuron_id,
+                    activation_level=activation,
+                    rerank_score=float(raw_score),
+                    blended_score=blended,
+                )
+            )
+        results.sort(key=lambda r: r.blended_score, reverse=True)
+        return results[:limit]
+
+
+def _minmax(scores: list[float]) -> list[float]:
+    """Min-max normalise to [0, 1] within the batch; missing scores map to 0."""
+    finite = [s for s in scores if s != float("-inf")]
+    if not finite:
+        return [0.0 for _ in scores]
+    lo, hi = min(finite), max(finite)
+    if hi <= lo:
+        return [1.0 if s != float("-inf") else 0.0 for s in scores]
+    return [((s - lo) / (hi - lo)) if s != float("-inf") else 0.0 for s in scores]
+
+
 def _sigmoid(x: float) -> float:
     """Sigmoid function mapping any real number to [0, 1]."""
     import math
@@ -173,22 +265,38 @@ def rerank_activations(
     min_score: float = 0.15,
     max_candidates: int = 30,
     limit: int = 50,
+    endpoint: str | None = None,
 ) -> dict[str, ActivationResult]:
     """Convenience function: rerank activations and return updated dict.
 
     Replaces activation_level with blended_score for reranked neurons.
     Non-reranked neurons (below limit) are dropped.
+
+    ``endpoint`` selects HTTP reranking over an OpenAI-compatible ``/rerank``
+    server (e.g. llamastash). When ``None``/empty, falls back to the
+    ``SURREAL_MEMORY_RERANKER_ENDPOINT`` env var, then to an in-process
+    sentence-transformers CrossEncoder.
     """
-    if not reranker_available():
+    resolved_endpoint = (endpoint or "").strip() or _rerank_endpoint()
+    if not resolved_endpoint and not _check_cross_encoder():
         logger.debug("Reranker not available, returning activations unchanged")
         return activations
 
-    reranker = CrossEncoderReranker(
-        model_name=model_name,
-        blend_weight=blend_weight,
-        min_score=min_score,
-        max_candidates=max_candidates,
-    )
+    reranker: Any
+    if resolved_endpoint:
+        reranker = HttpReranker(
+            endpoint=resolved_endpoint,
+            model_name=model_name,
+            blend_weight=blend_weight,
+            max_candidates=max_candidates,
+        )
+    else:
+        reranker = CrossEncoderReranker(
+            model_name=model_name,
+            blend_weight=blend_weight,
+            min_score=min_score,
+            max_candidates=max_candidates,
+        )
 
     # Build candidate list from activations
     candidates: list[tuple[str, str, float]] = []
@@ -203,7 +311,12 @@ def rerank_activations(
     # Sort by activation level descending (over-fetch from top)
     candidates.sort(key=lambda c: c[2], reverse=True)
 
-    reranked = reranker.rerank(query, candidates, limit)
+    try:
+        reranked = reranker.rerank(query, candidates, limit)
+    except Exception:
+        # Reranking must never break recall — fall back to the SA ordering.
+        logger.warning("Reranking failed; returning activations unchanged", exc_info=True)
+        return activations
 
     # Build new activations dict with blended scores
     from dataclasses import replace as dc_replace

--- a/src/surreal_memory/engine/retrieval.py
+++ b/src/surreal_memory/engine/retrieval.py
@@ -500,7 +500,11 @@ class ReflexPipeline:
             try:
                 from surreal_memory.engine.reranker import reranker_available
 
-                if reranker_available():
+                # The config endpoint (config.toml [reranker].endpoint) makes
+                # reranking available even when neither the env endpoint nor an
+                # in-process CrossEncoder is present, so gate on it explicitly.
+                config_endpoint = (self._config.reranker_endpoint or "").strip()
+                if config_endpoint or reranker_available():
                     from surreal_memory.engine.reranker import rerank_activations
 
                     # Fetch content for top candidates
@@ -527,6 +531,7 @@ class ReflexPipeline:
                             min_score=self._config.reranker_min_score,
                             max_candidates=self._config.reranker_max_candidates,
                             limit=50,
+                            endpoint=self._config.reranker_endpoint,
                         )
                         logger.debug(
                             "Reranked %d → %d activations",

--- a/src/surreal_memory/storage/sqlite_brain_ops.py
+++ b/src/surreal_memory/storage/sqlite_brain_ops.py
@@ -74,6 +74,13 @@ class SQLiteBrainMixin:
                         "embedding_provider": brain.config.embedding_provider,
                         "embedding_model": brain.config.embedding_model,
                         "embedding_similarity_threshold": brain.config.embedding_similarity_threshold,
+                        "reranker_enabled": brain.config.reranker_enabled,
+                        "reranker_model": brain.config.reranker_model,
+                        "reranker_overfetch_multiplier": brain.config.reranker_overfetch_multiplier,
+                        "reranker_blend_weight": brain.config.reranker_blend_weight,
+                        "reranker_min_score": brain.config.reranker_min_score,
+                        "reranker_max_candidates": brain.config.reranker_max_candidates,
+                        "reranker_endpoint": brain.config.reranker_endpoint,
                     }
                 ),
                 brain.owner_id,

--- a/src/surreal_memory/storage/sqlite_row_mappers.py
+++ b/src/surreal_memory/storage/sqlite_row_mappers.py
@@ -259,6 +259,13 @@ def row_to_brain(row: aiosqlite.Row) -> Brain:
         fidelity_summary_threshold=config_data.get("fidelity_summary_threshold", 0.3),
         fidelity_essence_threshold=config_data.get("fidelity_essence_threshold", 0.1),
         essence_generator=config_data.get("essence_generator", "extractive"),
+        reranker_enabled=config_data.get("reranker_enabled", False),
+        reranker_model=config_data.get("reranker_model", "BAAI/bge-reranker-v2-m3"),
+        reranker_overfetch_multiplier=config_data.get("reranker_overfetch_multiplier", 3),
+        reranker_blend_weight=config_data.get("reranker_blend_weight", 0.7),
+        reranker_min_score=config_data.get("reranker_min_score", 0.15),
+        reranker_max_candidates=config_data.get("reranker_max_candidates", 30),
+        reranker_endpoint=config_data.get("reranker_endpoint", ""),
     )
 
     return Brain(

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -8,13 +8,14 @@ sync engine, change log, Merkle hashes, and typed memories.
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import logging
 from datetime import datetime
 from hashlib import sha256
 from typing import Any, Literal
 from uuid import uuid4
 
-from surreal_memory.core.brain import Brain, BrainSnapshot
+from surreal_memory.core.brain import Brain, BrainConfig, BrainSnapshot
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import Neuron, NeuronState, NeuronType
 from surreal_memory.core.synapse import Direction, Synapse, SynapseType
@@ -36,6 +37,39 @@ from surreal_memory.storage.surrealdb.versions import SurrealDBVersionsMixin
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
+
+
+def _serialize_brain_config(config: Any) -> dict[str, Any]:
+    """Serialize a ``BrainConfig`` dataclass to a plain dict for storage.
+
+    Persisting the full config (not just a metadata copy) is what makes the
+    per-brain retrieval knobs — including reranking — survive a round-trip.
+    """
+    try:
+        return dataclasses.asdict(config)
+    except Exception:
+        return {}
+
+
+def _deserialize_brain_config(raw: Any) -> BrainConfig:
+    """Rebuild a ``BrainConfig`` from a stored dict, dropping unknown keys.
+
+    Legacy brains stored their *metadata* in the ``config`` column (the old
+    ``save_brain`` bug), so a dict with no BrainConfig fields yields a default
+    ``BrainConfig``. Unknown/removed keys are filtered so config schema changes
+    never break load.
+    """
+    if not isinstance(raw, dict) or not raw:
+        return BrainConfig()
+    valid = {f.name for f in dataclasses.fields(BrainConfig)}
+    filtered = {k: v for k, v in raw.items() if k in valid}
+    if not filtered:
+        return BrainConfig()
+    try:
+        return BrainConfig(**filtered)
+    except Exception:
+        logger.warning("Failed to deserialize stored brain config; using defaults", exc_info=True)
+        return BrainConfig()
 
 
 def _is_auth_error(exc: Exception) -> bool:
@@ -1187,7 +1221,7 @@ class SurrealDBStorage(
         record_data: dict[str, Any] = {
             "id": brain.id,  # Use original ID to avoid underscore conversion
             "name": brain.name,
-            "config": dict(brain.metadata),
+            "config": _serialize_brain_config(brain.config),
             "metadata": dict(brain.metadata),
             "created_at": brain.created_at,
             "updated_at": brain.updated_at,
@@ -1234,6 +1268,7 @@ class SurrealDBStorage(
                         return Brain(
                             id=bid_str,
                             name=name,
+                            config=_deserialize_brain_config(r.get("config")),
                             metadata=dict(r.get("metadata") or {}),
                             created_at=_parse_datetime(r.get("created_at")) or utcnow(),
                             updated_at=_parse_datetime(r.get("updated_at")) or utcnow(),
@@ -1970,6 +2005,7 @@ class SurrealDBStorage(
         return Brain(
             id=bid,
             name=str(r.get("name", "")),
+            config=_deserialize_brain_config(r.get("config")),
             metadata=dict(r.get("metadata") or {}),
             created_at=_parse_datetime(r.get("created_at")) or utcnow(),
             updated_at=_parse_datetime(r.get("updated_at")) or utcnow(),

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -39,6 +39,11 @@ _SYNC_ID_MAX_LEN = 128
 # Valid TOML string value: alphanumeric, hyphens, underscores, dots, slashes, spaces
 _TOML_SAFE_STRING = re.compile(r"^[a-zA-Z0-9_\-\./ ]*$")
 _TOML_STR_MAX_LEN = 128
+# URL charset (RFC 3986 gen-/sub-delims + unreserved + %), minus quotes,
+# backslash, apostrophe and whitespace — so it can't break out of a TOML
+# double-quoted basic string. Used for endpoint URLs which need ':' '?' '&' etc.
+_TOML_SAFE_URL = re.compile(r"^[a-zA-Z0-9\-._~:/?#\[\]@!$&()*+,;=%]*$")
+_TOML_URL_MAX_LEN = 256
 
 
 def get_surrealmemory_dir() -> Path:
@@ -341,12 +346,17 @@ class BrainSettings:
             extras=extras,
         )
 
-    def to_brain_config_kwargs(self, embedding: EmbeddingSettings | None = None) -> dict[str, Any]:
+    def to_brain_config_kwargs(
+        self,
+        embedding: EmbeddingSettings | None = None,
+        reranker: Any = None,
+    ) -> dict[str, Any]:
         """Build kwargs for ``core.brain.BrainConfig`` from this settings instance.
 
-        Combines the explicit BrainSettings fields, embedding-derived fields, and
-        any ``extras`` keys that match a real BrainConfig field name. Unknown
-        extras are dropped so ``BrainConfig(**kwargs)`` is safe.
+        Combines the explicit BrainSettings fields, embedding-derived fields,
+        reranker-derived fields (from ``config.toml [reranker]``), and any
+        ``extras`` keys that match a real BrainConfig field name. Unknown extras
+        are dropped so ``BrainConfig(**kwargs)`` is safe.
         """
         from surreal_memory.core.brain import BrainConfig
 
@@ -368,6 +378,8 @@ class BrainSettings:
                     "embedding_similarity_threshold": embedding.similarity_threshold,
                 }
             )
+        if reranker is not None:
+            kwargs.update(reranker_brain_config_overrides(reranker))
         for key, value in self.extras.items():
             if key in valid_fields and key not in kwargs:
                 kwargs[key] = value
@@ -897,6 +909,22 @@ def _sanitize_toml_str(value: str) -> str:
     return cleaned
 
 
+def _sanitize_toml_url(value: str) -> str:
+    """Sanitize a URL for safe TOML serialization (double-quoted basic string).
+
+    Unlike :func:`_sanitize_toml_str`, this permits URL characters (``:`` ``?``
+    ``&`` ``%`` …) while still rejecting quotes, backslashes, whitespace and
+    control characters that could break out of the string or inject TOML. Values
+    that are too long or contain any unsafe character return ``""`` (rejected,
+    never silently truncated to a broken URL)."""
+    if not isinstance(value, str):
+        return ""
+    cleaned = value.strip()
+    if len(cleaned) > _TOML_URL_MAX_LEN or not _TOML_SAFE_URL.match(cleaned):
+        return ""
+    return cleaned
+
+
 _ISO_DATETIME_PATTERN = re.compile(r"^[0-9T:\-\+Z\. ]*$")
 
 
@@ -1163,6 +1191,9 @@ class RerankerConfig:
     blend_weight: float = 0.7  # Reranker weight (SA gets 1 - this)
     min_score: float = 0.15
     max_candidates: int = 30  # Safety cap on overfetch
+    # OpenAI-compatible /rerank base URL (e.g. llamastash "http://127.0.0.1:11435/v1").
+    # When set, reranking is served over HTTP (no in-process torch/CrossEncoder).
+    endpoint: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -1172,6 +1203,7 @@ class RerankerConfig:
             "blend_weight": self.blend_weight,
             "min_score": self.min_score,
             "max_candidates": self.max_candidates,
+            "endpoint": self.endpoint,
         }
 
     @classmethod
@@ -1183,7 +1215,27 @@ class RerankerConfig:
             blend_weight=float(data.get("blend_weight", 0.7)),
             min_score=float(data.get("min_score", 0.15)),
             max_candidates=int(data.get("max_candidates", 30)),
+            endpoint=str(data.get("endpoint", "")),
         )
+
+
+def reranker_brain_config_overrides(reranker: RerankerConfig) -> dict[str, Any]:
+    """Map ``config.toml [reranker]`` onto the ``BrainConfig.reranker_*`` fields.
+
+    The retrieval pipeline reads reranking knobs from the per-brain
+    ``BrainConfig``, so this bridges the app-level ``RerankerConfig`` onto those
+    fields. Used both when creating a brain and when layering config over an
+    already-stored brain (:func:`_migrate_brain_runtime_config`).
+    """
+    return {
+        "reranker_enabled": reranker.enabled,
+        "reranker_model": reranker.model_name,
+        "reranker_overfetch_multiplier": reranker.overfetch_multiplier,
+        "reranker_blend_weight": reranker.blend_weight,
+        "reranker_min_score": reranker.min_score,
+        "reranker_max_candidates": reranker.max_candidates,
+        "reranker_endpoint": reranker.endpoint,
+    }
 
 
 @dataclass(frozen=True)
@@ -1655,6 +1707,8 @@ class UnifiedConfig:
             f"blend_weight = {self.reranker.blend_weight}",
             f"min_score = {self.reranker.min_score}",
             f"max_candidates = {self.reranker.max_candidates}",
+            "# OpenAI-compatible /rerank base URL (e.g. llamastash); empty = in-process CrossEncoder",
+            f'endpoint = "{_sanitize_toml_url(self.reranker.endpoint)}"',
             "",
             "# Auto-tier promotion/demotion (Pro feature)",
             "[tiers]",
@@ -2077,6 +2131,11 @@ async def _migrate_brain_runtime_config(
     """
     try:
         overrides = config.brain.runtime_overrides()
+        # Also layer config.toml [reranker] onto the stored brain so reranking is
+        # driven by app config (issue: reranker BrainConfig fields were never
+        # persisted, so the feature was dead code). Always applied; the diff check
+        # below no-ops when the stored brain already matches.
+        overrides.update(reranker_brain_config_overrides(config.reranker))
         if not overrides:
             return
 
@@ -2148,7 +2207,9 @@ async def _get_sqlite_storage(
         if brain is None:
             from surreal_memory.core.brain import BrainConfig
 
-            brain_config = BrainConfig(**config.brain.to_brain_config_kwargs(config.embedding))
+            brain_config = BrainConfig(
+                **config.brain.to_brain_config_kwargs(config.embedding, config.reranker)
+            )
             brain = Brain.create(name=name, config=brain_config, brain_id=name)
             await storage.save_brain(brain)
         else:

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.6.1"
+        assert surreal_memory.__version__ == "2.7.0"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_reranker_http_and_config.py
+++ b/tests/unit/test_reranker_http_and_config.py
@@ -1,0 +1,422 @@
+"""Tests for the 2.7.0 reranker integration: HTTP (llamastash) path, the
+config→BrainConfig bridge, and per-brain config persistence.
+
+These cover the wiring that turns the reranker from dead code into a working,
+config-driven feature:
+  * HttpReranker scores over an OpenAI-compatible ``/rerank`` endpoint.
+  * ``rerank_activations(endpoint=...)`` selects the HTTP path and blends.
+  * ``RerankerConfig.endpoint`` survives dict + TOML round-trips (injection-safe).
+  * ``reranker_brain_config_overrides`` / ``to_brain_config_kwargs`` map app
+    config onto ``BrainConfig.reranker_*``.
+  * ``store`` serialises/deserialises the full ``BrainConfig`` (so the reranker
+    knobs survive a save/load round-trip instead of resetting to defaults).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from dataclasses import dataclass, replace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from surreal_memory.core.brain import Brain, BrainConfig
+from surreal_memory.engine.reranker import (
+    HttpReranker,
+    _minmax,
+    rerank_activations,
+    reranker_available,
+)
+from surreal_memory.storage.sqlite_store import SQLiteStorage
+from surreal_memory.storage.surrealdb.store import (
+    _deserialize_brain_config,
+    _serialize_brain_config,
+)
+from surreal_memory.unified_config import (
+    BrainSettings,
+    RerankerConfig,
+    UnifiedConfig,
+    _migrate_brain_runtime_config,
+    _sanitize_toml_url,
+    reranker_brain_config_overrides,
+)
+
+
+@dataclass
+class FakeActivationResult:
+    neuron_id: str
+    activation_level: float
+    hop_distance: int = 1
+    path: list[str] | None = None
+    source_anchor: str = ""
+
+    def __post_init__(self) -> None:
+        if self.path is None:
+            self.path = []
+
+
+class _FakeResp:
+    """Context-manager stand-in for urllib.request.urlopen()'s return."""
+
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self) -> _FakeResp:
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+
+def _rerank_payload(scores_by_index: dict[int, float]) -> dict:
+    return {"results": [{"index": i, "relevance_score": s} for i, s in scores_by_index.items()]}
+
+
+# ---------------------------------------------------------------------------
+# HttpReranker
+# ---------------------------------------------------------------------------
+
+
+class TestHttpReranker:
+    def test_rerank_empty(self) -> None:
+        r = HttpReranker(endpoint="http://x/v1", model_name="m")
+        assert r.rerank("q", [], limit=5) == []
+
+    def test_rerank_blends_and_orders(self) -> None:
+        """High reranker score promotes a lower-activation candidate."""
+        candidates = [
+            ("n_high", "unrelated but strongly activated", 0.9),
+            ("n_rel", "the actually relevant document", 0.4),
+        ]
+        payload = _rerank_payload({0: -5.0, 1: 8.0})  # n_high low, n_rel high
+
+        r = HttpReranker(endpoint="http://x/v1", model_name="m", blend_weight=0.7)
+        with patch("urllib.request.urlopen", return_value=_FakeResp(payload)):
+            results = r.rerank("relevant?", candidates, limit=2)
+
+        assert [x.neuron_id for x in results] == ["n_rel", "n_high"]
+        # n_rel blended = 0.7*1 + 0.3*0.4 = 0.82 ; n_high = 0.7*0 + 0.3*0.9 = 0.27
+        assert results[0].blended_score == pytest.approx(0.82)
+        assert results[1].blended_score == pytest.approx(0.27)
+
+    def test_endpoint_trailing_slash_normalised(self) -> None:
+        r = HttpReranker(endpoint="http://x/v1/", model_name="m")
+        assert r._endpoint == "http://x/v1"
+
+    def test_missing_index_maps_to_zero(self) -> None:
+        candidates = [("a", "d0", 0.5), ("b", "d1", 0.5)]
+        payload = _rerank_payload({0: 3.0})  # index 1 absent → -inf → 0
+        r = HttpReranker(endpoint="http://x/v1", model_name="m", blend_weight=1.0)
+        with patch("urllib.request.urlopen", return_value=_FakeResp(payload)):
+            results = r.rerank("q", candidates, limit=2)
+        # blend_weight=1.0 → pure normalised score; present index wins
+        assert results[0].neuron_id == "a"
+
+
+class TestMinMax:
+    def test_all_equal(self) -> None:
+        assert _minmax([2.0, 2.0]) == [1.0, 1.0]
+
+    def test_normalises_to_unit_range(self) -> None:
+        assert _minmax([0.0, 5.0, 10.0]) == [0.0, 0.5, 1.0]
+
+    def test_missing_scores_map_to_zero(self) -> None:
+        out = _minmax([float("-inf"), 1.0, 3.0])
+        assert out[0] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# rerank_activations endpoint path
+# ---------------------------------------------------------------------------
+
+
+class TestRerankActivationsEndpoint:
+    def test_endpoint_selects_http_and_promotes_relevant(self) -> None:
+        activations = {
+            "n_high": FakeActivationResult("n_high", 0.9),
+            "n_rel": FakeActivationResult("n_rel", 0.4),
+        }
+        contents = {"n_high": "unrelated", "n_rel": "relevant"}
+        # candidates sorted by activation desc → n_high idx0, n_rel idx1
+        payload = _rerank_payload({0: -5.0, 1: 8.0})
+        with patch("urllib.request.urlopen", return_value=_FakeResp(payload)):
+            result = rerank_activations(
+                "relevant?",
+                activations,
+                contents,
+                endpoint="http://127.0.0.1:11435/v1",
+            )
+        # n_rel now outranks n_high on blended activation level
+        assert result["n_rel"].activation_level > result["n_high"].activation_level
+
+    def test_endpoint_failure_falls_back_unchanged(self) -> None:
+        activations = {"n1": FakeActivationResult("n1", 0.8)}
+        contents = {"n1": "c1"}
+        with patch("urllib.request.urlopen", side_effect=OSError("boom")):
+            result = rerank_activations(
+                "q", activations, contents, endpoint="http://127.0.0.1:11435/v1"
+            )
+        # Reranking must never break recall
+        assert result is activations
+
+    def test_endpoint_makes_reranker_available(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {"SURREAL_MEMORY_RERANKER_ENDPOINT": "http://127.0.0.1:11435/v1"},
+        ):
+            assert reranker_available() is True
+
+
+# ---------------------------------------------------------------------------
+# RerankerConfig.endpoint — dict + TOML round-trips, injection safety
+# ---------------------------------------------------------------------------
+
+
+class TestRerankerConfigEndpoint:
+    def test_dict_roundtrip_preserves_endpoint(self) -> None:
+        cfg = RerankerConfig(enabled=True, endpoint="http://127.0.0.1:11435/v1")
+        restored = RerankerConfig.from_dict(cfg.to_dict())
+        assert restored.endpoint == "http://127.0.0.1:11435/v1"
+
+    def test_default_endpoint_empty(self) -> None:
+        assert RerankerConfig().endpoint == ""
+
+    def test_toml_roundtrip_preserves_endpoint(self) -> None:
+        import dataclasses
+
+        with tempfile.TemporaryDirectory() as d:
+            cfg = UnifiedConfig(data_dir=Path(d))
+            cfg = dataclasses.replace(
+                cfg,
+                reranker=RerankerConfig(enabled=True, endpoint="http://127.0.0.1:11435/v1"),
+            )
+            cfg.save()
+            reloaded = UnifiedConfig.load(Path(d) / "config.toml")
+        assert reloaded.reranker.endpoint == "http://127.0.0.1:11435/v1"
+        assert reloaded.reranker.enabled is True
+
+    @pytest.mark.parametrize(
+        "good",
+        [
+            "http://127.0.0.1:11435/v1",
+            "https://host.example.com:8443/v1/rerank?x=1&y=2",
+            "http://[::1]:11435/v1",
+        ],
+    )
+    def test_sanitize_url_preserves_valid(self, good: str) -> None:
+        assert _sanitize_toml_url(good) == good
+
+    @pytest.mark.parametrize(
+        "bad",
+        ['http://x"/y', "http://x\\y", "http://x y", "http://x\nY", "a" * 300],
+    )
+    def test_sanitize_url_rejects_unsafe(self, bad: str) -> None:
+        assert _sanitize_toml_url(bad) == ""
+
+
+# ---------------------------------------------------------------------------
+# Config → BrainConfig bridge
+# ---------------------------------------------------------------------------
+
+
+class TestRerankerBridge:
+    def test_overrides_map_all_fields(self) -> None:
+        rc = RerankerConfig(
+            enabled=True,
+            model_name="BAAI/bge-reranker-v2-m3",
+            overfetch_multiplier=4,
+            blend_weight=0.65,
+            min_score=0.2,
+            max_candidates=25,
+            endpoint="http://127.0.0.1:11435/v1",
+        )
+        ov = reranker_brain_config_overrides(rc)
+        assert ov == {
+            "reranker_enabled": True,
+            "reranker_model": "BAAI/bge-reranker-v2-m3",
+            "reranker_overfetch_multiplier": 4,
+            "reranker_blend_weight": 0.65,
+            "reranker_min_score": 0.2,
+            "reranker_max_candidates": 25,
+            "reranker_endpoint": "http://127.0.0.1:11435/v1",
+        }
+        # Every key is a real BrainConfig field
+        bc = BrainConfig(**ov)
+        assert bc.reranker_enabled is True
+        assert bc.reranker_endpoint == "http://127.0.0.1:11435/v1"
+
+    def test_to_brain_config_kwargs_includes_reranker(self) -> None:
+        rc = RerankerConfig(enabled=True, endpoint="http://127.0.0.1:11435/v1")
+        kwargs = BrainSettings().to_brain_config_kwargs(None, rc)
+        assert kwargs["reranker_enabled"] is True
+        assert kwargs["reranker_endpoint"] == "http://127.0.0.1:11435/v1"
+        # Result is a valid BrainConfig
+        bc = BrainConfig(**kwargs)
+        assert bc.reranker_endpoint == "http://127.0.0.1:11435/v1"
+
+    def test_to_brain_config_kwargs_without_reranker_unchanged(self) -> None:
+        kwargs = BrainSettings().to_brain_config_kwargs(None)
+        assert "reranker_enabled" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# Per-brain BrainConfig persistence (store)
+# ---------------------------------------------------------------------------
+
+
+class TestBrainConfigPersistence:
+    def test_roundtrip_preserves_reranker(self) -> None:
+        bc = BrainConfig(
+            reranker_enabled=True,
+            reranker_endpoint="http://127.0.0.1:11435/v1",
+            reranker_blend_weight=0.65,
+        )
+        stored = _serialize_brain_config(bc)
+        assert stored["reranker_endpoint"] == "http://127.0.0.1:11435/v1"
+        restored = _deserialize_brain_config(stored)
+        assert restored.reranker_enabled is True
+        assert restored.reranker_endpoint == "http://127.0.0.1:11435/v1"
+        assert restored.reranker_blend_weight == 0.65
+
+    def test_legacy_metadata_config_yields_defaults(self) -> None:
+        """Pre-2.7.0 rows stored metadata in the config column — deserialise to
+        a default BrainConfig instead of raising."""
+        legacy = {"some_metadata_key": "value", "session": "x"}
+        bc = _deserialize_brain_config(legacy)
+        assert bc.reranker_enabled is False
+        assert isinstance(bc, BrainConfig)
+
+    def test_empty_and_non_dict_yield_defaults(self) -> None:
+        assert _deserialize_brain_config({}).reranker_enabled is False
+        assert _deserialize_brain_config(None).reranker_enabled is False
+        assert _deserialize_brain_config("garbage").reranker_enabled is False
+
+    def test_unknown_keys_are_dropped(self) -> None:
+        stored = _serialize_brain_config(BrainConfig(reranker_enabled=True))
+        stored["a_field_removed_in_a_future_version"] = 123
+        restored = _deserialize_brain_config(stored)
+        assert restored.reranker_enabled is True
+
+
+class TestRerankActivationsSelection:
+    """The endpoint path must fire even without an in-process CrossEncoder."""
+
+    def test_no_endpoint_no_encoder_returns_unchanged(self) -> None:
+        activations = {"n1": FakeActivationResult("n1", 0.8)}
+        with patch("surreal_memory.engine.reranker._check_cross_encoder", return_value=False):
+            result = rerank_activations("q", activations, {"n1": "c"}, endpoint=None)
+        assert result is activations
+
+    def test_http_used_even_without_cross_encoder(self) -> None:
+        activations = {
+            "n_high": FakeActivationResult("n_high", 0.9),
+            "n_rel": FakeActivationResult("n_rel", 0.4),
+        }
+        payload = _rerank_payload({0: -5.0, 1: 8.0})
+        with (
+            patch("surreal_memory.engine.reranker._check_cross_encoder", return_value=False),
+            patch("urllib.request.urlopen", return_value=_FakeResp(payload)),
+        ):
+            result = rerank_activations(
+                "q",
+                activations,
+                {"n_high": "u", "n_rel": "r"},
+                endpoint="http://127.0.0.1:11435/v1",
+            )
+        assert result["n_rel"].activation_level > result["n_high"].activation_level
+
+
+# ---------------------------------------------------------------------------
+# SQLite backend persistence + config layering (real store round-trips)
+# ---------------------------------------------------------------------------
+
+ENDPOINT = "http://127.0.0.1:11435/v1"
+
+
+class TestSqliteRerankerPersistence:
+    """The SQLite backend must persist reranker_* too, or reranking is dead code
+    there even though it works on SurrealDB."""
+
+    @pytest.mark.asyncio
+    async def test_sqlite_roundtrip_persists_reranker(self, tmp_path: Path) -> None:
+        store = SQLiteStorage(tmp_path / "s.db")
+        await store.initialize()
+        try:
+            brain = Brain.create(
+                name="rr_brain",
+                config=BrainConfig(
+                    reranker_enabled=True,
+                    reranker_endpoint=ENDPOINT,
+                    reranker_blend_weight=0.65,
+                ),
+            )
+            await store.save_brain(brain)
+
+            got = await store.get_brain(brain.id)
+            assert got is not None
+            assert got.config.reranker_enabled is True
+            assert got.config.reranker_endpoint == ENDPOINT
+            assert got.config.reranker_blend_weight == 0.65
+
+            by_name = await store.find_brain_by_name("rr_brain")
+            assert by_name is not None
+            assert by_name.config.reranker_endpoint == ENDPOINT
+        finally:
+            await store.close()
+
+
+class TestMigrateLayersReranker:
+    """`_migrate_brain_runtime_config` layers config.toml [reranker] onto an
+    already-stored brain, so enabling reranking takes effect without recreating
+    a brain (and reaches recall via the persisted config)."""
+
+    @pytest.mark.asyncio
+    async def test_layers_reranker_onto_existing_brain(self, tmp_path: Path) -> None:
+        store = SQLiteStorage(tmp_path / "m.db")
+        await store.initialize()
+        try:
+            brain = Brain.create(name="legacy")  # reranker off by default
+            await store.save_brain(brain)
+            assert (await store.get_brain(brain.id)).config.reranker_enabled is False
+
+            config = replace(
+                UnifiedConfig(data_dir=tmp_path),
+                reranker=RerankerConfig(enabled=True, endpoint=ENDPOINT),
+            )
+            await _migrate_brain_runtime_config(store, brain, config)
+
+            reloaded = await store.get_brain(brain.id)
+            assert reloaded.config.reranker_enabled is True
+            assert reloaded.config.reranker_endpoint == ENDPOINT
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_migration_is_idempotent_noop_when_matching(self, tmp_path: Path) -> None:
+        store = SQLiteStorage(tmp_path / "n.db")
+        await store.initialize()
+        try:
+            brain = Brain.create(
+                name="already",
+                config=BrainConfig(reranker_enabled=True, reranker_endpoint=ENDPOINT),
+            )
+            await store.save_brain(brain)
+            stored_before = await store.get_brain(brain.id)
+
+            config = replace(
+                UnifiedConfig(data_dir=tmp_path),
+                reranker=RerankerConfig(enabled=True, endpoint=ENDPOINT),
+            )
+            # Stored brain already matches config → no change / no error.
+            await _migrate_brain_runtime_config(store, stored_before, config)
+
+            after = await store.get_brain(brain.id)
+            assert after.config.reranker_enabled is True
+            assert after.config.reranker_endpoint == ENDPOINT
+        finally:
+            await store.close()

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Makes **cross-encoder reranking a fully working, config-driven recall stage** (release 2.7.0) and fixes the per-brain `BrainConfig` persistence bug that made it — and every non-default per-brain retrieval knob — impossible to enable.

### Root cause it fixes
`save_brain` stored a copy of the brain **metadata** in the `config` column, and `get_brain`/`find_brain_by_name` never loaded `config` at all — so every brain came back with a **default** `BrainConfig` (reranker off). The reranker code existed but could never fire: dead code.

## What changed

**Reranking (HTTP / config-driven)**
- `HttpReranker` — rerank over an OpenAI-compatible `/rerank` endpoint (llamastash / llama.cpp), no `torch` dependency. Falls back to `SURREAL_MEMORY_RERANKER_ENDPOINT`, then to an in-process `CrossEncoder`. Raw llama.cpp relevance logits are **min-max normalised within the candidate set** before blending with spreading-activation level.
- `config.toml [reranker].endpoint` → `RerankerConfig.endpoint` → `BrainConfig.reranker_endpoint`, wired through `to_brain_config_kwargs()` and layered onto already-stored brains on connect (`_migrate_brain_runtime_config`, idempotent).
- New `_sanitize_toml_url()` — the existing `_sanitize_toml_str` rejects `:` so a URL blanked on save; the URL sanitizer preserves URL chars while staying TOML-injection-safe (rejects quotes/backslash/whitespace/over-length).
- `retrieval.py` now also fires reranking when a config endpoint is set (not just when an env endpoint / local CrossEncoder is present).

**Persistence fix (the dead-code root cause)**
- SurrealDB `save_brain` now serialises the full `BrainConfig` (`dataclasses.asdict`); `get_brain` and `find_brain_by_name` restore it (`_deserialize_brain_config`, unknown keys dropped, legacy metadata-in-`config` rows fall back to defaults).
- SQLite backend persists `reranker_*` too (save dict + row mapper) — otherwise reranking would be dead code on SQLite even though it works on SurrealDB.

## Config

```toml
[reranker]
enabled = true
endpoint = "http://127.0.0.1:11435/v1"   # OpenAI-compatible /rerank (e.g. llamastash)
model_name = "BAAI/bge-reranker-v2-m3"
blend_weight = 0.7
```

## Test plan

- [x] 33 new unit tests: HTTP blending, min-max, TOML round-trip + injection safety, config→BrainConfig bridge, SurrealDB **and** SQLite persistence round-trips, `_migrate_brain_runtime_config` layering + idempotency (`tests/unit/test_reranker_http_and_config.py`).
- [x] Full suite: 5802 passed. The 4 failed / 59 errors are pre-existing environment failures (SurrealDB e2e/integration needing a live ≥3.2.0 server + xdist DB contention) — verified identical on clean `main` via `git stash`, i.e. **no regressions**.
- [x] `ruff check` + `ruff format` + security lint (`ruff --select S`) clean; `mypy src/ --ignore-missing-imports` clean.
- [x] **Live end-to-end** against the real llamastash `bge-reranker-v2-m3`: a relevant-but-low-activation memory (0.30) is promoted above an irrelevant-but-high-activation one (0.95) → 0.79 vs 0.285. Reranking fires.

## Notes

- Design: `config.toml [reranker]` is authoritative and layered onto brains on connect (consistent with the existing `[brain]`-extras mechanism, issue #168); the diff check makes it a no-op when the stored brain already matches.
- Reranking never breaks recall — any HTTP/model error falls back to the spreading-activation ordering.
- Version bumped to 2.7.0 across pyproject, `__init__`, both npm packages, and the VS Code extension; `CHANGELOG.md` + `docs/changelog.md` updated.
