### PR TITLE
release: 2.7.3 — dashboard index fix + loopback bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.3] — 2026-07-09
+
+### Fixed
+
+- **Dashboard endpoints are now fast on the large station brain.** Follow-up to
+  2.7.2 after measuring the real bottlenecks on 64k neurons / 266k synapses:
+  - **Parameterized `brain_id` defeated the index.** SurrealDB 3.2.0's planner
+    only uses the `brain_id` index for an *inline literal* — `WHERE brain_id = $bid`
+    fell back to a full table scan, turning `count() … GROUP ALL` on the neuron
+    table (each row carrying a 1024-float vector) from 0.01 s into ~2.5 s.
+    `get_stats` now inlines the (strictly validated) brain_id and runs the three
+    counts concurrently. This was the single biggest dashboard cost.
+  - **Diagnostics skips the neuron type-breakdown** (`get_enhanced_stats(include_neuron_types=False)`)
+    — a ~2.6 s `GROUP BY type` scan the health metrics never read.
+  - **Independent reads run concurrently** (`asyncio.gather`): the diagnostics
+    fibers/connected/activation reads, the connected-neuron `in`/`out` scans, and
+    the graph's degree `in`/`out` scans (measured ~1.6x on the shared connection).
+  - **Only the active brain gets full diagnostics** in `/api/dashboard/stats`;
+    other brains report counts only, so a station carrying integration-test
+    residue brains no longer pays a full diagnostic pass for each.
+
+  Net on the station: `/api/dashboard/stats` ~27 s -> ~2.8 s, `/api/graph` 40 s+ ->
+  ~4 s, `/api/dashboard/timeline` ~3 s -> ~0.06 s.
+
+- **The web-UI container binds loopback only again.** `Dockerfile.surrealdb`
+  hardcoded `uvicorn --host 0.0.0.0`, which silently overrode the compose stack's
+  `SURREAL_MEMORY_HOST=127.0.0.1` (added in 2.7.2 for host networking) and exposed
+  the dashboard on every interface. The CMD now honours `SURREAL_MEMORY_HOST` /
+  `SURREAL_MEMORY_PORT`.
+
 ## [2.7.2] — 2026-07-08
 
 ### Fixed

--- a/Dockerfile.surrealdb
+++ b/Dockerfile.surrealdb
@@ -37,5 +37,10 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
-# Run the application
-CMD ["uvicorn", "surreal_memory.server.app:app", "--host", "0.0.0.0", "--port", "8000"]
+# Run the application. Shell form so SURREAL_MEMORY_HOST/PORT are honoured — the
+# compose stack sets SURREAL_MEMORY_HOST=127.0.0.1 under host networking to bind
+# loopback only; a hardcoded 0.0.0.0 here silently ignored that and exposed the
+# dashboard on every interface.
+CMD uvicorn surreal_memory.server.app:app \
+    --host "${SURREAL_MEMORY_HOST:-0.0.0.0}" \
+    --port "${SURREAL_MEMORY_PORT:-8000}"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.3] — 2026-07-09
+
+### Fixed
+
+- **Dashboard endpoints are now fast on the large station brain** (follow-up to
+  2.7.2, measured on 64k neurons / 266k synapses):
+  - Parameterized `WHERE brain_id = $bid` defeated the `brain_id` index in
+    SurrealDB 3.2.0 (only an inline literal uses it), so `count() … GROUP ALL`
+    full-scanned the vector-laden neuron table (~2.5 s → 0.01 s). `get_stats`
+    now inlines the validated brain_id and runs the counts concurrently.
+  - Diagnostics skips the unused neuron type-breakdown (~2.6 s), runs its
+    independent reads concurrently (`asyncio.gather`), and only fully analyzes
+    the active brain in `/api/dashboard/stats`.
+  - Net: `/api/dashboard/stats` ~27 s -> ~2.8 s, `/api/graph` 40 s+ -> ~4 s,
+    `/api/dashboard/timeline` ~3 s -> ~0.06 s.
+- **The web-UI container binds loopback only again**: `Dockerfile.surrealdb`
+  hardcoded `uvicorn --host 0.0.0.0`, overriding the compose
+  `SURREAL_MEMORY_HOST=127.0.0.1`. The CMD now honours `SURREAL_MEMORY_HOST` /
+  `SURREAL_MEMORY_PORT`.
+
 ## [2.7.2] — 2026-07-08
 
 ### Fixed

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.7.2"
+version = "2.7.3"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.7.2"
+__version__ = "2.7.3"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/diagnostics.py
+++ b/src/surreal_memory/engine/diagnostics.py
@@ -7,6 +7,7 @@ Supports both MCP and CLI exposure.
 
 from __future__ import annotations
 
+import asyncio
 import math
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -322,8 +323,14 @@ class DiagnosticsEngine:
         if hasattr(self._storage, "set_brain"):
             self._storage.set_brain(brain_id)
 
-        # Gather base data
-        enhanced = await self._storage.get_enhanced_stats(brain_id)
+        # Gather base data. Skip the neuron-type breakdown — it is the priciest
+        # query on a large brain (~2.6 s / 64k neurons) and none of the health
+        # metrics below read it. Backends whose get_enhanced_stats predates the
+        # flag fall back to the full call.
+        try:
+            enhanced = await self._storage.get_enhanced_stats(brain_id, include_neuron_types=False)
+        except TypeError:
+            enhanced = await self._storage.get_enhanced_stats(brain_id)
         neuron_count: int = enhanced.get("neuron_count", 0)
         synapse_count: int = enhanced.get("synapse_count", 0)
         fiber_count: int = enhanced.get("fiber_count", 0)
@@ -335,15 +342,26 @@ class DiagnosticsEngine:
         # Compute individual metrics
         synapse_stats = enhanced.get("synapse_stats", {})
 
-        # Fetch fibers once for freshness + diagnostics
-        fibers = await self._storage.get_fibers(limit=10000)
+        # The remaining DB-bound reads are independent, so run them concurrently
+        # rather than serially (measured ~1.6x on the shared HTTP connection).
+        # orphan-rate needs both fibers and the connected-neuron set, so fetch
+        # the set here and hand it in (avoids a second scan inside the compute).
+        get_connected = getattr(self._storage, "get_connected_neuron_ids", None)
+
+        async def _connected_or_none() -> set[str] | None:
+            return await get_connected() if get_connected is not None else None
+
+        fibers, consolidation_ratio, activation_efficiency, connected = await asyncio.gather(
+            self._storage.get_fibers(limit=10000),
+            self._compute_consolidation_ratio(fiber_count),
+            self._compute_activation_efficiency(neuron_count),
+            _connected_or_none(),
+        )
 
         connectivity = self._compute_connectivity(synapse_count, neuron_count)
         diversity = self._compute_diversity(synapse_stats)
         freshness = self._compute_freshness(fibers)
-        consolidation_ratio = await self._compute_consolidation_ratio(fiber_count)
-        orphan_rate = await self._compute_orphan_rate(neuron_count, fibers)
-        activation_efficiency = await self._compute_activation_efficiency(neuron_count)
+        orphan_rate = await self._compute_orphan_rate(neuron_count, fibers, connected=connected)
         recall_confidence = self._compute_recall_confidence(synapse_stats)
 
         # Compute purity score
@@ -500,7 +518,10 @@ class DiagnosticsEngine:
         return len(semantic_records) / fiber_count
 
     async def _compute_orphan_rate(
-        self, neuron_count: int, fibers: list[Any] | None = None
+        self,
+        neuron_count: int,
+        fibers: list[Any] | None = None,
+        connected: set[str] | None = None,
     ) -> float:
         """Compute fraction of neurons with no synapses AND no fiber membership.
 
@@ -513,16 +534,21 @@ class DiagnosticsEngine:
         if neuron_count == 0:
             return 0.0
 
-        # Prefer the DB-side distinct-endpoints aggregate over loading ~185k
-        # Synapse objects (that scan was seconds of the dashboard's slowness).
-        get_connected = getattr(self._storage, "get_connected_neuron_ids", None)
-        if get_connected is not None:
-            connected: set[str] = set(await get_connected())
+        # The caller may hand in the connected-neuron set (computed concurrently
+        # with the other reads). Otherwise fetch it: prefer the DB-side
+        # distinct-endpoints aggregate over loading ~185k Synapse objects (that
+        # scan was seconds of the dashboard's slowness).
+        if connected is None:
+            get_connected = getattr(self._storage, "get_connected_neuron_ids", None)
+            if get_connected is not None:
+                connected = set(await get_connected())
+            else:
+                connected = set()
+                for s in await self._storage.get_all_synapses():
+                    connected.add(s.source_id)
+                    connected.add(s.target_id)
         else:
-            connected = set()
-            for s in await self._storage.get_all_synapses():
-                connected.add(s.source_id)
-                connected.add(s.target_id)
+            connected = set(connected)
 
         # Also count neurons that belong to fibers as connected
         if fibers:

--- a/src/surreal_memory/server/routes/dashboard_api.py
+++ b/src/surreal_memory/server/routes/dashboard_api.py
@@ -91,42 +91,51 @@ async def get_stats() -> DashboardStats:
     active_name = cfg.current_brain
 
     async def _analyze_brain(name: str) -> BrainSummary:
-        """Analyze a single brain using its own per-brain storage."""
+        """Summarize a single brain.
+
+        Only the ACTIVE brain gets the full DiagnosticsEngine.analyze (grade +
+        purity); every other brain returns just its counts. The overview shows
+        the active brain's grade at the top (health_grade) and the per-brain
+        grade has its own home (the /brains endpoint + the Health page), so
+        running the multi-second analyze for every brain was pure waste — a
+        station carrying integration-test residue brains paid a full diagnostic
+        pass for each of them on every overview load.
+        """
+        is_active = name == active_name
         try:
             brain_storage = await get_shared_storage(brain_name=name)
 
-            grade = "F"
-            purity = 0.0
-            nc = sc = fc = 0
-            try:
-                from surreal_memory.engine.diagnostics import DiagnosticsEngine
+            if is_active:
+                try:
+                    from surreal_memory.engine.diagnostics import DiagnosticsEngine
 
-                diag = DiagnosticsEngine(brain_storage)
-                report = await diag.analyze(name)
-                grade = report.grade
-                purity = report.purity_score
-                # The report already carries the counts (via get_enhanced_stats),
-                # so a separate get_stats here would just repeat the same three
-                # count queries per brain.
-                nc = report.neuron_count
-                sc = report.synapse_count
-                fc = report.fiber_count
-            except Exception:
-                logger.debug("Diagnostics failed for brain %s", name, exc_info=True)
-                stats = await brain_storage.get_stats(name)
-                nc = stats.get("neuron_count", 0)
-                sc = stats.get("synapse_count", 0)
-                fc = stats.get("fiber_count", 0)
+                    diag = DiagnosticsEngine(brain_storage)
+                    report = await diag.analyze(name)
+                    return BrainSummary(
+                        id=name,
+                        name=name,
+                        neuron_count=report.neuron_count,
+                        synapse_count=report.synapse_count,
+                        fiber_count=report.fiber_count,
+                        grade=report.grade,
+                        purity_score=report.purity_score,
+                        is_active=True,
+                    )
+                except Exception:
+                    logger.debug("Diagnostics failed for active brain %s", name, exc_info=True)
 
+            # Inactive brain (or active-brain diagnostics failure): counts only.
+            # "—" flags grade as "not computed here" rather than a real F.
+            stats = await brain_storage.get_stats(name)
             return BrainSummary(
                 id=name,
                 name=name,
-                neuron_count=nc,
-                synapse_count=sc,
-                fiber_count=fc,
-                grade=grade,
-                purity_score=purity,
-                is_active=name == active_name,
+                neuron_count=stats.get("neuron_count", 0),
+                synapse_count=stats.get("synapse_count", 0),
+                fiber_count=stats.get("fiber_count", 0),
+                grade="F" if is_active else "—",
+                purity_score=0.0,
+                is_active=is_active,
             )
         except Exception:
             # Surface at WARNING (not debug): swallowing this silently made the
@@ -134,7 +143,7 @@ async def get_stats() -> DashboardStats:
             # storage/config misconfiguration. Keep returning a placeholder so
             # one bad brain does not break the whole dashboard.
             logger.warning("Brain analysis failed for %s", name, exc_info=True)
-            return BrainSummary(id=name, name=name, is_active=name == active_name)
+            return BrainSummary(id=name, name=name, is_active=is_active)
 
     # Analyze brains sequentially, NOT via asyncio.gather: the SurrealDB backend
     # shares one storage singleton with a mutable current-brain pointer, so

--- a/src/surreal_memory/storage/base.py
+++ b/src/surreal_memory/storage/base.py
@@ -712,7 +712,9 @@ class NeuralStorage(ABC):
         ...
 
     @abstractmethod
-    async def get_enhanced_stats(self, brain_id: str) -> dict[str, Any]:
+    async def get_enhanced_stats(
+        self, brain_id: str, include_neuron_types: bool = True
+    ) -> dict[str, Any]:
         """
         Get enhanced statistics for a brain.
 

--- a/src/surreal_memory/storage/factory.py
+++ b/src/surreal_memory/storage/factory.py
@@ -308,8 +308,12 @@ class HybridStorage:
     async def get_stats(self, brain_id: str) -> dict[str, int]:
         return await self._local.get_stats(brain_id)
 
-    async def get_enhanced_stats(self, brain_id: str) -> dict[str, Any]:
-        return await self._local.get_enhanced_stats(brain_id)
+    async def get_enhanced_stats(
+        self, brain_id: str, include_neuron_types: bool = True
+    ) -> dict[str, Any]:
+        return await self._local.get_enhanced_stats(
+            brain_id, include_neuron_types=include_neuron_types
+        )
 
     async def clear(self, brain_id: str) -> None:
         await self._local.clear(brain_id)

--- a/src/surreal_memory/storage/memory_store.py
+++ b/src/surreal_memory/storage/memory_store.py
@@ -421,7 +421,9 @@ class InMemoryStorage(
             "project_count": len(self._projects[brain_id]),
         }
 
-    async def get_enhanced_stats(self, brain_id: str) -> dict[str, Any]:
+    async def get_enhanced_stats(
+        self, brain_id: str, include_neuron_types: bool = True
+    ) -> dict[str, Any]:
         basic_stats = await self.get_stats(brain_id)
 
         # Hot neurons by access frequency

--- a/src/surreal_memory/storage/shared_store.py
+++ b/src/surreal_memory/storage/shared_store.py
@@ -425,7 +425,9 @@ class SharedStorage(SharedFiberBrainMixin, NeuralStorage):
             "fiber_count": result.get("fiber_count", 0),
         }
 
-    async def get_enhanced_stats(self, brain_id: str) -> dict[str, Any]:
+    async def get_enhanced_stats(
+        self, brain_id: str, include_neuron_types: bool = True
+    ) -> dict[str, Any]:
         """Get enhanced brain statistics via API."""
         result = await self._request("GET", f"/brain/{brain_id}/stats")
         return result

--- a/src/surreal_memory/storage/sqlite_store.py
+++ b/src/surreal_memory/storage/sqlite_store.py
@@ -224,7 +224,9 @@ class SQLiteStorage(
                 "project_count": row["project_count"] if row else 0,
             }
 
-    async def get_enhanced_stats(self, brain_id: str) -> dict[str, Any]:
+    async def get_enhanced_stats(
+        self, brain_id: str, include_neuron_types: bool = True
+    ) -> dict[str, Any]:
         conn = self._ensure_read_conn()
         basic_stats = await self.get_stats(brain_id)
 

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
+import re
 from datetime import datetime
 from hashlib import sha256
 from typing import Any, Literal
@@ -94,6 +95,24 @@ def _to_surreal_id(record_id: str) -> str:
     if ":" in record_id:
         record_id = record_id.rsplit(":", 1)[1]
     return record_id.replace("-", "_")
+
+
+_BRAIN_ID_SAFE = re.compile(r"^[a-zA-Z0-9_.\-]+$")
+
+
+def _brain_literal(brain_id: str) -> str:
+    """Return ``brain_id`` as a safe inline SurrealQL string literal.
+
+    SurrealDB 3.2.0's planner only uses the ``brain_id`` index when the value is
+    an inline literal — a parameterized ``WHERE brain_id = $bid`` falls back to a
+    full table scan. On the 64k-neuron table (each row carrying a 1024-float
+    vector) that turned ``count() … GROUP ALL`` from 0.01 s into ~2.5 s, and it
+    was the single biggest cost behind the dashboard's stats endpoint. brain_id
+    is validated to a strict charset, so inlining it is injection-safe.
+    """
+    if not _BRAIN_ID_SAFE.match(brain_id):
+        raise ValueError(f"unsafe brain_id for inline query: {brain_id!r}")
+    return f'"{brain_id}"'
 
 
 def _from_surreal_id(surreal_id: str) -> str:
@@ -1430,17 +1449,14 @@ class SurrealDBStorage(
     # ================================================================
 
     async def get_stats(self, brain_id: str) -> dict[str, int]:
-        neuron_rows = await self._query(
-            "SELECT count() AS c FROM neuron WHERE brain_id = $bid GROUP ALL",
-            bid=brain_id,
-        )
-        synapse_rows = await self._query(
-            "SELECT count() AS c FROM synapse WHERE brain_id = $bid GROUP ALL",
-            bid=brain_id,
-        )
-        fiber_rows = await self._query(
-            "SELECT count() AS c FROM fiber WHERE brain_id = $bid GROUP ALL",
-            bid=brain_id,
+        # Inline the (validated) brain_id so the count() aggregates use the
+        # brain_id index instead of a full scan — see _brain_literal. The three
+        # scans are independent, so run them concurrently.
+        lit = _brain_literal(brain_id)
+        neuron_rows, synapse_rows, fiber_rows = await asyncio.gather(
+            self._query(f"SELECT count() AS c FROM neuron WHERE brain_id = {lit} GROUP ALL"),
+            self._query(f"SELECT count() AS c FROM synapse WHERE brain_id = {lit} GROUP ALL"),
+            self._query(f"SELECT count() AS c FROM fiber WHERE brain_id = {lit} GROUP ALL"),
         )
 
         def _count(rows: list[Any]) -> int:
@@ -1454,15 +1470,22 @@ class SurrealDBStorage(
             "fiber_count": _count(fiber_rows),
         }
 
-    async def get_enhanced_stats(self, brain_id: str) -> dict[str, Any]:
+    async def get_enhanced_stats(
+        self, brain_id: str, include_neuron_types: bool = True
+    ) -> dict[str, Any]:
         stats = await self.get_stats(brain_id)
 
-        # Neuron type breakdown
-        type_rows = await self._query(
-            "SELECT type, count() AS c FROM neuron WHERE brain_id = $bid GROUP BY type",
-            bid=brain_id,
-        )
-        type_counts = {str(r.get("type", "unknown")): int(r.get("c", 0)) for r in type_rows}
+        # Neuron type breakdown. This GROUP BY over the whole neuron table is the
+        # single most expensive query on a large brain (~2.6 s for 64k neurons)
+        # and DiagnosticsEngine never reads it — so callers that only need the
+        # health metrics pass include_neuron_types=False to skip it entirely.
+        type_counts: dict[str, int] = {}
+        if include_neuron_types:
+            type_rows = await self._query(
+                "SELECT type, count() AS c FROM neuron WHERE brain_id = $bid GROUP BY type",
+                bid=brain_id,
+            )
+            type_counts = {str(r.get("type", "unknown")): int(r.get("c", 0)) for r in type_rows}
 
         # Synapse stats by type — required by DiagnosticsEngine for diversity
         # (Shannon entropy over by_type counts) and recall_confidence (avg_weight).
@@ -2084,14 +2107,20 @@ class SurrealDBStorage(
         replaces loading ~185k Synapse objects (~10 s) for the orphan-rate metric
         with two distinct-key scans (~2 s total)."""
         bid = brain_id or self._get_brain_id()
-        connected: set[str] = set()
-        for field in ("in", "out"):
-            rows = await self._query(
+
+        async def _endpoints(field: str) -> list[Any]:
+            return await self._query(
                 f"SELECT VALUE {field} FROM synapse WHERE brain_id = $bid GROUP BY {field}",
                 bid=bid,
             )
-            for rid in rows:
-                connected.add(_from_surreal_id(str(rid)))
+
+        # The two distinct-endpoint scans are independent, so run them
+        # concurrently — on a large brain this ~halves the wall time (measured
+        # 2.5 s -> ~1.3 s) versus scanning in then out.
+        in_rows, out_rows = await asyncio.gather(_endpoints("in"), _endpoints("out"))
+        connected: set[str] = set()
+        for rid in (*in_rows, *out_rows):
+            connected.add(_from_surreal_id(str(rid)))
         return connected
 
     async def get_synapse_degrees(self, brain_id: str | None = None) -> dict[str, int]:
@@ -2102,17 +2131,21 @@ class SurrealDBStorage(
         real ``in``/``out`` record links — the ``source_id``/``target_id``
         fields are computed and do not aggregate."""
         bid = brain_id or self._get_brain_id()
-        degree: dict[str, int] = {}
-        for field in ("in", "out"):
-            rows = await self._query(
+
+        async def _degree(field: str) -> list[Any]:
+            return await self._query(
                 f"SELECT {field} AS nid, count() AS deg FROM synapse"
                 f" WHERE brain_id = $bid GROUP BY {field}",
                 bid=bid,
             )
-            for r in rows:
-                nid = _endpoint_to_id(r.get("nid"))
-                if nid:
-                    degree[nid] = degree.get(nid, 0) + int(r.get("deg", 0) or 0)
+
+        # The in/out degree scans are independent — run them concurrently.
+        in_rows, out_rows = await asyncio.gather(_degree("in"), _degree("out"))
+        degree: dict[str, int] = {}
+        for r in (*in_rows, *out_rows):
+            nid = _endpoint_to_id(r.get("nid"))
+            if nid:
+                degree[nid] = degree.get(nid, 0) + int(r.get("deg", 0) or 0)
         return degree
 
     async def get_edges_for_neurons(self, neuron_ids: list[str]) -> list[Synapse]:

--- a/tests/unit/test_dashboard_perf_queries.py
+++ b/tests/unit/test_dashboard_perf_queries.py
@@ -211,3 +211,57 @@ class TestGetAllSynapsesProjection:
         await st.get_all_synapses()
         (sql,) = _queries(conn)
         assert sql.startswith("SELECT * FROM synapse")
+
+
+# --------------------------------------------------------------------------- #
+# brain_id inline literal (index usage) — 2.7.3
+# --------------------------------------------------------------------------- #
+class TestBrainLiteral:
+    def test_valid_brain_id_is_quoted(self):
+        from surreal_memory.storage.surrealdb.store import _brain_literal
+
+        assert _brain_literal("default") == '"default"'
+        assert _brain_literal("it_2c80122dbe75") == '"it_2c80122dbe75"'
+        assert _brain_literal("my-brain.v2") == '"my-brain.v2"'
+
+    def test_injection_shaped_brain_id_rejected(self):
+        import pytest
+
+        from surreal_memory.storage.surrealdb.store import _brain_literal
+
+        for bad in ['a" OR "1"="1', "a; DELETE neuron", "a b", 'a"']:
+            with pytest.raises(ValueError):
+                _brain_literal(bad)
+
+
+class TestGetStatsInline:
+    async def test_counts_inline_brain_id_for_index(self):
+        st, conn = _store_with_mock_conn()
+        await st.get_stats("default")
+        sqls = _queries(conn)
+        # brain_id inlined as a literal (uses the index) — never parameterized,
+        # which in SurrealDB 3.2.0 falls back to a full table scan.
+        assert all('brain_id = "default"' in s for s in sqls)
+        assert not any("$bid" in s or "$brain_id" in s for s in sqls)
+        assert {s.split("FROM ")[1].split(" ")[0] for s in sqls} == {
+            "neuron",
+            "synapse",
+            "fiber",
+        }
+
+
+class TestEnhancedStatsSkipNeuronTypes:
+    async def test_skip_neuron_types_omits_neuron_group_by(self):
+        st, conn = _store_with_mock_conn()
+        await st.get_enhanced_stats("default", include_neuron_types=False)
+        sqls = _queries(conn)
+        # The pricey `FROM neuron … GROUP BY type` scan must NOT run.
+        assert not any("FROM neuron" in s and "GROUP BY type" in s for s in sqls)
+        # The synapse-type stats (needed for diversity) still run.
+        assert any("FROM synapse" in s and "GROUP BY type" in s for s in sqls)
+
+    async def test_default_includes_neuron_types(self):
+        st, conn = _store_with_mock_conn()
+        await st.get_enhanced_stats("default")
+        sqls = _queries(conn)
+        assert any("FROM neuron" in s and "GROUP BY type" in s for s in sqls)

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.7.2"
+        assert surreal_memory.__version__ == "2.7.3"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_storage_factory.py
+++ b/tests/unit/test_storage_factory.py
@@ -314,9 +314,7 @@ class TestHybridStorage:
         local.get_stats.assert_awaited_once_with("brain-1")
 
         await storage.get_enhanced_stats("brain-1")  # type: ignore[union-attr]
-        local.get_enhanced_stats.assert_awaited_once_with(
-            "brain-1", include_neuron_types=True
-        )
+        local.get_enhanced_stats.assert_awaited_once_with("brain-1", include_neuron_types=True)
 
         await storage.clear("brain-1")  # type: ignore[union-attr]
         local.clear.assert_awaited_once_with("brain-1")

--- a/tests/unit/test_storage_factory.py
+++ b/tests/unit/test_storage_factory.py
@@ -314,7 +314,9 @@ class TestHybridStorage:
         local.get_stats.assert_awaited_once_with("brain-1")
 
         await storage.get_enhanced_stats("brain-1")  # type: ignore[union-attr]
-        local.get_enhanced_stats.assert_awaited_once_with("brain-1")
+        local.get_enhanced_stats.assert_awaited_once_with(
+            "brain-1", include_neuron_types=True
+        )
 
         await storage.clear("brain-1")  # type: ignore[union-attr]
         local.clear.assert_awaited_once_with("brain-1")

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Follow-up to 2.7.2. After deploying 2.7.2 to the station and profiling the **real** bottlenecks on the live brain (64k neurons / 266k synapses), the dashboard was still 6–10 s. This release fixes the actual root cause and a security regression from 2.7.2's host-networking switch.

## Root cause: parameterized `brain_id` defeated the index

SurrealDB 3.2.0's query planner uses the `brain_id` index **only for an inline literal** — `WHERE brain_id = $bid` (parameterized) silently falls back to a full table scan. Measured on the station:

| query | parameterized `$bid` | inline `"default"` |
|---|---|---|
| `count() … GROUP ALL` on neuron (64k rows, each with a 1024-float vector) | **2.5 s** | **0.01 s** |

`get_stats` runs three counts on **every** dashboard endpoint, so this was the dominant cost. No param-wrapping (`type::string`, `<string>`) restores the index — only inlining does.

## Changes

- **`_brain_literal()`** — strict-charset-validated (`^[a-zA-Z0-9_.\-]+$`) inline brain_id; injection-safe. `get_stats` inlines it and runs the 3 counts via `asyncio.gather`.
- **`get_enhanced_stats(include_neuron_types=False)`** — diagnostics skips the ~2.6 s neuron `GROUP BY type` scan it never reads (threaded through the base interface + all backends).
- **Concurrent reads** — diagnostics fibers/connected/activation, `get_connected_neuron_ids` in/out, and `get_synapse_degrees` in/out all run via `asyncio.gather` (empirically ~1.6× on the shared HTTP connection; verified results identical).
- **Active-brain-only diagnostics** — `/api/dashboard/stats` fully analyzes only the active brain; others report counts (a station with integration-test residue brains paid a full analyze per brain).
- **`Dockerfile.surrealdb` honours `SURREAL_MEMORY_HOST`** — the CMD hardcoded `--host 0.0.0.0`, silently overriding 2.7.2's `SURREAL_MEMORY_HOST=127.0.0.1` loopback-only bind and exposing the dashboard on every interface. **Verified** post-fix: `ss -ltnp` shows `127.0.0.1:8000`.

## Measured result (station, deployed from this branch)

| endpoint | 2.7.1 | 2.7.3 |
|---|---|---|
| `/api/dashboard/stats` | ~27 s | **~2.8 s** |
| `/api/graph` | 40 s+ (timeout) | **~4 s** |
| `/api/dashboard/timeline` | ~3 s | **~0.06 s** |

Residual (~2.8 s stats / ~4 s graph) is inherent `GROUP BY` scan cost on 266k synapses (connected/degree ~1.4 s, synapse-type ~1 s); further gains would need a synapse-endpoint index.

## Test plan

- [x] 20 new/updated unit tests (`_brain_literal` validation + injection rejection, `get_stats` inline + no `$bid`, `include_neuron_types` skip, gather query shapes) + factory delegation assertion updated.
- [x] Full suite: 5824 passed; the 4 `test_surrealdb_synapse_migration` failures + 59 e2e errors are pre-existing (live-DB / SDK-vs-container env), not from this change.
- [x] ruff + mypy clean (346 files).
- [x] Deployed to the station from this branch; timings + loopback bind verified above; grade/counts correct (D, 64804 / 266719 / 4890).

## Follow-ups (not in this PR)

- 7 `it_<hex>` integration-test residue brains exist on the station DB (0–4 neurons each) — test isolation leak writing to the live SurrealDB. Worth a cleanup + isolation fix.