### PR TITLE
release: 2.7.1 — reranker-flip fix + local BGE embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.1] — 2026-07-08
+
+### Fixed
+
+- **Reranker no longer flip-flops on a shared brain.** Reranking is
+  deployment/runtime config, but 2.7.0 persisted it onto the per-brain
+  `BrainConfig` and re-applied it on every connect. With multiple clients on one
+  brain (e.g. the CLI/MCP with reranking on and the web-UI container with it off),
+  whichever connected last flipped the flag for everyone. Reranking is now read
+  from the effective **app config** at recall time (`ReflexPipeline`), and
+  `_migrate_brain_runtime_config` no longer touches the brain's reranker fields —
+  each client uses its own endpoint independently.
+
+### Changed
+
+- **Docker Compose defaults to local BGE embeddings.** `docker-compose.surrealdb.yml`
+  no longer hard-codes Gemini; it inherits the embedding provider/model/dimension
+  from `.env` (defaulting to the OpenAI-compatible `bge-m3` on llamastash, 1024-dim)
+  and reaches the host's llamastash via `host.docker.internal`, so the web UI and
+  the CLI/MCP share one local embedding backend.
+
 ## [2.7.0] — 2026-07-07
 
 ### Added

--- a/docker-compose.surrealdb.yml
+++ b/docker-compose.surrealdb.yml
@@ -44,6 +44,10 @@ services:
     ports:
       - "8000:8000"
       - "8765:8765"
+    # Reach the host's llamastash (OpenAI-compatible bge-m3 embeddings) from
+    # inside the container via host.docker.internal → OPENAI_BASE_URL below.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       # Core
       - SURREAL_MEMORY_DIR=/data
@@ -65,13 +69,17 @@ services:
       - SURREALDB_NS=surreal_memory
       - SURREALDB_DB=default
 
-      # Embedding (Gemini)
-      - SURREAL_MEMORY_EMBEDDING_ENABLED=true
-      - SURREAL_MEMORY_EMBEDDING_PROVIDER=gemini
-      # gemini-embedding-001 is the current 3072-dim default. The old
-      # gemini-embedding-exp-03-07 is experimental/deprecated — do not use.
-      - SURREAL_MEMORY_EMBEDDING_MODEL=${SURREAL_MEMORY_EMBEDDING_MODEL:-gemini-embedding-001}
-      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      # Embedding — local BGE (bge-m3, 1024-dim) via the OpenAI-compatible
+      # llamastash endpoint. Inherits from .env; the container reaches the host's
+      # llamastash through host.docker.internal (see extra_hosts below), so the
+      # host's 127.0.0.1 base URL is overridden here with the container route.
+      - SURREAL_MEMORY_EMBEDDING_ENABLED=${SURREAL_MEMORY_EMBEDDING_ENABLED:-true}
+      - SURREAL_MEMORY_EMBEDDING_PROVIDER=${SURREAL_MEMORY_EMBEDDING_PROVIDER:-openai}
+      - SURREAL_MEMORY_EMBEDDING_MODEL=${SURREAL_MEMORY_EMBEDDING_MODEL:-bge-m3-FP16}
+      - SURREAL_MEMORY_EMBEDDING_DIMENSION=${SURREAL_MEMORY_EMBEDDING_DIMENSION:-1024}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL_CONTAINER:-http://host.docker.internal:11435/v1}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-sk-noauth}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
 
       # Cloud Sync
       - SURREAL_MEMORY_SYNC_ENABLED=true

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.1] — 2026-07-08
+
+### Fixed
+
+- **Reranker no longer flip-flops on a shared brain.** Reranking is
+  deployment/runtime config, but 2.7.0 persisted it onto the per-brain
+  `BrainConfig` and re-applied it on every connect. With multiple clients on one
+  brain (e.g. the CLI/MCP with reranking on and the web-UI container with it off),
+  whichever connected last flipped the flag for everyone. Reranking is now read
+  from the effective **app config** at recall time (`ReflexPipeline`), and
+  `_migrate_brain_runtime_config` no longer touches the brain's reranker fields —
+  each client uses its own endpoint independently.
+
+### Changed
+
+- **Docker Compose defaults to local BGE embeddings.** `docker-compose.surrealdb.yml`
+  no longer hard-codes Gemini; it inherits the embedding provider/model/dimension
+  from `.env` (defaulting to the OpenAI-compatible `bge-m3` on llamastash, 1024-dim)
+  and reaches the host's llamastash via `host.docker.internal`, so the web UI and
+  the CLI/MCP share one local embedding backend.
+
 ## [2.7.0] — 2026-07-07
 
 ### Added

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.7.0"
+version = "2.7.1"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.7.0"
+__version__ = "2.7.1"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/retrieval.py
+++ b/src/surreal_memory/engine/retrieval.py
@@ -495,15 +495,24 @@ class ReflexPipeline:
                     logger.debug("Deferred write flush failed (non-critical)", exc_info=True)
             return _early_result
 
-        # 4.9 Cross-encoder reranking (optional post-SA refinement)
-        if self._config.reranker_enabled and len(activations) > 1:
+        # 4.9 Cross-encoder reranking (optional post-SA refinement).
+        # Reranking is deployment/runtime config, NOT per-brain state — read it
+        # from the effective app config so each client (CLI, MCP, web UI) uses its
+        # OWN endpoint. Persisting it on the (shared) brain made a reranker-off
+        # client — e.g. the web-UI container — flip the flag for everyone on
+        # connect (the reranker-flip bug). The brain's reranker_* fields are kept
+        # for compatibility but are no longer the source of truth here.
+        from surreal_memory.unified_config import get_config as _get_app_config
+
+        _rr = _get_app_config().reranker
+        if _rr.enabled and len(activations) > 1:
             try:
                 from surreal_memory.engine.reranker import reranker_available
 
                 # The config endpoint (config.toml [reranker].endpoint) makes
                 # reranking available even when neither the env endpoint nor an
                 # in-process CrossEncoder is present, so gate on it explicitly.
-                config_endpoint = (self._config.reranker_endpoint or "").strip()
+                config_endpoint = (_rr.endpoint or "").strip()
                 if config_endpoint or reranker_available():
                     from surreal_memory.engine.reranker import rerank_activations
 
@@ -515,7 +524,7 @@ class ReflexPipeline:
                             key=lambda x: x[1].activation_level,
                             reverse=True,
                         )
-                    ][: self._config.reranker_max_candidates]
+                    ][: _rr.max_candidates]
                     neuron_batch = await self._storage.get_neurons_batch(top_nids)
                     neuron_contents = {
                         nid: n.content for nid, n in neuron_batch.items() if n.content
@@ -526,12 +535,12 @@ class ReflexPipeline:
                             query,
                             activations,
                             neuron_contents,
-                            model_name=self._config.reranker_model,
-                            blend_weight=self._config.reranker_blend_weight,
-                            min_score=self._config.reranker_min_score,
-                            max_candidates=self._config.reranker_max_candidates,
+                            model_name=_rr.model_name,
+                            blend_weight=_rr.blend_weight,
+                            min_score=_rr.min_score,
+                            max_candidates=_rr.max_candidates,
                             limit=50,
-                            endpoint=self._config.reranker_endpoint,
+                            endpoint=_rr.endpoint,
                         )
                         logger.debug(
                             "Reranked %d → %d activations",

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -2130,12 +2130,12 @@ async def _migrate_brain_runtime_config(
     must never break recall.
     """
     try:
+        # NOTE: reranker config is intentionally NOT layered onto the brain here.
+        # It is deployment/runtime config, read from the app config at recall time
+        # (see ReflexPipeline). Persisting it on a shared brain let a reranker-off
+        # client (e.g. the web-UI container) flip the flag for everyone on
+        # connect — the reranker-flip bug. Only [brain] extras are migrated.
         overrides = config.brain.runtime_overrides()
-        # Also layer config.toml [reranker] onto the stored brain so reranking is
-        # driven by app config (issue: reranker BrainConfig fields were never
-        # persisted, so the feature was dead code). Always applied; the diff check
-        # below no-ops when the stored brain already matches.
-        overrides.update(reranker_brain_config_overrides(config.reranker))
         if not overrides:
             return
 

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.7.0"
+        assert surreal_memory.__version__ == "2.7.1"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_reranker_http_and_config.py
+++ b/tests/unit/test_reranker_http_and_config.py
@@ -370,19 +370,20 @@ class TestSqliteRerankerPersistence:
             await store.close()
 
 
-class TestMigrateLayersReranker:
-    """`_migrate_brain_runtime_config` layers config.toml [reranker] onto an
-    already-stored brain, so enabling reranking takes effect without recreating
-    a brain (and reaches recall via the persisted config)."""
+class TestMigrateDoesNotTouchReranker:
+    """Reranker config is deployment/runtime config read from the app config at
+    recall time, NOT persisted per-brain. ``_migrate_brain_runtime_config`` must
+    leave the stored brain's reranker fields untouched — otherwise a reranker-off
+    client (e.g. the web-UI container) would flip the flag on the shared brain for
+    everyone (the reranker-flip bug)."""
 
     @pytest.mark.asyncio
-    async def test_layers_reranker_onto_existing_brain(self, tmp_path: Path) -> None:
+    async def test_migrate_does_not_enable_reranker(self, tmp_path: Path) -> None:
         store = SQLiteStorage(tmp_path / "m.db")
         await store.initialize()
         try:
             brain = Brain.create(name="legacy")  # reranker off by default
             await store.save_brain(brain)
-            assert (await store.get_brain(brain.id)).config.reranker_enabled is False
 
             config = replace(
                 UnifiedConfig(data_dir=tmp_path),
@@ -390,30 +391,33 @@ class TestMigrateLayersReranker:
             )
             await _migrate_brain_runtime_config(store, brain, config)
 
+            # The app config's reranker is NOT forced onto the stored brain.
             reloaded = await store.get_brain(brain.id)
-            assert reloaded.config.reranker_enabled is True
-            assert reloaded.config.reranker_endpoint == ENDPOINT
+            assert reloaded.config.reranker_enabled is False
+            assert reloaded.config.reranker_endpoint == ""
         finally:
             await store.close()
 
     @pytest.mark.asyncio
-    async def test_migration_is_idempotent_noop_when_matching(self, tmp_path: Path) -> None:
+    async def test_migrate_does_not_disable_reranker(self, tmp_path: Path) -> None:
+        # The exact reranker-flip scenario: the shared brain has reranker ON (set
+        # by another client), and this client's app config has it OFF. Migration
+        # must NOT disable it on the shared brain.
         store = SQLiteStorage(tmp_path / "n.db")
         await store.initialize()
         try:
             brain = Brain.create(
-                name="already",
+                name="shared",
                 config=BrainConfig(reranker_enabled=True, reranker_endpoint=ENDPOINT),
             )
             await store.save_brain(brain)
-            stored_before = await store.get_brain(brain.id)
+            stored = await store.get_brain(brain.id)
 
             config = replace(
                 UnifiedConfig(data_dir=tmp_path),
-                reranker=RerankerConfig(enabled=True, endpoint=ENDPOINT),
+                reranker=RerankerConfig(enabled=False, endpoint=""),  # this client: off
             )
-            # Stored brain already matches config → no change / no error.
-            await _migrate_brain_runtime_config(store, stored_before, config)
+            await _migrate_brain_runtime_config(store, stored, config)
 
             after = await store.get_brain(brain.id)
             assert after.config.reranker_enabled is True

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Point release fixing the **reranker-flip** design wrinkle from 2.7.0 and defaulting the web-UI container to **local BGE embeddings**.

## Fixed — reranker-flip on a shared brain

2.7.0 persisted reranker config onto the per-brain `BrainConfig` and re-applied it on every connect (`_migrate_brain_runtime_config`). With multiple clients on one brain — the CLI/MCP with reranking **on** and the web-UI container with it **off** — whichever connected last flipped the flag for everyone (observed live: the container's init reset the shared `default` brain's `reranker_enabled` to `false`).

Reranking is deployment/runtime config, so:
- `ReflexPipeline` now reads it from the **effective app config** (`get_config().reranker`) at recall time — each client (CLI, MCP, web UI) uses its **own** endpoint.
- `_migrate_brain_runtime_config` no longer touches the brain's reranker fields (only `[brain]` extras are migrated).

The per-brain `BrainConfig.reranker_*` fields + persistence remain for compatibility but are no longer the source of truth for gating. Tests updated: `_migrate` must NOT enable **or** disable a stored brain's reranker (both directions of the flip).

## Changed — local BGE embeddings for the container

`docker-compose.surrealdb.yml` hard-coded Gemini embeddings, diverging from the CLI/MCP (local `bge-m3` on llamastash). It now inherits the embedding provider/model/dimension from `.env` (default: OpenAI-compatible `bge-m3`, 1024-dim) and reaches the host's llamastash via `host.docker.internal` (`extra_hosts`). One local embedding backend across the station.

## Test plan

- [x] Reranker/migrate/health unit tests: 89 passed (incl. new `TestMigrateDoesNotTouchReranker` — no flip in either direction).
- [x] Full suite: 5807 passed; 4 failed = pre-existing SurrealDB integration/xdist env failures (unrelated), no regressions.
- [x] `ruff check` clean; `docker compose config` validates.
- [x] Station config untouched by the suite run.

## Notes

- Includes the docs from #48 (already on `main`).
- Version bumped to 2.7.1 across pyproject/`__init__`/npm×2/VS Code; `CHANGELOG.md` + `docs/changelog.md` updated.