### PR TITLE
release: 2.7.2 — dashboard performance + host-network web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.2] — 2026-07-08
+
+### Fixed
+
+- **Dashboard is fast again on large, fully-embedded brains.** After a full
+  re-embed every neuron row carries a 1024-float `embedding_vec`, and the
+  dashboard's `SELECT *` scans dragged those vectors (plus two unbounded
+  full-table scans) into Python — Overview took ~27 s and the Graph view 40 s+
+  on a 64k-neuron / 185k-synapse brain. Now:
+  - `find_neurons(include_embedding=False)` projects `SELECT * OMIT embedding_vec`;
+    the timeline and daily-stats endpoints use it (and push the time window into
+    the query).
+  - The graph view no longer loads every neuron and synapse: node degree is
+    aggregated in the DB (`GROUP BY in/out` on the RELATE edge), the selected
+    core's edges come from the indexed `->synapse` graph traversal, and only the
+    rendered nodes are fetched (`find_neurons_by_ids`, no vectors).
+  - Diagnostics (health grade/purity) replaces its unbounded synapse and
+    neuron_state scans with DB aggregates (`get_connected_neuron_ids`,
+    `count_activated_neuron_states`) and no longer duplicates the count queries.
+
+### Changed
+
+- **The web-UI container runs on host networking** (`docker-compose.surrealdb.yml`).
+  The app shares the host loopback, so it reaches host-local services —
+  llamastash embeddings/reranker on `127.0.0.1:11435` and SurrealDB via its
+  published `127.0.0.1:8001` — without `host.docker.internal` and without
+  binding llamastash to a docker bridge (smaller exposure). The dashboard now
+  binds loopback-only by default (`SURREAL_MEMORY_HOST=127.0.0.1`); set it to
+  `0.0.0.0` in `.env` to expose it on the LAN.
+
 ## [2.7.1] — 2026-07-08
 
 ### Fixed

--- a/docker-compose.surrealdb.yml
+++ b/docker-compose.surrealdb.yml
@@ -41,43 +41,41 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.surrealdb
-    ports:
-      - "8000:8000"
-      - "8765:8765"
-    # Reach the host's llamastash (OpenAI-compatible bge-m3 embeddings) from
-    # inside the container via host.docker.internal → OPENAI_BASE_URL below.
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+    # Host networking: the app shares the host's loopback, so it reaches the
+    # host-local llamastash (embeddings + reranker on 127.0.0.1:11435) directly —
+    # no host.docker.internal, and llamastash never has to bind a docker bridge
+    # (smaller exposure). SurrealDB stays on the bridge; the app reaches it via
+    # the published host port 8001. Note: `ports:` is invalid under host net —
+    # the app binds SURREAL_MEMORY_HOST:SURREAL_MEMORY_PORT on the host itself.
+    network_mode: host
     environment:
       # Core
       - SURREAL_MEMORY_DIR=/data
       - SURREAL_MEMORY_BRAIN=${SURREAL_MEMORY_BRAIN:-default}
-      - SURREAL_MEMORY_HOST=0.0.0.0
+      # Loopback-only bind: the dashboard is reachable solely from this machine.
+      # Set SURREAL_MEMORY_HOST=0.0.0.0 in .env to expose it on the LAN.
+      - SURREAL_MEMORY_HOST=${SURREAL_MEMORY_HOST:-127.0.0.1}
       - SURREAL_MEMORY_PORT=8000
-      # Dashboard access gate (require_local_request): /api/dashboard answers
-      # only localhost or these CIDRs. Inside Docker the browser's request
-      # reaches the container from the bridge gateway (172.18.0.x), not
-      # 127.0.0.1, so the bridge subnet must be trusted or every dashboard
-      # API call returns 403. Override in .env to narrow/extend.
-      - SURREAL_MEMORY_TRUSTED_NETWORKS=${SURREAL_MEMORY_TRUSTED_NETWORKS:-172.18.0.0/16}
+      # Dashboard access gate (require_local_request): under host networking the
+      # browser reaches the app from 127.0.0.1, which is always trusted — the
+      # docker-bridge CIDR is no longer needed. Kept overridable for LAN setups.
+      - SURREAL_MEMORY_TRUSTED_NETWORKS=${SURREAL_MEMORY_TRUSTED_NETWORKS:-}
 
-      # SurrealDB
+      # SurrealDB — via its published host port (no docker DNS under host net).
       - SURREAL_MEMORY_STORAGE=surrealdb
-      - SURREALDB_URL=http://surrealdb:8001
+      - SURREALDB_URL=${SURREALDB_URL:-http://127.0.0.1:8001}
       - SURREALDB_USER=${SURREALDB_USER:-root}
       - SURREALDB_PASS=${SURREALDB_PASS:-surrealmemory}
       - SURREALDB_NS=surreal_memory
       - SURREALDB_DB=default
 
       # Embedding — local BGE (bge-m3, 1024-dim) via the OpenAI-compatible
-      # llamastash endpoint. Inherits from .env; the container reaches the host's
-      # llamastash through host.docker.internal (see extra_hosts below), so the
-      # host's 127.0.0.1 base URL is overridden here with the container route.
+      # llamastash endpoint on the host loopback (shared under host networking).
       - SURREAL_MEMORY_EMBEDDING_ENABLED=${SURREAL_MEMORY_EMBEDDING_ENABLED:-true}
       - SURREAL_MEMORY_EMBEDDING_PROVIDER=${SURREAL_MEMORY_EMBEDDING_PROVIDER:-openai}
       - SURREAL_MEMORY_EMBEDDING_MODEL=${SURREAL_MEMORY_EMBEDDING_MODEL:-bge-m3-FP16}
       - SURREAL_MEMORY_EMBEDDING_DIMENSION=${SURREAL_MEMORY_EMBEDDING_DIMENSION:-1024}
-      - OPENAI_BASE_URL=${OPENAI_BASE_URL_CONTAINER:-http://host.docker.internal:11435/v1}
+      - OPENAI_BASE_URL=${OPENAI_BASE_URL_CONTAINER:-http://127.0.0.1:11435/v1}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-sk-noauth}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.2] — 2026-07-08
+
+### Fixed
+
+- **Dashboard is fast again on large, fully-embedded brains.** After a full
+  re-embed every neuron row carries a 1024-float `embedding_vec`, and the
+  dashboard's `SELECT *` scans dragged those vectors (plus two unbounded
+  full-table scans) into Python — Overview took ~27 s and the Graph view 40 s+
+  on a 64k-neuron / 185k-synapse brain. Now:
+  - `find_neurons(include_embedding=False)` projects `SELECT * OMIT embedding_vec`;
+    the timeline and daily-stats endpoints use it (and push the time window into
+    the query).
+  - The graph view no longer loads every neuron and synapse: node degree is
+    aggregated in the DB (`GROUP BY in/out` on the RELATE edge), the selected
+    core's edges come from the indexed `->synapse` graph traversal, and only the
+    rendered nodes are fetched (`find_neurons_by_ids`, no vectors).
+  - Diagnostics (health grade/purity) replaces its unbounded synapse and
+    neuron_state scans with DB aggregates (`get_connected_neuron_ids`,
+    `count_activated_neuron_states`) and no longer duplicates the count queries.
+
+### Changed
+
+- **The web-UI container runs on host networking** (`docker-compose.surrealdb.yml`).
+  The app shares the host loopback, so it reaches host-local services —
+  llamastash embeddings/reranker on `127.0.0.1:11435` and SurrealDB via its
+  published `127.0.0.1:8001` — without `host.docker.internal` and without
+  binding llamastash to a docker bridge (smaller exposure). The dashboard now
+  binds loopback-only by default (`SURREAL_MEMORY_HOST=127.0.0.1`); set it to
+  `0.0.0.0` in `.env` to expose it on the LAN.
+
 ## [2.7.1] — 2026-07-08
 
 ### Fixed

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.7.1"
+version = "2.7.2"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.7.1"
+__version__ = "2.7.2"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/diagnostics.py
+++ b/src/surreal_memory/engine/diagnostics.py
@@ -513,11 +513,16 @@ class DiagnosticsEngine:
         if neuron_count == 0:
             return 0.0
 
-        all_synapses = await self._storage.get_all_synapses()
-        connected: set[str] = set()
-        for s in all_synapses:
-            connected.add(s.source_id)
-            connected.add(s.target_id)
+        # Prefer the DB-side distinct-endpoints aggregate over loading ~185k
+        # Synapse objects (that scan was seconds of the dashboard's slowness).
+        get_connected = getattr(self._storage, "get_connected_neuron_ids", None)
+        if get_connected is not None:
+            connected: set[str] = set(await get_connected())
+        else:
+            connected = set()
+            for s in await self._storage.get_all_synapses():
+                connected.add(s.source_id)
+                connected.add(s.target_id)
 
         # Also count neurons that belong to fibers as connected
         if fibers:
@@ -536,8 +541,13 @@ class DiagnosticsEngine:
         if neuron_count == 0:
             return 0.0
 
-        states = await self._storage.get_all_neuron_states()
-        activated_count = sum(1 for s in states if s.access_frequency > 0)
+        # DB aggregate instead of loading every neuron_state (~64k rows).
+        count_active = getattr(self._storage, "count_activated_neuron_states", None)
+        if count_active is not None:
+            activated_count = int(await count_active())
+        else:
+            states = await self._storage.get_all_neuron_states()
+            activated_count = sum(1 for s in states if s.access_frequency > 0)
         return activated_count / max(neuron_count, 1)
 
     @staticmethod

--- a/src/surreal_memory/server/app.py
+++ b/src/surreal_memory/server/app.py
@@ -586,21 +586,33 @@ def create_app(
         capped_limit = min(limit, 2000)
         edge_cap = 4000
 
-        synapses = await storage.get_all_synapses()
-        total_synapses = len(synapses)
-
-        # Degree count → rank neurons by connectivity, take the densest core.
-        degree: dict[str, int] = {}
-        for s in synapses:
-            degree[s.source_id] = degree.get(s.source_id, 0) + 1
-            degree[s.target_id] = degree.get(s.target_id, 0) + 1
-        ranked_ids = sorted(degree, key=lambda nid: degree[nid], reverse=True)
-        selected_ids = set(ranked_ids[offset : offset + capped_limit])
-
-        # Edge-first: keep edges with both endpoints in the dense set (cap payload).
-        visible_synapses = [
-            s for s in synapses if s.source_id in selected_ids and s.target_id in selected_ids
-        ][:edge_cap]
+        # Degree ranking + edge fetch via DB aggregates/graph traversal when the
+        # backend supports it (SurrealDB). Loading all ~185k synapses into Python
+        # just to rank/filter them was ~10 s of the graph view's 30 s+ hang.
+        get_degrees = getattr(storage, "get_synapse_degrees", None)
+        get_edges = getattr(storage, "get_edges_for_neurons", None)
+        if get_degrees is not None and get_edges is not None:
+            degree: dict[str, int] = await get_degrees()
+            # Each edge contributes once to its in-group and once to its out-group.
+            total_synapses = sum(degree.values()) // 2
+            ranked_ids = sorted(degree, key=lambda nid: degree[nid], reverse=True)
+            selected_ids = set(ranked_ids[offset : offset + capped_limit])
+            # Indexed ->synapse traversal fetches only the selected core's edges.
+            core_edges = await get_edges(list(selected_ids))
+            visible_synapses = [s for s in core_edges if s.target_id in selected_ids][:edge_cap]
+        else:
+            synapses = await storage.get_all_synapses()
+            total_synapses = len(synapses)
+            degree = {}
+            for s in synapses:
+                degree[s.source_id] = degree.get(s.source_id, 0) + 1
+                degree[s.target_id] = degree.get(s.target_id, 0) + 1
+            ranked_ids = sorted(degree, key=lambda nid: degree[nid], reverse=True)
+            selected_ids = set(ranked_ids[offset : offset + capped_limit])
+            # Edge-first: keep edges with both endpoints in the dense set (cap payload).
+            visible_synapses = [
+                s for s in synapses if s.source_id in selected_ids and s.target_id in selected_ids
+            ][:edge_cap]
 
         # Nodes = every endpoint the visible edges reference, plus the selected core.
         endpoint_ids = {s.source_id for s in visible_synapses} | {
@@ -608,11 +620,19 @@ def create_app(
         }
         node_ids = endpoint_ids | selected_ids
 
-        # No id-batch store method exists; index all neurons in Python (~4.6k is fine).
-        all_neurons = await storage.find_neurons(limit=100000)
-        by_id = {n.id: n for n in all_neurons}
-        neurons = [by_id[nid] for nid in node_ids if nid in by_id]
-        total_neurons = len(degree) or len(all_neurons)
+        # Fetch ONLY the nodes we render, without the embedding vector. Loading all
+        # ~64k neurons here (each carrying a 1024-float embedding_vec) was the graph
+        # view's 30 s+ hang; node_ids is a few thousand at most.
+        find_by_ids = getattr(storage, "find_neurons_by_ids", None)
+        if find_by_ids is not None:
+            neurons = await find_by_ids(list(node_ids), include_embedding=False)
+        else:
+            all_neurons = await storage.find_neurons(limit=100000)
+            by_id = {n.id: n for n in all_neurons}
+            neurons = [by_id[nid] for nid in node_ids if nid in by_id]
+        # Isolated neurons never render in the graph, so the connected-node count
+        # (len(degree)) is the graph's universe; the true brain total is on /stats.
+        total_neurons = len(degree)
 
         fibers = await storage.get_fibers(limit=1000)
 

--- a/src/surreal_memory/server/routes/dashboard_api.py
+++ b/src/surreal_memory/server/routes/dashboard_api.py
@@ -94,13 +94,10 @@ async def get_stats() -> DashboardStats:
         """Analyze a single brain using its own per-brain storage."""
         try:
             brain_storage = await get_shared_storage(brain_name=name)
-            stats = await brain_storage.get_stats(name)
-            nc = stats.get("neuron_count", 0)
-            sc = stats.get("synapse_count", 0)
-            fc = stats.get("fiber_count", 0)
 
             grade = "F"
             purity = 0.0
+            nc = sc = fc = 0
             try:
                 from surreal_memory.engine.diagnostics import DiagnosticsEngine
 
@@ -108,8 +105,18 @@ async def get_stats() -> DashboardStats:
                 report = await diag.analyze(name)
                 grade = report.grade
                 purity = report.purity_score
+                # The report already carries the counts (via get_enhanced_stats),
+                # so a separate get_stats here would just repeat the same three
+                # count queries per brain.
+                nc = report.neuron_count
+                sc = report.synapse_count
+                fc = report.fiber_count
             except Exception:
                 logger.debug("Diagnostics failed for brain %s", name, exc_info=True)
+                stats = await brain_storage.get_stats(name)
+                nc = stats.get("neuron_count", 0)
+                sc = stats.get("synapse_count", 0)
+                fc = stats.get("fiber_count", 0)
 
             return BrainSummary(
                 id=name,
@@ -379,7 +386,25 @@ async def get_timeline(
     end: str | None = Query(default=None, description="ISO datetime end"),
 ) -> TimelineResponse:
     """Get chronological list of memories for timeline visualization."""
-    neurons = await storage.find_neurons(limit=min(limit, 2000))
+    # Push the time window into the DB when both bounds are given, and never fetch
+    # the embedding_vec — the timeline uses only id/content/type/created_at/metadata,
+    # so dragging the 1024-float vector per row was pure waste.
+    from datetime import datetime as _dt
+
+    def _iso(s: str | None) -> _dt | None:
+        if not s:
+            return None
+        try:
+            return _dt.fromisoformat(s)
+        except ValueError:
+            return None
+
+    start_dt = _iso(start)
+    end_dt = _iso(end)
+    time_range = (start_dt, end_dt) if start_dt and end_dt else None
+    neurons = await storage.find_neurons(
+        limit=min(limit, 2000), time_range=time_range, include_embedding=False
+    )
 
     entries: list[TimelineEntry] = []
     for n in neurons:
@@ -444,7 +469,9 @@ async def get_daily_stats(
     end = now
 
     # Use public API: find_neurons with time_range
-    neurons = await storage.find_neurons(time_range=(start, end), limit=1000)
+    neurons = await storage.find_neurons(
+        time_range=(start, end), limit=1000, include_embedding=False
+    )
 
     # Aggregate neurons by day
     days_map: dict[str, DailyStatsEntry] = {}

--- a/src/surreal_memory/storage/base.py
+++ b/src/surreal_memory/storage/base.py
@@ -144,6 +144,7 @@ class NeuralStorage(ABC):
         limit: int = 100,
         offset: int = 0,
         ephemeral: bool | None = None,
+        include_embedding: bool = True,
     ) -> list[Neuron]:
         """
         Find neurons matching criteria.

--- a/src/surreal_memory/storage/memory_store.py
+++ b/src/surreal_memory/storage/memory_store.py
@@ -106,6 +106,7 @@ class InMemoryStorage(
         limit: int = 100,
         offset: int = 0,
         ephemeral: bool | None = None,
+        include_embedding: bool = True,
     ) -> list[Neuron]:
         full_scan = content_contains is None and content_exact is None
         limit = min(limit, 10000 if full_scan else 1000)

--- a/src/surreal_memory/storage/shared_store.py
+++ b/src/surreal_memory/storage/shared_store.py
@@ -201,6 +201,7 @@ class SharedStorage(SharedFiberBrainMixin, NeuralStorage):
         limit: int = 100,
         offset: int = 0,
         ephemeral: bool | None = None,
+        include_embedding: bool = True,
     ) -> list[Neuron]:
         """Find neurons matching criteria."""
         params: dict[str, Any] = {"limit": limit, "offset": offset}

--- a/src/surreal_memory/storage/sqlite_neurons.py
+++ b/src/surreal_memory/storage/sqlite_neurons.py
@@ -192,6 +192,7 @@ class SQLiteNeuronMixin:
         limit: int = 100,
         offset: int = 0,
         ephemeral: bool | None = None,
+        include_embedding: bool = True,
     ) -> list[Neuron]:
         # Cache shortcut for exact-match lookups (most repeated pattern)
         if content_exact is not None and content_contains is None and time_range is None:

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -601,6 +601,7 @@ class SurrealDBStorage(
         limit: int = 100,
         offset: int = 0,
         ephemeral: bool | None = None,
+        include_embedding: bool = True,
     ) -> list[Neuron]:
         brain_id = self._get_brain_id()
         conditions = ["brain_id = $brain_id"]
@@ -629,11 +630,42 @@ class SurrealDBStorage(
             params["ephemeral"] = ephemeral
 
         where = " AND ".join(conditions)
+        # OMIT the 1024-3072-float embedding_vec when the caller doesn't need it
+        # (dashboard graph/timeline). It is ~4-8 KB/row, so dragging it over tens of
+        # thousands of rows is the single biggest dashboard slowdown after a re-embed.
+        projection = "SELECT *" if include_embedding else "SELECT * OMIT embedding_vec"
         rows = await self._query(
-            f"SELECT * FROM neuron WHERE {where} ORDER BY id LIMIT {int(limit)} START {int(offset)}",
+            f"{projection} FROM neuron WHERE {where} ORDER BY id LIMIT {int(limit)} START {int(offset)}",
             **params,
         )
         return [_row_to_neuron(r) for r in rows]
+
+    async def find_neurons_by_ids(
+        self, neuron_ids: list[str], include_embedding: bool = False
+    ) -> list[Neuron]:
+        """Fetch specific neurons by id in one query, omitting the embedding by
+        default. Used by the graph view, which needs only a few thousand nodes out
+        of tens of thousands and never uses the vector."""
+        if not neuron_ids:
+            return []
+        # Convert to SurrealDB record ids and keep only injection-safe names
+        # (alphanumeric + underscore), since they are interpolated into FROM.
+        safe = [
+            sid
+            for nid in neuron_ids
+            for sid in (_to_surreal_id(nid),)
+            if sid and all(c.isalnum() or c == "_" for c in sid)
+        ]
+        if not safe:
+            return []
+        projection = "SELECT *" if include_embedding else "SELECT * OMIT embedding_vec"
+        out: list[Neuron] = []
+        # Chunk to keep the FROM record-id list a sane query size.
+        for i in range(0, len(safe), 1000):
+            things = ", ".join(f"neuron:{s}" for s in safe[i : i + 1000])
+            rows = await self._query(f"{projection} FROM {things}")
+            out.extend(_row_to_neuron(r) for r in rows)
+        return out
 
     async def suggest_neurons(
         self,
@@ -2029,10 +2061,100 @@ class SurrealDBStorage(
         )
         return [_row_to_neuron_state(r) for r in rows]
 
-    async def get_all_synapses(self) -> list[Synapse]:
-        brain_id = self._get_brain_id()
+    async def count_activated_neuron_states(self, brain_id: str | None = None) -> int:
+        """Count neuron_states with access_frequency > 0 via a DB aggregate.
+
+        Diagnostics used to load every neuron_state (~64k rows) just to count the
+        activated ones — a multi-second scan on the dashboard. This does it in a
+        single ``count() … GROUP ALL`` (~0.4 s)."""
+        bid = brain_id or self._get_brain_id()
         rows = await self._query(
-            "SELECT * FROM synapse WHERE brain_id = $brain_id",
+            "SELECT count() AS c FROM neuron_state"
+            " WHERE brain_id = $bid AND access_frequency > 0 GROUP ALL",
+            bid=bid,
+        )
+        return int(rows[0].get("c", 0)) if rows else 0
+
+    async def get_connected_neuron_ids(self, brain_id: str | None = None) -> set[str]:
+        """Return the set of neuron ids that are an endpoint of any synapse.
+
+        Uses ``GROUP BY in`` / ``GROUP BY out`` on the native RELATE edge (the
+        `source_id`/`target_id` fields are computed, so `array::group` on them
+        yields nothing — but the real `in`/`out` record links group fine). This
+        replaces loading ~185k Synapse objects (~10 s) for the orphan-rate metric
+        with two distinct-key scans (~2 s total)."""
+        bid = brain_id or self._get_brain_id()
+        connected: set[str] = set()
+        for field in ("in", "out"):
+            rows = await self._query(
+                f"SELECT VALUE {field} FROM synapse WHERE brain_id = $bid GROUP BY {field}",
+                bid=bid,
+            )
+            for rid in rows:
+                connected.add(_from_surreal_id(str(rid)))
+        return connected
+
+    async def get_synapse_degrees(self, brain_id: str | None = None) -> dict[str, int]:
+        """Per-neuron synapse degree via DB ``GROUP BY`` on the RELATE endpoints.
+
+        Replaces loading every synapse into Python just to count endpoints
+        (the dashboard graph's ranking step). Note: grouping must target the
+        real ``in``/``out`` record links — the ``source_id``/``target_id``
+        fields are computed and do not aggregate."""
+        bid = brain_id or self._get_brain_id()
+        degree: dict[str, int] = {}
+        for field in ("in", "out"):
+            rows = await self._query(
+                f"SELECT {field} AS nid, count() AS deg FROM synapse"
+                f" WHERE brain_id = $bid GROUP BY {field}",
+                bid=bid,
+            )
+            for r in rows:
+                nid = _endpoint_to_id(r.get("nid"))
+                if nid:
+                    degree[nid] = degree.get(nid, 0) + int(r.get("deg", 0) or 0)
+        return degree
+
+    async def get_edges_for_neurons(self, neuron_ids: list[str]) -> list[Synapse]:
+        """Outgoing synapses of the given neurons via the indexed graph traversal.
+
+        ``->synapse`` on a record id uses the RELATE edge index, so fetching the
+        edges of a few thousand selected nodes is sub-second — versus ~10 s for a
+        full ``SELECT * FROM synapse`` table scan with 185k+ edges."""
+        if not neuron_ids:
+            return []
+        safe = [
+            sid
+            for nid in neuron_ids
+            for sid in (_to_surreal_id(nid),)
+            if sid and all(c.isalnum() or c == "_" for c in sid)
+        ]
+        edges: list[Synapse] = []
+        for i in range(0, len(safe), 500):
+            things = ", ".join(f"neuron:{s}" for s in safe[i : i + 500])
+            rows = await self._query(
+                "SELECT id, ->synapse.{id, out, type, weight, direction, created_at} AS edges"
+                f" FROM {things}"
+            )
+            for row in rows:
+                src = row.get("id")
+                for e in row.get("edges") or []:
+                    d = dict(e)
+                    d["in"] = src
+                    try:
+                        edges.append(_row_to_synapse(d))
+                    except Exception:
+                        continue
+        return edges
+
+    async def get_all_synapses(self, include_metadata: bool = True) -> list[Synapse]:
+        brain_id = self._get_brain_id()
+        # OMIT the metadata blob when the caller (e.g. the dashboard graph) only
+        # needs endpoints/type/weight — it roughly halves the transfer for the
+        # ~185k-row synapse scan.
+        projection = "SELECT *" if include_metadata else "SELECT * OMIT metadata"
+        rows = await self._query(
+            f"{projection} FROM synapse WHERE brain_id = $brain_id",
             brain_id=brain_id,
         )
         return [_row_to_synapse(r) for r in rows]

--- a/tests/unit/test_dashboard_perf_queries.py
+++ b/tests/unit/test_dashboard_perf_queries.py
@@ -1,0 +1,213 @@
+"""Unit tests for the 2.7.2 dashboard-performance query shapes.
+
+After the full BGE re-embed every neuron row carries a 1024-float
+``embedding_vec``, which made ``SELECT *`` scans the dashboard's bottleneck
+(Overview ~27 s, Graph 40 s+). These tests pin the fixes:
+
+  * ``find_neurons(include_embedding=False)`` issues ``SELECT * OMIT embedding_vec``.
+  * ``find_neurons_by_ids`` fetches records directly (no full-table scan) and
+    omits the vector by default.
+  * ``get_synapse_degrees`` aggregates per-endpoint degree with ``GROUP BY in/out``
+    (the computed source_id/target_id fields do NOT aggregate).
+  * ``get_edges_for_neurons`` uses the indexed ``->synapse`` traversal.
+  * ``count_activated_neuron_states`` / ``get_connected_neuron_ids`` replace the
+    unbounded neuron_state / synapse scans in diagnostics.
+
+The surrealdb SDK is stubbed (repo convention); the connection is an AsyncMock.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+if "surrealdb" not in sys.modules:
+    sys.modules["surrealdb"] = MagicMock()
+    sys.modules["surrealdb.errors"] = MagicMock()
+
+from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+
+class _FakeRID:
+    def __init__(self, table: str, ident: str) -> None:
+        self.table_name = table
+        self.id = ident
+
+    def __str__(self) -> str:
+        return f"{self.table_name}:{self.id}"
+
+
+def _store_with_mock_conn() -> tuple[SurrealDBStorage, AsyncMock]:
+    st = SurrealDBStorage(url="http://localhost:8001")
+    conn = AsyncMock()
+    conn.query = AsyncMock(return_value=[])
+    st._conn = conn
+    st._current_brain_id = "b1"
+    return st, conn
+
+
+def _queries(conn: AsyncMock) -> list[str]:
+    out = []
+    for call in conn.query.call_args_list:
+        out.append(call.args[0] if call.args else call.kwargs.get("sql", ""))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# find_neurons projection
+# --------------------------------------------------------------------------- #
+class TestFindNeuronsProjection:
+    async def test_default_selects_star(self):
+        st, conn = _store_with_mock_conn()
+        await st.find_neurons(limit=10)
+        (sql,) = _queries(conn)
+        assert sql.startswith("SELECT * FROM neuron")
+        assert "OMIT" not in sql
+
+    async def test_include_embedding_false_omits_vector(self):
+        st, conn = _store_with_mock_conn()
+        await st.find_neurons(limit=10, include_embedding=False)
+        (sql,) = _queries(conn)
+        assert sql.startswith("SELECT * OMIT embedding_vec FROM neuron")
+
+    async def test_omitted_row_has_no_embedding_metadata(self):
+        st, conn = _store_with_mock_conn()
+        conn.query = AsyncMock(
+            return_value=[
+                [
+                    {
+                        "id": _FakeRID("neuron", "n_1"),
+                        "type": "concept",
+                        "content": "x",
+                        "metadata": {},
+                    }
+                ]
+            ]
+        )
+        neurons = await st.find_neurons(limit=1, include_embedding=False)
+        assert len(neurons) == 1
+        assert "_embedding" not in neurons[0].metadata
+
+
+# --------------------------------------------------------------------------- #
+# find_neurons_by_ids
+# --------------------------------------------------------------------------- #
+class TestFindNeuronsByIds:
+    async def test_fetches_records_directly_with_omit(self):
+        st, conn = _store_with_mock_conn()
+        await st.find_neurons_by_ids(["abc-123", "def-456"])
+        (sql,) = _queries(conn)
+        assert sql.startswith("SELECT * OMIT embedding_vec FROM neuron:abc_123, neuron:def_456")
+        assert "WHERE" not in sql  # record fetch, not a table scan
+
+    async def test_empty_and_unsafe_ids_are_dropped(self):
+        st, conn = _store_with_mock_conn()
+        assert await st.find_neurons_by_ids([]) == []
+        # An injection-shaped id must not reach the query string.
+        await st.find_neurons_by_ids(["bad; DELETE neuron", "ok-1"])
+        (sql,) = _queries(conn)
+        assert "DELETE" not in sql
+        assert "neuron:ok_1" in sql
+
+    async def test_chunks_large_id_lists(self):
+        st, conn = _store_with_mock_conn()
+        await st.find_neurons_by_ids([f"n-{i}" for i in range(1500)])
+        sqls = _queries(conn)
+        assert len(sqls) == 2  # 1000 + 500
+
+
+# --------------------------------------------------------------------------- #
+# Degree + traversal aggregates
+# --------------------------------------------------------------------------- #
+class TestSynapseDegrees:
+    async def test_groups_by_native_in_and_out(self):
+        st, conn = _store_with_mock_conn()
+        conn.query = AsyncMock(
+            side_effect=[
+                [[{"nid": _FakeRID("neuron", "a_1"), "deg": 3}]],  # GROUP BY in
+                [[{"nid": _FakeRID("neuron", "a_1"), "deg": 2}]],  # GROUP BY out
+            ]
+        )
+        degree = await st.get_synapse_degrees()
+        sqls = _queries(conn)
+        assert any("GROUP BY in" in s for s in sqls)
+        assert any("GROUP BY out" in s for s in sqls)
+        # source_id/target_id are computed fields and must not be grouped on.
+        assert not any("GROUP BY source_id" in s or "GROUP BY target_id" in s for s in sqls)
+        assert degree == {"a-1": 5}
+
+
+class TestEdgesForNeurons:
+    async def test_uses_indexed_graph_traversal(self):
+        st, conn = _store_with_mock_conn()
+        conn.query = AsyncMock(
+            return_value=[
+                [
+                    {
+                        "id": _FakeRID("neuron", "src_1"),
+                        "edges": [
+                            {
+                                "id": _FakeRID("synapse", "e_1"),
+                                "out": _FakeRID("neuron", "dst_2"),
+                                "type": "related_to",
+                                "weight": 0.8,
+                                "direction": "uni",
+                            }
+                        ],
+                    }
+                ]
+            ]
+        )
+        edges = await st.get_edges_for_neurons(["src-1"])
+        (sql,) = _queries(conn)
+        assert "->synapse" in sql
+        assert sql.strip().startswith("SELECT id, ->synapse")
+        assert len(edges) == 1
+        assert edges[0].source_id == "src-1"
+        assert edges[0].target_id == "dst-2"
+
+    async def test_empty_input_short_circuits(self):
+        st, conn = _store_with_mock_conn()
+        assert await st.get_edges_for_neurons([]) == []
+        conn.query.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Diagnostics aggregates
+# --------------------------------------------------------------------------- #
+class TestDiagnosticsAggregates:
+    async def test_count_activated_uses_group_all(self):
+        st, conn = _store_with_mock_conn()
+        conn.query = AsyncMock(return_value=[[{"c": 42}]])
+        n = await st.count_activated_neuron_states()
+        (sql,) = _queries(conn)
+        assert "count()" in sql and "access_frequency > 0" in sql and "GROUP ALL" in sql
+        assert n == 42
+
+    async def test_connected_ids_groups_endpoints(self):
+        st, conn = _store_with_mock_conn()
+        conn.query = AsyncMock(
+            side_effect=[
+                [[str(_FakeRID("neuron", "a_1"))]],  # SELECT VALUE in ... GROUP BY in
+                [[str(_FakeRID("neuron", "b_2"))]],  # SELECT VALUE out ... GROUP BY out
+            ]
+        )
+        connected = await st.get_connected_neuron_ids()
+        sqls = _queries(conn)
+        assert any("SELECT VALUE in" in s and "GROUP BY in" in s for s in sqls)
+        assert any("SELECT VALUE out" in s and "GROUP BY out" in s for s in sqls)
+        assert connected == {"a-1", "b-2"}
+
+
+class TestGetAllSynapsesProjection:
+    async def test_include_metadata_false_omits_blob(self):
+        st, conn = _store_with_mock_conn()
+        await st.get_all_synapses(include_metadata=False)
+        (sql,) = _queries(conn)
+        assert sql.startswith("SELECT * OMIT metadata FROM synapse")
+
+    async def test_default_keeps_metadata(self):
+        st, conn = _store_with_mock_conn()
+        await st.get_all_synapses()
+        (sql,) = _queries(conn)
+        assert sql.startswith("SELECT * FROM synapse")

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.7.1"
+        assert surreal_memory.__version__ == "2.7.2"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Point release fixing the **dashboard slowness** reported after the full BGE re-embed (Overview ~27 s, Graph 40 s+ locally) and switching the web-UI container to **host networking** so it reaches the host-local llamastash without widening llamastash's exposure.

## Performance (measured root causes, live station: 64k neurons / 185k synapses)

| View | Was | Root cause |
|---|---|---|
| Overview `/api/dashboard/stats` | ~27 s | full diagnostics per brain: unbounded `SELECT * FROM synapse` (**9.9 s**), unbounded neuron_state scan, 10k-fiber scan, duplicated count queries |
| Graph `/api/graph` | 40 s+ (timeout) | `find_neurons(limit=100000)` — all 64k neurons **with 1024-float `embedding_vec`** (~4–8 KB/row), 99% discarded; full synapse scan for degree ranking |
| Timeline | ~3 s | ≤2000 rows fetched **with vectors**; time filter in Python |

Fixes:
- `find_neurons(include_embedding=False)` → `SELECT * OMIT embedding_vec` (measured 2.5× faster per row-batch); used by timeline + daily-stats, window pushed into the query.
- New `find_neurons_by_ids` — direct record fetch of only the rendered graph nodes, no vectors, chunked + injection-safe.
- Graph: degree via `GROUP BY in/out` on the RELATE edge (~2.4 s vs 10 s scan; note: the computed `source_id/target_id` do **not** aggregate), visible edges via the **indexed `->synapse` traversal** (~0.5 s per 500 nodes, measured), nodes via `find_neurons_by_ids`.
- Diagnostics: `get_connected_neuron_ids` (distinct endpoints, GROUP BY) replaces the synapse scan for orphan-rate; `count_activated_neuron_states` (count() GROUP ALL, 0.37 s measured) replaces the neuron_state scan; duplicate per-brain count queries removed.
- Non-SurrealDB backends keep the previous code path via `getattr` fallbacks; the base-interface `find_neurons` gains the `include_embedding` param (default `True` — no behavior change for existing callers).

## Host networking (web UI)

`docker-compose.surrealdb.yml`: the app service gets `network_mode: host`; `ports:`/`extra_hosts:` removed (invalid under host net); `SURREALDB_URL` → published `127.0.0.1:8001`; `OPENAI_BASE_URL` default → `http://127.0.0.1:11435/v1` (llamastash on the shared loopback — this is what makes container-side embeddings/reranking work). Dashboard binds **loopback-only** by default (`SURREAL_MEMORY_HOST=127.0.0.1`, overridable via .env). The dashboard gate always trusts loopback, so no 403; the bridge CIDR is moot.

## Test plan

- [x] 13 new unit tests pin the query shapes (OMIT projection, by-ids record fetch + chunking + injection-safety, GROUP BY in/out, `->synapse` traversal, count aggregates).
- [x] Full suite: 5820 passed; 4 failed = pre-existing SurrealDB integration/xdist env failures (unrelated).
- [x] ruff + mypy clean (346 files); `docker compose config` validates.
- [ ] Post-deploy timing on the station (target <2 s stats/timeline; graph a few s): will verify after merge + redeploy.