### PR TITLE
perf: cache dashboard overview grade + graph per brain (2.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.4] — 2026-07-09
+
+### Changed
+
+- **Dashboard overview and graph are cached per brain for a short window**, so
+  repeat loads are instant. The grade/purity (a full `DiagnosticsEngine.analyze`)
+  and the graph payload each aggregate over the whole synapse graph — a few
+  seconds on a large brain that no index removes — but both are slow-moving, so
+  recomputing them on every request was waste. The overview's neuron/synapse/fiber
+  counts stay live (they're cheap, indexed `count()`); only the multi-second
+  grade/purity and the graph structure are cached. TTL is configurable via
+  `SURREAL_MEMORY_DASHBOARD_CACHE_TTL` (seconds, default 60); set it to `0` to
+  disable caching entirely.
+
 ## [2.7.3] — 2026-07-09
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.4] — 2026-07-09
+
+### Changed
+
+- **Dashboard overview and graph are cached per brain for a short window**, so
+  repeat loads are instant. The grade/purity (a full `DiagnosticsEngine.analyze`)
+  and the graph payload each aggregate over the whole synapse graph — a few
+  seconds on a large brain that no index removes — but both are slow-moving, so
+  recomputing them on every request was waste. The overview's neuron/synapse/fiber
+  counts stay live (they're cheap, indexed `count()`); only the multi-second
+  grade/purity and the graph structure are cached. TTL is configurable via
+  `SURREAL_MEMORY_DASHBOARD_CACHE_TTL` (seconds, default 60); set it to `0` to
+  disable caching entirely.
+
 ## [2.7.3] — 2026-07-09
 
 ### Fixed

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.7.3"
+version = "2.7.4"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.7.3"
+__version__ = "2.7.4"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/server/app.py
+++ b/src/surreal_memory/server/app.py
@@ -14,6 +14,7 @@ from fastapi.responses import FileResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 
 from surreal_memory import __version__
+from surreal_memory.server.dashboard_cache import TTLCache
 from surreal_memory.server.models import HealthResponse, ReadyResponse
 from surreal_memory.server.routes import (
     brain_router,
@@ -31,6 +32,12 @@ from surreal_memory.storage.sqlite_schema import SCHEMA_VERSION
 
 # Static files directory
 STATIC_DIR = Path(__file__).parent / "static"
+
+# The graph view aggregates degree over the whole synapse graph + fetches the
+# dense core's nodes/edges — a few seconds on a large brain. The graph structure
+# is slow-moving, so cache the built payload per (brain, limit, offset) for a
+# short window (see dashboard_cache).
+_GRAPH_CACHE = TTLCache()
 
 
 @asynccontextmanager
@@ -586,6 +593,19 @@ def create_app(
         capped_limit = min(limit, 2000)
         edge_cap = 4000
 
+        # Serve a recently-built graph for this (brain, limit, offset) from cache.
+        _brain_id = "default"
+        _get_bid = getattr(storage, "_get_brain_id", None)
+        if _get_bid is not None:
+            try:
+                _brain_id = _get_bid()
+            except Exception:
+                pass
+        _cache_key = f"graph:{_brain_id}:{limit}:{offset}"
+        _cached_graph = _GRAPH_CACHE.get(_cache_key)
+        if _cached_graph is not None:
+            return dict(_cached_graph)
+
         # Degree ranking + edge fetch via DB aggregates/graph traversal when the
         # backend supports it (SurrealDB). Loading all ~185k synapses into Python
         # just to rank/filter them was ~10 s of the graph view's 30 s+ hang.
@@ -636,7 +656,7 @@ def create_app(
 
         fibers = await storage.get_fibers(limit=1000)
 
-        return {
+        payload = {
             "neurons": [
                 {
                     "id": n.id,
@@ -673,6 +693,8 @@ def create_app(
                 "fiber_count": len(fibers),
             },
         }
+        _GRAPH_CACHE.set(_cache_key, payload)
+        return payload
 
     # React SPA dist directory
     spa_dist = STATIC_DIR / "dist"

--- a/src/surreal_memory/server/dashboard_cache.py
+++ b/src/surreal_memory/server/dashboard_cache.py
@@ -1,0 +1,82 @@
+"""Tiny TTL cache for the expensive dashboard reads.
+
+The overview grade/purity (a full ``DiagnosticsEngine.analyze``) and the graph
+view are inherently a few seconds each on a large brain — they aggregate over
+hundreds of thousands of synapses (``GROUP BY`` scans that no index removes).
+But these are *slow-moving quality/structure* views: the health grade barely
+shifts between two page loads seconds apart, and neither does a 64k-node graph.
+
+So instead of recomputing on every request, cache the result per brain for a
+short window. Repeat loads (the common case — the dashboard auto-refreshes and
+users navigate back and forth) are served instantly; the value is recomputed at
+most once per TTL. Counts (neuron/synapse/fiber) are cheap and are NOT cached
+here — the overview keeps them live.
+
+TTL is read from ``SURREAL_MEMORY_DASHBOARD_CACHE_TTL`` (seconds); set it to 0 to
+disable caching entirely (every request recomputes).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable
+from typing import Any
+
+_DEFAULT_TTL_SECONDS = 60.0
+
+
+def _configured_ttl() -> float:
+    raw = os.environ.get("SURREAL_MEMORY_DASHBOARD_CACHE_TTL")
+    if raw is None or raw == "":
+        return _DEFAULT_TTL_SECONDS
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return _DEFAULT_TTL_SECONDS
+
+
+class TTLCache:
+    """A minimal, single-process TTL cache.
+
+    Entries expire ``ttl`` seconds after they are written. A ttl of 0 disables
+    the cache (``get`` always misses, ``set`` is a no-op) so it can be turned off
+    without touching call sites. The clock is injectable for deterministic tests.
+    """
+
+    def __init__(
+        self,
+        ttl: float | None = None,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._ttl = _configured_ttl() if ttl is None else max(0.0, ttl)
+        self._clock = clock
+        self._store: dict[str, tuple[float, Any]] = {}
+
+    @property
+    def enabled(self) -> bool:
+        return self._ttl > 0
+
+    def get(self, key: str) -> Any | None:
+        if not self.enabled:
+            return None
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        written_at, value = entry
+        if self._clock() - written_at > self._ttl:
+            self._store.pop(key, None)
+            return None
+        return value
+
+    def set(self, key: str, value: Any) -> None:
+        if not self.enabled:
+            return
+        self._store[key] = (self._clock(), value)
+
+    def invalidate(self, key: str) -> None:
+        self._store.pop(key, None)
+
+    def clear(self) -> None:
+        self._store.clear()

--- a/src/surreal_memory/server/routes/dashboard_api.py
+++ b/src/surreal_memory/server/routes/dashboard_api.py
@@ -9,10 +9,32 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
+from surreal_memory.server.dashboard_cache import TTLCache
 from surreal_memory.server.dependencies import get_storage, require_local_request
 from surreal_memory.storage.base import NeuralStorage
 
 logger = logging.getLogger(__name__)
+
+# Full diagnostics (grade/purity) aggregates over the whole synapse graph — a few
+# seconds on a large brain. The grade is slow-moving, so cache it per brain for a
+# short window; the overview's counts are computed live (cheap) around it.
+_GRADE_CACHE = TTLCache()
+
+
+async def _cached_grade_purity(storage: NeuralStorage, brain_name: str) -> tuple[str, float]:
+    """Return (grade, purity) for a brain, cached per brain for the TTL window."""
+    key = f"grade:{brain_name}"
+    cached = _GRADE_CACHE.get(key)
+    if cached is not None:
+        grade, purity = cached
+        return str(grade), float(purity)
+    from surreal_memory.engine.diagnostics import DiagnosticsEngine
+
+    report = await DiagnosticsEngine(storage).analyze(brain_name)
+    result = (report.grade, report.purity_score)
+    _GRADE_CACHE.set(key, result)
+    return result
+
 
 router = APIRouter(
     prefix="/api/dashboard",
@@ -105,36 +127,27 @@ async def get_stats() -> DashboardStats:
         try:
             brain_storage = await get_shared_storage(brain_name=name)
 
+            # Counts are cheap (indexed count()) — always compute them live so the
+            # neuron/synapse/fiber numbers are never stale.
+            stats = await brain_storage.get_stats(name)
+            grade = "—"
+            purity = 0.0
             if is_active:
+                # Grade/purity is the multi-second part — served from the per-brain
+                # TTL cache (recomputed at most once per window).
                 try:
-                    from surreal_memory.engine.diagnostics import DiagnosticsEngine
-
-                    diag = DiagnosticsEngine(brain_storage)
-                    report = await diag.analyze(name)
-                    return BrainSummary(
-                        id=name,
-                        name=name,
-                        neuron_count=report.neuron_count,
-                        synapse_count=report.synapse_count,
-                        fiber_count=report.fiber_count,
-                        grade=report.grade,
-                        purity_score=report.purity_score,
-                        is_active=True,
-                    )
+                    grade, purity = await _cached_grade_purity(brain_storage, name)
                 except Exception:
                     logger.debug("Diagnostics failed for active brain %s", name, exc_info=True)
-
-            # Inactive brain (or active-brain diagnostics failure): counts only.
-            # "—" flags grade as "not computed here" rather than a real F.
-            stats = await brain_storage.get_stats(name)
+                    grade = "F"
             return BrainSummary(
                 id=name,
                 name=name,
                 neuron_count=stats.get("neuron_count", 0),
                 synapse_count=stats.get("synapse_count", 0),
                 fiber_count=stats.get("fiber_count", 0),
-                grade="F" if is_active else "—",
-                purity_score=0.0,
+                grade=grade,
+                purity_score=purity,
                 is_active=is_active,
             )
         except Exception:

--- a/tests/unit/test_dashboard_cache.py
+++ b/tests/unit/test_dashboard_cache.py
@@ -1,0 +1,84 @@
+"""Unit tests for the dashboard TTL cache (2.7.4).
+
+The overview grade/purity and the graph payload are cached per brain for a short
+window so repeat dashboard loads are instant. These pin the cache semantics:
+hit within TTL, miss after expiry, disable via ttl=0 / env, and invalidation.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from surreal_memory.server.dashboard_cache import TTLCache
+
+
+class _Clock:
+    """Manual monotonic clock for deterministic expiry tests."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+class TestTTLCache:
+    def test_hit_within_ttl(self):
+        clock = _Clock()
+        cache = TTLCache(ttl=60.0, clock=clock)
+        cache.set("k", {"grade": "A"})
+        clock.advance(59.0)
+        assert cache.get("k") == {"grade": "A"}
+
+    def test_miss_after_expiry(self):
+        clock = _Clock()
+        cache = TTLCache(ttl=60.0, clock=clock)
+        cache.set("k", 123)
+        clock.advance(61.0)
+        assert cache.get("k") is None
+
+    def test_missing_key_returns_none(self):
+        assert TTLCache(ttl=60.0).get("absent") is None
+
+    def test_ttl_zero_disables_cache(self):
+        cache = TTLCache(ttl=0.0)
+        assert cache.enabled is False
+        cache.set("k", "v")
+        assert cache.get("k") is None
+
+    def test_invalidate_and_clear(self):
+        cache = TTLCache(ttl=60.0)
+        cache.set("a", 1)
+        cache.set("b", 2)
+        cache.invalidate("a")
+        assert cache.get("a") is None
+        assert cache.get("b") == 2
+        cache.clear()
+        assert cache.get("b") is None
+
+    def test_expired_entry_is_evicted_on_read(self):
+        clock = _Clock()
+        cache = TTLCache(ttl=10.0, clock=clock)
+        cache.set("k", "v")
+        clock.advance(11.0)
+        cache.get("k")  # triggers eviction
+        assert "k" not in cache._store
+
+
+class TestConfiguredTTL:
+    def test_env_overrides_default(self, monkeypatch):
+        monkeypatch.setenv("SURREAL_MEMORY_DASHBOARD_CACHE_TTL", "5")
+        mod = importlib.import_module("surreal_memory.server.dashboard_cache")
+        assert mod._configured_ttl() == 5.0
+
+    def test_env_zero_disables(self, monkeypatch):
+        monkeypatch.setenv("SURREAL_MEMORY_DASHBOARD_CACHE_TTL", "0")
+        assert TTLCache().enabled is False
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("SURREAL_MEMORY_DASHBOARD_CACHE_TTL", "not-a-number")
+        mod = importlib.import_module("surreal_memory.server.dashboard_cache")
+        assert mod._configured_ttl() == mod._DEFAULT_TTL_SECONDS

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.7.3"
+        assert surreal_memory.__version__ == "2.7.4"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Removes the **residual dashboard slowness** left after 2.7.3. The overview grade/purity (a full `DiagnosticsEngine.analyze`) and the `/api/graph` payload each aggregate over the whole synapse graph — a few seconds on the station's **64k-neuron / 266k-synapse** brain, and no index removes the `GROUP BY` scans. Both are **slow-moving** views (a health grade / a 64k-node graph don't change between two page loads seconds apart), so recomputing them on every request was pure waste.

This caches them per brain for a short window, so **repeat loads are instant** (the common case — the dashboard auto-refreshes and users navigate back and forth).

## What's cached (and what isn't)

| Endpoint | Cached | Always live |
|---|---|---|
| `/api/dashboard/stats` | active brain's **grade/purity** (the multi-second `analyze`) | neuron/synapse/fiber **counts** (cheap indexed `count()`) |
| `/api/graph` | the built payload, keyed by `(brain, limit, offset)` | — |
| `/api/dashboard/timeline` | — (already ~0.06 s) | everything |

Counts stay live so the numbers you watch (“ile neuronów/synaps/fibers”) are never stale; only the expensive grade/graph structure is cached.

## Design

- New `server/dashboard_cache.TTLCache` — minimal per-process TTL cache, injectable clock, `ttl=0` disables it entirely.
- TTL from `SURREAL_MEMORY_DASHBOARD_CACHE_TTL` (seconds, **default 60**); set `0` to turn caching off.
- Each value recomputes at most once per TTL window; first load (or after expiry) still pays the compute (~2.8 s stats / ~4 s graph from 2.7.3), every repeat within the window is instant.

## Why cache, not more query tuning

After 2.7.3 the remaining cost is the `GROUP BY in/out` / `GROUP BY type` scans over 266k synapses (connectivity, degree, orphan-rate). These are inherent to computing graph/quality metrics fresh; no index eliminates them. Heavier alternatives (denormalized degree counters updated on write, materialized stats table) trade write-path overhead + consistency risk for zero first-load cost — happy to pursue if you'd prefer that over a short cache.

## Test plan

- [x] 9 unit tests pin the cache semantics (hit within TTL, miss after expiry, `ttl=0` disable, env override, invalidate/clear).
- [x] Full suite: 5834 passed; 4 failed = pre-existing SurrealDB migration integration failures under xdist (identical in the 2.7.2/2.7.3 runs, unrelated).
- [x] ruff + mypy clean (347 files).
- [ ] Post-merge deploy on the station: verify repeat `/api/dashboard/stats` and `/api/graph` are sub-100 ms within the TTL window (first load unchanged).

Not deployed to the station — awaiting your approval.