### PR TITLE
fix: test-config isolation + web UI diversity/tool-stats bugs

### DIFF
--- a/src/surreal_memory/engine/diagnostics.py
+++ b/src/surreal_memory/engine/diagnostics.py
@@ -143,9 +143,22 @@ def _build_dynamic_action(
             f"(current: {ratio:.1f} synapses/neuron, target: 3.0+)."
         )
     elif component == "diversity":
+        # Diversity is Shannon entropy over synapse types (distribution balance),
+        # normalised against _EXPECTED_SYNAPSE_TYPES common types. A brain can use
+        # MORE than that baseline yet still score low when the mix is skewed, so
+        # never claim "{used} of {expected}" when used >= expected (that read as
+        # the contradictory "16 of 8 expected synapse types used").
+        expected = DiagnosticsEngine._EXPECTED_SYNAPSE_TYPES
+        if types_used < expected:
+            return (
+                f"Use varied memory types — only {types_used} of {expected} common "
+                "synapse types used. Try: 'X caused Y', 'after A then B', "
+                "'X is related to Y'."
+            )
         return (
-            f"Use varied memory types — only {types_used} of 8 expected synapse types used. "
-            "Try: 'X caused Y', 'after A then B', 'X is related to Y'."
+            f"Balance your synapse types — {types_used} types are in use but "
+            "unevenly distributed, so a few relations dominate. Vary phrasing: "
+            "'X caused Y', 'after A then B', 'X is related to Y'."
         )
     elif component == "freshness":
         fresh_count = int(freshness * max(fiber_count, 1))

--- a/src/surreal_memory/storage/surrealdb/tool_events.py
+++ b/src/surreal_memory/storage/surrealdb/tool_events.py
@@ -185,19 +185,40 @@ class SurrealDBToolEventsMixin:
         )
         successes = int(ok_rows[0]["c"]) if ok_rows else 0
         grouped = await self._query(
-            "SELECT tool_name, server_name, count() AS cnt FROM tool_events"
+            "SELECT tool_name, server_name, count() AS cnt,"
+            " math::mean(duration_ms) AS avg_ms FROM tool_events"
             " WHERE brain_id = $bid GROUP BY tool_name, server_name",
             bid=brain_id,
         )
+        # Per-tool success counts. `math::sum(success)` does NOT coerce a bool to
+        # 1/0 on SurrealDB (it returns 0), so count the success=true rows per
+        # group separately instead. Without success_rate/avg_duration_ms here the
+        # web UI renders "NaN%" / "NaNs" for every tool row.
+        ok_grouped = await self._query(
+            "SELECT tool_name, server_name, count() AS ok FROM tool_events"
+            " WHERE brain_id = $bid AND success = true GROUP BY tool_name, server_name",
+            bid=brain_id,
+        )
+        ok_by_key = {
+            (r.get("tool_name", ""), r.get("server_name", "")): int(r.get("ok", 0) or 0)
+            for r in ok_grouped
+        }
         grouped.sort(key=lambda r: int(r.get("cnt", 0) or 0), reverse=True)
-        top_tools = [
-            {
-                "tool_name": r.get("tool_name", ""),
-                "server_name": r.get("server_name", ""),
-                "count": int(r.get("cnt", 0) or 0),
-            }
-            for r in grouped[:20]
-        ]
+        top_tools = []
+        for r in grouped[:20]:
+            name = r.get("tool_name", "")
+            server = r.get("server_name", "")
+            cnt = int(r.get("cnt", 0) or 0)
+            ok = ok_by_key.get((name, server), 0)
+            top_tools.append(
+                {
+                    "tool_name": name,
+                    "server_name": server,
+                    "count": cnt,
+                    "success_rate": round(ok / cnt, 2) if cnt > 0 else 0.0,
+                    "avg_duration_ms": round(float(r.get("avg_ms", 0) or 0)),
+                }
+            )
         return {
             "total_events": total,
             "success_rate": round(successes / total, 2) if total > 0 else 0,
@@ -215,21 +236,42 @@ class SurrealDBToolEventsMixin:
         cutoff = utcnow() - timedelta(days=safe_days)
         rows = await self._query(
             "SELECT time::format(created_at, '%Y-%m-%d') AS day, tool_name,"
-            " count() AS cnt FROM tool_events"
+            " count() AS cnt, math::mean(duration_ms) AS avg_ms FROM tool_events"
             " WHERE brain_id = $bid AND created_at >= $cutoff"
             " GROUP BY day, tool_name",
             bid=brain_id,
             cutoff=cutoff,
         )
+        # Per (day, tool) success counts so the trend chart's success line has a
+        # real success_rate instead of NaN.
+        ok_rows = await self._query(
+            "SELECT time::format(created_at, '%Y-%m-%d') AS day, tool_name,"
+            " count() AS ok FROM tool_events"
+            " WHERE brain_id = $bid AND created_at >= $cutoff AND success = true"
+            " GROUP BY day, tool_name",
+            bid=brain_id,
+            cutoff=cutoff,
+        )
+        ok_by_key = {
+            (r.get("day", ""), r.get("tool_name", "")): int(r.get("ok", 0) or 0) for r in ok_rows
+        }
         rows.sort(
             key=lambda r: (str(r.get("day", "")), int(r.get("cnt", 0) or 0)),
             reverse=True,
         )
-        return [
-            {
-                "date": r.get("day", ""),
-                "tool_name": r.get("tool_name", ""),
-                "count": int(r.get("cnt", 0) or 0),
-            }
-            for r in rows[: min(int(limit), 50)]
-        ]
+        result: list[dict[str, Any]] = []
+        for r in rows[: min(int(limit), 50)]:
+            day = r.get("day", "")
+            name = r.get("tool_name", "")
+            cnt = int(r.get("cnt", 0) or 0)
+            ok = ok_by_key.get((day, name), 0)
+            result.append(
+                {
+                    "date": day,
+                    "tool_name": name,
+                    "count": cnt,
+                    "success_rate": round(ok / cnt, 2) if cnt > 0 else 0.0,
+                    "avg_duration_ms": round(float(r.get("avg_ms", 0) or 0)),
+                }
+            )
+        return result

--- a/tests/unit/test_embedding_provider.py
+++ b/tests/unit/test_embedding_provider.py
@@ -177,7 +177,11 @@ class TestCosineSimilarity:
         v1 = await provider.embed("first text")
         v2 = await provider.embed("second text")
         sim = await provider.similarity(v1, v2)
-        assert -1.0 <= sim <= 1.0
+        # Cosine similarity is mathematically in [-1, 1], but a dot product of
+        # near-parallel unit vectors can round to 1.0000000000000002. The mock
+        # embeds from a per-process-randomised hash(), so the vectors differ each
+        # run; without this float epsilon the range check is flaky across CI runs.
+        assert -1.0 - 1e-9 <= sim <= 1.0 + 1e-9
 
     @pytest.mark.asyncio
     async def test_self_similarity(self) -> None:

--- a/tests/unit/test_health_roadmap.py
+++ b/tests/unit/test_health_roadmap.py
@@ -35,6 +35,18 @@ class TestBuildDynamicAction:
         action = _build_dynamic_action("diversity", "fallback", metrics)
         assert "3 of 8" in action
 
+    def test_diversity_action_no_contradiction_when_types_exceed_expected(self) -> None:
+        # types_used (16) exceeds the expected baseline (8). The old message read
+        # "only 16 of 8 expected synapse types used" — logically contradictory.
+        # Diversity is Shannon entropy (balance), so it must switch to a balance
+        # message rather than an impossible "N of 8" count.
+        metrics: dict[str, Any] = {"types_used": 16}
+        action = _build_dynamic_action("diversity", "fallback", metrics)
+        assert "16 of 8" not in action
+        assert "of 8" not in action  # no stale hard-coded baseline at all
+        assert "16" in action  # still references the real count
+        assert "Balance" in action or "unevenly" in action
+
     def test_freshness_action_includes_count(self) -> None:
         metrics: dict[str, Any] = {
             "freshness": 0.2,

--- a/tests/unit/test_mem0_sync_handler.py
+++ b/tests/unit/test_mem0_sync_handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -106,20 +107,24 @@ class TestMem0SyncConfig:
 
 
 class TestSwitchBrainValidation:
-    def test_valid_brain_name(self) -> None:
-        config = UnifiedConfig()
+    # NOTE: switch_brain() persists via config.save(), so every config here MUST
+    # use an isolated data_dir. A bare UnifiedConfig() defaults to the real
+    # ~/.surrealmemory and would clobber the user's live config.toml current_brain
+    # (this test literally switched a real station to "my-brain.v2").
+    def test_valid_brain_name(self, tmp_path: Path) -> None:
+        config = UnifiedConfig(data_dir=tmp_path)
         config.current_brain = "default"
         # Should not raise for valid names
         config.switch_brain("my-brain.v2")
         assert config.current_brain == "my-brain.v2"
 
-    def test_invalid_brain_name_rejected(self) -> None:
-        config = UnifiedConfig()
+    def test_invalid_brain_name_rejected(self, tmp_path: Path) -> None:
+        config = UnifiedConfig(data_dir=tmp_path)
         with pytest.raises(ValueError, match="Invalid brain name"):
             config.switch_brain('bad"name\nnewline')
 
-    def test_path_traversal_rejected(self) -> None:
-        config = UnifiedConfig()
+    def test_path_traversal_rejected(self, tmp_path: Path) -> None:
+        config = UnifiedConfig(data_dir=tmp_path)
         with pytest.raises(ValueError, match="Invalid brain name"):
             config.switch_brain("../etc/passwd")
 

--- a/tests/unit/test_surrealdb_tool_events.py
+++ b/tests/unit/test_surrealdb_tool_events.py
@@ -16,11 +16,12 @@ from surreal_memory.storage.surrealdb.tool_events import SurrealDBToolEventsMixi
 class _ToolEventsStore(SurrealDBToolEventsMixin):
     """Routes _query by SQL fragment; records UPDATE/insert calls."""
 
-    def __init__(self, unprocessed=None, total=0, ok=0, grouped=None) -> None:
+    def __init__(self, unprocessed=None, total=0, ok=0, grouped=None, ok_grouped=None) -> None:
         self._unprocessed = unprocessed or []
         self._total = total
         self._ok = ok
         self._grouped = grouped or []
+        self._ok_grouped = ok_grouped or []
         self.updates: list[dict[str, Any]] = []
         self.inserts: list[dict[str, Any]] = []
 
@@ -46,6 +47,9 @@ class _ToolEventsStore(SurrealDBToolEventsMixin):
             return [{"c": self._ok}]
         if "count() AS c FROM tool_events WHERE brain_id = $bid GROUP ALL" in sql:
             return [{"c": self._total}]
+        # Per-tool success counts (check before the generic grouped route).
+        if "AND success = true" in sql and "GROUP BY tool_name, server_name" in sql:
+            return self._ok_grouped
         if "GROUP BY tool_name, server_name" in sql:
             return self._grouped
         return []
@@ -96,12 +100,39 @@ async def test_get_tool_stats_computes_rate_and_top_tools() -> None:
         total=4,
         ok=3,
         grouped=[
-            {"tool_name": "Read", "server_name": "", "cnt": 3},
-            {"tool_name": "Bash", "server_name": "", "cnt": 1},
+            {"tool_name": "Read", "server_name": "", "cnt": 3, "avg_ms": 12.5},
+            {"tool_name": "Bash", "server_name": "", "cnt": 1, "avg_ms": 800.0},
+        ],
+        ok_grouped=[
+            {"tool_name": "Read", "server_name": "", "ok": 2},
+            {"tool_name": "Bash", "server_name": "", "ok": 1},
         ],
     )
     stats = await store.get_tool_stats("default")
     assert stats["total_events"] == 4
     assert stats["success_rate"] == 0.75
-    assert stats["top_tools"][0]["tool_name"] == "Read"
-    assert stats["top_tools"][0]["count"] == 3
+    read = stats["top_tools"][0]
+    assert read["tool_name"] == "Read"
+    assert read["count"] == 3
+    # Per-tool fields must be present and numeric — the web UI renders "NaN%" /
+    # "NaNs" when success_rate / avg_duration_ms are missing.
+    assert read["success_rate"] == round(2 / 3, 2)
+    assert read["avg_duration_ms"] == round(12.5)  # 12 — Python banker's rounding
+    bash = stats["top_tools"][1]
+    assert bash["success_rate"] == 1.0
+    assert bash["avg_duration_ms"] == 800
+
+
+async def test_get_tool_stats_no_success_rows_is_zero_not_nan() -> None:
+    """A tool with zero successes must yield success_rate 0.0, never NaN."""
+    store = _ToolEventsStore(
+        total=2,
+        ok=0,
+        grouped=[{"tool_name": "Bash", "server_name": "", "cnt": 2, "avg_ms": 0.0}],
+        ok_grouped=[],  # no success=true rows for any tool
+    )
+    stats = await store.get_tool_stats("default")
+    tool = stats["top_tools"][0]
+    assert tool["success_rate"] == 0.0
+    assert tool["avg_duration_ms"] == 0
+    assert isinstance(tool["success_rate"], float)


### PR DESCRIPTION
## Problem

Running the dev test suite (`pytest tests/`) on a machine with a live
Surreal-Memory station **silently rewrote the real `~/.surrealmemory/config.toml`**,
flipping `current_brain` to `my-brain.v2`. That value then survived reboots (it is
a file) and, via the config → `store.initialize()` auto-create loop, kept
resurrecting a `my-brain.v2` brain — producing a persistent split-brain between
the MCP (env-pinned to `default`) and the CLI (reading the clobbered `config.toml`).

## Root cause (bisected)

`tests/unit/test_mem0_sync_handler.py::TestSwitchBrainValidation::test_valid_brain_name`:

```python
config = UnifiedConfig()            # data_dir defaults to get_surrealmemory_dir() = ~/.surrealmemory
config.switch_brain("my-brain.v2")  # switch_brain() persists via config.save()
```

`UnifiedConfig()` with no `data_dir` targets the **real** `~/.surrealmemory`, and
`switch_brain()` calls `config.save()`, so the hard-coded `"my-brain.v2"` was
written straight into the developer's live station config. Confirmed by bisecting
the whole suite: this one file flips `~/.surrealmemory/config.toml` `current_brain`
to `my-brain.v2`; every other test leaves it alone.

## Fix

Isolate the three `TestSwitchBrainValidation` cases with `data_dir=tmp_path` so
`switch_brain()`/`save()` write to a temp config instead of the real station.

## Verification

- Before: set `current_brain = "default"` → run full suite → reverts to `my-brain.v2`.
- After: set `current_brain = "default"` → run full suite → **stays `default`**.
- Suite: 5805 passed, 4 failed (pre-existing SurrealDB integration/xdist env
  failures, unrelated), no new regressions.