### PR TITLE
docs: document cross-encoder reranking (v2.7.0), fix stale references

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Everything else — sessions, context loading, habit tracking, maintenance — w
 
 - **Encoding Pipeline** — composable async steps: extract entities → create neurons → link synapses → bundle into fibers
 - **Reflex Retrieval** — spreading activation through the neuron graph, combined with SurrealDB vector search when available
+- **Reranking** — optional cross-encoder pass over-fetches SA candidates and blends relevance score with activation level for higher recall precision
 - **Consolidation** — merges similar neurons, reinforces strong paths, prunes weak ones
 - **Compression** — 5-tier lifecycle: full → summary → essence → ghost → metadata
 
@@ -195,6 +196,7 @@ Sync uses **Merkle delta** — only diffs travel, not the full brain.
 - **15 memory types** — fact, decision, error, insight, preference, workflow, instruction, and more
 - **Spreading activation** — memories surface by association, not keyword match
 - **Vector search** — SurrealDB HNSW for semantic similarity (when embeddings are configured)
+- **Cross-encoder reranking** — optional config-driven precision pass, HTTP (shared inference server) or in-process, blended with the activation score
 - **Cognitive reasoning** — hypothesize, submit evidence, make predictions, verify with Bayesian confidence
 
 #### Knowledge Ingestion
@@ -250,6 +252,31 @@ Set the provider to `auto` to pick the best available option at runtime
 
 > Embeddings use **one** model per brain — switching models changes vector
 > dimensions and invalidates existing vectors. Pick a provider before ingesting at scale.
+
+---
+
+## Reranking
+
+Spreading activation over-fetches candidates; an optional cross-encoder reranker then
+scores each `(query, memory)` pair for relevance and blends that score with the
+activation level (`blend_weight`, default `0.7`) for a final precision pass. Off by
+default — recall works the same without it.
+
+```toml
+[reranker]
+enabled = true
+endpoint = "http://127.0.0.1:11435/v1"   # OpenAI-compatible /rerank (e.g. llamastash)
+model_name = "BAAI/bge-reranker-v2-m3"
+blend_weight = 0.7
+```
+
+- **HTTP mode** (`endpoint` set) — runs on a shared inference server (e.g. llama.cpp /
+  llamastash on GPU), no `torch` dependency needed locally. Falls back to the
+  `SURREAL_MEMORY_RERANKER_ENDPOINT` env var when `endpoint` is unset.
+- **In-process mode** (no endpoint) — loads a local `sentence-transformers` `CrossEncoder`.
+  Install with `pip install "surreal-memory[reranker]"`.
+- Reranking never breaks recall — any error falls back to the spreading-activation
+  ordering unchanged.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 > Every item passes the VISION.md 4-question test + brain test.
 > ZERO LLM dependency — pure algorithmic, regex, graph-based.
 
-**Current state**: v2.0.0 — 53 MCP tools, 5500+ tests, schema v38, SurrealDB backend (SQLite/InMemory retained only as test fixtures), neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
+**Current state**: v2.0.0 — 56 MCP tools, 5500+ tests, schema v38, SurrealDB backend (SQLite/InMemory retained only as test fixtures), neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
 **Architecture**: Spreading activation reflex engine, biological memory model, MCP standard.
 
 ---
@@ -51,6 +51,7 @@
 | IDE rules generator (Cursor, Windsurf, Cline, Gemini, AGENTS.md) | v4.6 | — |
 | Cascading retrieval with fiber summary tier | v4.3 | — |
 | HuggingFace Spaces chatbot (ReflexPipeline, no LLM) | v4.3 | — |
+| Config-driven cross-encoder reranking (HTTP or in-process, blended with SA score) | v2.7.0 | Attention refinement |
 
 ---
 
@@ -84,7 +85,7 @@
 
 **Scope**: 3 sub-phases (plan: `.rune/plan-brain-quality.md`)
 - [ ] C1+C2: Domain entity types + structured data encoding (regex-based, no LLM)
-- [ ] C3: Cross-encoder reranking (optional `bge-reranker` post-SA refinement)
+- [x] C3: Cross-encoder reranking (optional `bge-reranker-v2-m3` post-SA refinement, HTTP or in-process) — **shipped v2.7.0**
 - [ ] C4: Agent visualization (`smem_visualize` → Vega-Lite/markdown/ASCII charts)
 - **Brain test**: Kế toán nhớ "ROE" khác "Paris" → Yes
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -380,7 +380,8 @@ Surreal-Memory uses SurrealDB (a multi-model document + graph + vector engine) a
 
 ### Q: Does Surreal-Memory use LLMs or embeddings?
 
-**No.** Surreal-Memory does **not** call any LLM or embedding API for encoding or retrieval. This is a common misconception.
+**Not by default — and never an LLM.** The core engine does **not** require any LLM or
+embedding API for encoding or retrieval. This is a common misconception.
 
 | Operation | How it works |
 |-----------|-------------|
@@ -395,7 +396,22 @@ This means:
 - **Fully offline** — works without internet after install
 - **Deterministic** — same query on same brain = same results (no model randomness)
 
-The only AI involvement is the *agent itself* (Claude, GPT, etc.) deciding when to call Surreal-Memory tools. The memory system is pure algorithmic graph traversal.
+Two **optional** layers sit on top of that deterministic core, off by default:
+
+- **Embeddings** — SurrealDB HNSW vector search for semantic similarity when wording
+  differs. See [Embeddings](../README.md#embeddings) for providers (Gemini, OpenAI,
+  OpenRouter, local `sentence-transformers`, Ollama).
+- **Cross-encoder reranking** — a `config.toml [reranker]` precision pass that
+  rescores spreading-activation candidates, blended with the activation level. See
+  [Reranking](../README.md#reranking). Never an LLM — a small cross-encoder classifier
+  that scores relevance, not a text generator.
+
+Neither is required, and recall works identically without them — they only sharpen
+results when wording diverges from what was stored.
+
+The only *generative* AI involvement is the agent itself (Claude, GPT, etc.) deciding
+when to call Surreal-Memory tools. The memory system's own retrieval logic is pure
+algorithmic graph traversal, with the above two opt-in neural refinements.
 
 ### Q: What are the performance benchmarks?
 

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -77,6 +77,18 @@ config = BrainConfig(
 )
 ```
 
+`BrainConfig` also carries optional cross-encoder reranking fields (off by default;
+see [Reranking](../../README.md#reranking)), persisted per-brain since v2.7.0:
+
+```python
+config = BrainConfig(
+    reranker_enabled=True,
+    reranker_endpoint="http://127.0.0.1:11435/v1",  # HTTP mode; unset = in-process CrossEncoder
+    reranker_model="BAAI/bge-reranker-v2-m3",
+    reranker_blend_weight=0.7,   # reranker weight; SA activation gets 1 - this
+)
+```
+
 ### Neuron
 
 Atomic unit of information.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -241,7 +241,7 @@ class BrainConfig:
 
 ### CLI Configuration
 
-Stored in `~/.surreal-memory/config.toml`:
+Stored in `~/.surrealmemory/config.toml`:
 
 ```toml
 [brain]
@@ -262,7 +262,7 @@ api_key = ""
 ## File Structure
 
 ```
-~/.surreal-memory/
+~/.surrealmemory/
 ├── config.toml           # User configuration
 ├── brains/
 │   ├── default.db        # SQLite brain database

--- a/docs/blog/surreal-memory-openclaw.md
+++ b/docs/blog/surreal-memory-openclaw.md
@@ -338,7 +338,7 @@ Thêm vào MCP config (`~/.claude/claude_desktop_config.json` hoặc Cursor sett
 | **Cross-agent** | Không | Cloud sync | Portable SQLite brains |
 | **Compaction-safe** | Không (vấn đề chính) | Có | Có |
 | **Tests** | N/A | N/A | 3,976+ tests |
-| **MCP tools** | N/A | N/A | 53 tools |
+| **MCP tools** | N/A | N/A | 56 tools |
 | **Open source** | Có | Có (core) | Có (MIT) |
 
 ---

--- a/docs/blog/why-i-built-surrealmemory.md
+++ b/docs/blog/why-i-built-surrealmemory.md
@@ -107,12 +107,12 @@ ReflexPipeline (spreading activation → ranked results)
 Context Output (injectable into any LLM)
 ```
 
-Everything is async Python. Storage is pluggable (SQLite default, in-memory for testing). The MCP server exposes 53 tools that any AI assistant can call.
+Everything is async Python. Storage is pluggable (SQLite default, in-memory for testing). The MCP server exposes 56 tools that any AI assistant can call.
 
 ### Numbers
 
 - **1,649 tests** passing
-- **53 MCP tools** (remember, recall, context, train, conflicts, health, habits, ...)
+- **56 MCP tools** (remember, recall, context, train, conflicts, health, habits, ...)
 - **Python 3.11+**, async-first
 - **No LLM API required by default** — encoding uses local NLP (optional LLM enhancement available)
 - **SQLite storage** — no infrastructure required

--- a/docs/concepts/spreading-activation.md
+++ b/docs/concepts/spreading-activation.md
@@ -123,6 +123,23 @@ binding_strength = co_fire_count / total_anchor_sets
 
 The highest-scoring connected region is extracted as the result, with co-activated neurons ranked highest.
 
+### 6. Cross-Encoder Reranking (optional) :material-new-box:{ .new }
+
+When `[reranker].enabled = true` in `config.toml`, the pipeline over-fetches SA
+candidates and reranks them with a cross-encoder that scores each `(query, memory)`
+pair for relevance:
+
+```python
+blended_score = blend_weight * rerank_score + (1 - blend_weight) * activation_level
+```
+
+- Runs over HTTP against an OpenAI-compatible `/rerank` endpoint (e.g. llamastash /
+  llama.cpp) or, if unset, an in-process `sentence-transformers` `CrossEncoder`.
+- The activation level always contributes to the final score (`blend_weight` defaults
+  to `0.7`, so activation keeps a `0.3` floor), and any reranker error falls back to
+  the unmodified spreading-activation ordering — reranking never breaks recall.
+- Off by default; see [Reranking](../../README.md#reranking) for setup.
+
 ## Configuration
 
 ### Brain Config

--- a/docs/index.md
+++ b/docs/index.md
@@ -220,6 +220,7 @@ All advanced features are provided by the built-in **CommunityPlugin** at no cos
 - **Time-First Anchoring** -- Time neurons as primary anchors for temporally-aware recall
 - **Spreading Activation** -- Neural graph-based retrieval (classic mode)
 - **Adaptive Recall** -- Bayesian depth priors that learn optimal retrieval depth per entity
+- **Cross-Encoder Reranking** -- optional config-driven precision pass over SA candidates (HTTP or in-process), blended with activation level
 - **Memory Decay** -- Ebbinghaus forgetting curve for natural forgetting
 
 ### Knowledge & Reasoning

--- a/integrations/surreal-memory/SKILL.md
+++ b/integrations/surreal-memory/SKILL.md
@@ -122,7 +122,7 @@ If you prefer MCP over the plugin, add to `~/.openclaw/mcp.json`:
 }
 ```
 
-On Windows, use `"python"` (not `"python3"`). This gives you all 53 MCP tools but without the auto-context/auto-capture hooks.
+On Windows, use `"python"` (not `"python3"`). This gives you all 56 MCP tools but without the auto-context/auto-capture hooks.
 
 ### 3. Verify
 

--- a/integrations/surrealmemory/README.md
+++ b/integrations/surrealmemory/README.md
@@ -54,7 +54,7 @@ Add to `~/.openclaw/openclaw.json`:
 
 **v1.7.0+**: The plugin dynamically fetches **all tools** from the MCP server at startup. Whatever version of `surreal-memory` you have installed, the plugin automatically exposes every tool it provides — no plugin update needed when new tools are added.
 
-With `surreal-memory>=4.6.0`, this includes **53 tools**:
+With `surreal-memory>=4.6.0`, this includes **56 tools**:
 
 | Category | Tools |
 |----------|-------|


### PR DESCRIPTION
## Summary
- Reranking shipped in v2.7.0 but was only documented in CHANGELOG.md — add it to README (new `## Reranking` section + Engine/Features bullets), docs/index.md, docs/concepts/spreading-activation.md (pipeline step 6), docs/api/python.md (`BrainConfig` reranker fields), and mark ROADMAP.md C3 as shipped.
- docs/FAQ.md "Does Surreal-Memory use LLMs or embeddings? No." was flatly wrong now that embeddings and reranking are real optional features — clarified as core-vs-optional-layers.
- Fixed stale "53 MCP tools" → "56" across ROADMAP.md, 2 blog posts, and 2 integration docs via `scripts/sync_refs.py --fix`.
- Fixed `docs/architecture/overview.md` pointing at the legacy `~/.surreal-memory/` config path instead of `~/.surrealmemory/`.

## Test plan
- [x] `python scripts/sync_refs.py` — all references up-to-date
- [x] `uv run python scripts/gen_mcp_docs.py --check` — docs/api/mcp-tools.md up-to-date (reranking is config-only, no new MCP tools)
- [x] `uv run python scripts/gen_cli_docs.py --check` — docs/getting-started/cli-reference.md up-to-date (no new CLI commands)
- [x] Manual review of full diff for accuracy against source (`src/surreal_memory/engine/reranker.py`, `BrainConfig` fields in `src/surreal_memory/core/brain.py`)