### PR TITLE
perf(recall): full-text content index + index-backed neighbor traversal (25s → 8.4s)

### DIFF
--- a/src/surreal_memory/storage/surrealdb/schema.py
+++ b/src/surreal_memory/storage/surrealdb/schema.py
@@ -14,6 +14,12 @@ SCHEMA_SQL = """
 -- Surreal-Memory SurrealDB Schema
 -- ============================================================
 
+-- Full-text analyzer for neuron.content search (the @@ operator). Defined
+-- before the index that uses it. Tokenizes on whitespace/class and lowercases,
+-- so keyword/entity lookups become case-insensitive and index-backed instead of
+-- full-scanning with CONTAINS.
+DEFINE ANALYZER IF NOT EXISTS smem_content TOKENIZERS blank, class FILTERS lowercase, ascii;
+
 -- Neurons (primary memory units)
 DEFINE TABLE neuron SCHEMAFULL;
 DEFINE FIELD id              ON neuron TYPE string;
@@ -36,6 +42,7 @@ DEFINE INDEX idx_neuron_brain    ON neuron FIELDS brain_id;
 DEFINE INDEX idx_neuron_type     ON neuron FIELDS brain_id, type;
 DEFINE INDEX idx_neuron_hash     ON neuron FIELDS brain_id, content_hash;
 DEFINE INDEX idx_neuron_content  ON neuron FIELDS brain_id, content;
+DEFINE INDEX IF NOT EXISTS idx_neuron_content_fts ON neuron FIELDS content FULLTEXT ANALYZER smem_content BM25;
 -- idx_neuron_embedding (HNSW) is defined dynamically in ensure_schema() with the
 -- configured embedding dimension, so the vector index always matches the model.
 

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -635,7 +635,12 @@ class SurrealDBStorage(
             params["content_exact"] = content_exact
 
         if content_contains is not None:
-            conditions.append("content CONTAINS $content_contains")
+            # Full-text match (@@) via the BM25 index instead of a CONTAINS
+            # substring scan: 0.9ms vs 2.9s on a 65k-neuron brain. The analyzer
+            # lowercases, so matching is case-insensitive (a net improvement for
+            # keyword/entity lookups); it is token-based rather than arbitrary
+            # substring, which is the intended semantics for concept recall.
+            conditions.append("content @@ $content_contains")
             params["content_contains"] = content_contains
 
         if time_range is not None:
@@ -927,56 +932,65 @@ class SurrealDBStorage(
         min_weight: float | None = None,
     ) -> list[tuple[Neuron, Synapse]]:
         brain_id = self._get_brain_id()
+        base_params: dict[str, Any] = {
+            "brain_id": brain_id,
+            "nid": _to_surreal_id(neuron_id),
+        }
 
-        conditions = ["brain_id = $brain_id"]
-        params: dict[str, Any] = {"brain_id": brain_id}
-
-        if direction == "out":
-            conditions.append("in = type::record('neuron', $nid)")
-        elif direction == "in":
-            conditions.append("out = type::record('neuron', $nid)")
-        else:
-            conditions.append(
-                "(in = type::record('neuron', $nid) OR out = type::record('neuron', $nid))"
-            )
-        params["nid"] = _to_surreal_id(neuron_id)
-
+        extra: list[str] = []
         if synapse_types:
-            type_vals = [t.value for t in synapse_types]
-            type_list = ", ".join(f"'{t}'" for t in type_vals)
-            conditions.append(f"type IN [{type_list}]")
-
+            type_list = ", ".join(f"'{t.value}'" for t in synapse_types)
+            extra.append(f"type IN [{type_list}]")
         if min_weight is not None:
-            conditions.append("weight >= $min_weight")
-            params["min_weight"] = min_weight
+            extra.append("weight >= $min_weight")
+            base_params["min_weight"] = min_weight
 
-        where = " AND ".join(conditions)
-        # Inline both endpoint neurons via the native edge links (in.*/out.*) so a
-        # single query returns the neighbour records — kills the N+1 get_neuron
-        # call that ran once per edge before the RELATION migration.
-        syn_rows = await self._query(
-            f"SELECT *, in.* AS in_neuron, out.* AS out_neuron FROM synapse WHERE {where}",
-            **params,
-        )
+        # Query each edge direction with its own indexed equality (idx_synapse_in
+        # / idx_synapse_out). A combined ``in = .. OR out = ..`` disables the
+        # index and full-scans the whole synapse table (~950ms/call vs ~2ms). in
+        # is the source endpoint (outgoing edges), out the target (incoming).
+        edge_cols: list[str] = []
+        if direction in ("out", "both"):
+            edge_cols.append("in")
+        if direction in ("in", "both"):
+            edge_cols.append("out")
 
+        seen: set[str] = set()
         results: list[tuple[Neuron, Synapse]] = []
-        for sr in syn_rows:
-            syn = _row_to_synapse(sr)
-            # The neighbour is the endpoint that is not the queried neuron. Use the
-            # domain helper so a row that (defensively) touches neither end is
-            # skipped rather than silently resolving to the wrong endpoint.
-            other_id = syn.other_end(neuron_id)
-            if other_id is None:
-                continue
-            neighbor_row = (
-                sr.get("out_neuron") if other_id == syn.target_id else sr.get("in_neuron")
+        for col in edge_cols:
+            conditions = [
+                "brain_id = $brain_id",
+                f"{col} = type::record('neuron', $nid)",
+                *extra,
+            ]
+            where = " AND ".join(conditions)
+            # Inline both endpoint neurons via the native edge links (in.*/out.*)
+            # so a single query returns the neighbour records — kills the N+1
+            # get_neuron call that ran once per edge before the RELATION migration.
+            syn_rows = await self._query(
+                f"SELECT *, in.* AS in_neuron, out.* AS out_neuron FROM synapse WHERE {where}",
+                **base_params,
             )
-            neighbor = _row_to_neuron(neighbor_row) if neighbor_row else None
-            if neighbor is None:
-                # Orphan endpoint or inline missing — fall back to a direct fetch.
-                neighbor = await self.get_neuron(other_id)
-            if neighbor is not None:
-                results.append((neighbor, syn))
+            for sr in syn_rows:
+                syn = _row_to_synapse(sr)
+                if syn.id in seen:
+                    continue
+                seen.add(syn.id)
+                # The neighbour is the endpoint that is not the queried neuron.
+                # Use the domain helper so a row that (defensively) touches
+                # neither end is skipped rather than resolving to the wrong end.
+                other_id = syn.other_end(neuron_id)
+                if other_id is None:
+                    continue
+                neighbor_row = (
+                    sr.get("out_neuron") if other_id == syn.target_id else sr.get("in_neuron")
+                )
+                neighbor = _row_to_neuron(neighbor_row) if neighbor_row else None
+                if neighbor is None:
+                    # Orphan endpoint or inline missing — fall back to direct fetch.
+                    neighbor = await self.get_neuron(other_id)
+                if neighbor is not None:
+                    results.append((neighbor, syn))
         return results
 
     @property

--- a/tests/unit/test_surrealdb_typed_memory_all_types.py
+++ b/tests/unit/test_surrealdb_typed_memory_all_types.py
@@ -40,7 +40,7 @@ async def surrealdb_storage():  # type: ignore[no-untyped-def]
     from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
     storage = SurrealDBStorage(url=SURREALDB_URL)
-    await storage.connect()
+    await storage.initialize()
     brain = Brain.create(name="all-types-roundtrip")
     await storage.save_brain(brain)
     storage.set_brain(brain.id)


### PR DESCRIPTION
## Problem

On a large brain (65k neurons / 295k synapses) the MCP `recall` tool timed out:
the client caps each tool call at 30s, and `recall` took **~25s** on v2.7.3 —
right at the ceiling. The `smem` CLI (no timeout) still returned, which is why
"CLI works, MCP doesn't".

## Root cause — two hot-path full-scans

v2.7.3 already made most of recall index-backed (inline `brain_id`, native
`in`/`out` synapse edges). Two scans remained:

1. **`find_neurons` content lookup** used `content CONTAINS` — a case-sensitive
   substring scan over the whole `neuron` table (**2.9s/call**, ~10 calls per
   recall).
2. **`get_neighbors(direction='both')`** matched `(in = .. OR out = ..)`. An `OR`
   across two indexed columns disables `idx_synapse_in`/`idx_synapse_out`, so it
   full-scanned the `synapse` table with an inline `in.*/out.*` fetch
   (**~950ms/call**, ~26 per recall) — the dominant cost.

## Fixes

- **Full-text index**: add a BM25 `FULLTEXT` index (`idx_neuron_content_fts`)
  with a lowercase analyzer and switch `find_neurons` to the `@@` operator.
  `2.9s → 0.9ms`. Case-insensitive matching is a net improvement for
  keyword/entity recall; `suggest_neurons` keeps `CONTAINS` (prefix autocomplete
  needs substring).
- **Index-backed neighbor traversal**: query each edge direction with its own
  indexed equality and merge (dedup by id), preserving the inline `in.*/out.*`
  neighbour fetch. `951ms → 38ms`.
- **Bug fix**: the all-types-roundtrip test fixture called
  `SurrealDBStorage.connect()`, which does not exist (the method is
  `initialize()`). Skipped in CI (module skips when `SURREALDB_URL` is unset) but
  errored against a live SurrealDB.

## Result

| | v2.7.3 | this PR |
|---|---|---|
| recall (65k/295k brain) | ~25s | **~8.4s** |
| `content` lookup | 2.9s × ~10 | 0.9ms × ~10 |
| `get_neighbors` both | 951ms × ~26 | 38ms × ~26 |
| neurons / confidence | 22 / 1.00 | 22 / 1.00 (unchanged) |

recall now sits well under the 30s MCP tool ceiling, so no client-side
`MCP_TOOL_TIMEOUT` bump is needed.

## Test plan

- [x] `pytest tests/unit -m "not stress"` — 5797 passed (the one `test_reranker`
  failure is a HF-model download timeout in the local env, unrelated to these
  changes; reranker code is untouched).
- [x] Full-text quality verified on the live brain: `@@` vs `CONTAINS` return
  equivalent result sets (memory 212/209, recall 47/46) and are case-insensitive.
- [x] Neighbour traversal verified end-to-end (add_synapse → get_neighbors
  both/in/out → correct neighbours; recall spreading returns 22 neurons at
  confidence 1.00 across probe queries).
- [x] `ruff check` / `ruff format` clean.

The new `FULLTEXT` index and analyzer are added to `SCHEMA_SQL` (idempotent
`IF NOT EXISTS`), so fresh databases get them via `ensure_schema()`.