### PR TITLE
fix: schema parser silently drops DDL under comment blocks (2.7.4 FTS analyzer never created) + stop leaked aiosqlite threads wedging the test suite

### DIFF
--- a/src/surreal_memory/storage/surrealdb/schema.py
+++ b/src/surreal_memory/storage/surrealdb/schema.py
@@ -426,6 +426,28 @@ SYNAPSE_V8_DDL: list[str] = [
 ]
 
 
+def _parse_schema_statements(sql: str) -> list[str]:
+    """Split a SurrealQL schema script into executable statements.
+
+    Comment LINES are stripped inside each ``;``-separated chunk. The previous
+    approach — dropping any whole chunk whose stripped text *started* with
+    ``--`` — silently discarded every statement that sits directly under an
+    explanatory comment block: all 26 ``DEFINE TABLE`` statements and, since
+    2.7.4, the ``smem_content`` FULLTEXT analyzer. Without the analyzer the
+    ``idx_neuron_content_fts`` DEFINE fails (and was swallowed below), so the
+    ``@@`` operator behind ``find_neurons`` matched nothing — keyword recall
+    was silently dead on any database relying on ``ensure_schema``.
+    """
+    statements: list[str] = []
+    for chunk in sql.split(";"):
+        stmt = "\n".join(
+            line for line in chunk.splitlines() if not line.strip().startswith("--")
+        ).strip()
+        if stmt:
+            statements.append(stmt)
+    return statements
+
+
 async def ensure_schema(conn: Any, embedding_dim: int = 3072) -> None:
     """Apply schema to SurrealDB. Safe to call multiple times.
 
@@ -449,9 +471,7 @@ async def ensure_schema(conn: Any, embedding_dim: int = 3072) -> None:
     """
     dim = int(embedding_dim) if embedding_dim and int(embedding_dim) > 0 else 3072
     logger.info("Applying SurrealDB schema (v%d, embedding_dim=%d)...", SCHEMA_VERSION, dim)
-    statements = [
-        s.strip() for s in SCHEMA_SQL.split(";") if s.strip() and not s.strip().startswith("--")
-    ]
+    statements = _parse_schema_statements(SCHEMA_SQL)
     statements.append(
         "DEFINE INDEX idx_neuron_embedding ON neuron "
         f"FIELDS embedding_vec HNSW DIMENSION {dim} DIST COSINE"
@@ -460,8 +480,16 @@ async def ensure_schema(conn: Any, embedding_dim: int = 3072) -> None:
     for stmt in statements:
         try:
             await conn.query(stmt + ";")
-        except Exception:
-            # Index/table may already exist (or the flat synapse table blocks the
-            # RELATION re-definition on v7) — the migration handles conversion.
-            pass
+        except Exception as exc:
+            # A bare DEFINE on an existing index/table raises AlreadyExists on
+            # every start (including the flat synapse table blocking the
+            # RELATION re-definition on v7 — the migration handles conversion);
+            # that stays at debug. Anything else used to vanish here — the
+            # dropped-analyzer bug hid behind this very handler — so real
+            # failures are now logged without breaking startup.
+            head = stmt.splitlines()[0][:88]
+            if "already exists" in str(exc).lower():
+                logger.debug("Schema statement skipped (already exists): %s", head)
+            else:
+                logger.warning("Schema statement failed: %s (%s)", head, exc)
     logger.info("SurrealDB schema ready (v%d)", SCHEMA_VERSION)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncGenerator
+import contextlib
+from collections.abc import AsyncGenerator, Generator
 from datetime import datetime
 
 import pytest
@@ -163,3 +164,42 @@ async def populated_storage(
 def reference_time() -> datetime:
     """Standard reference time for tests."""
     return datetime(2024, 2, 4, 14, 30, 0)
+
+
+@pytest.fixture(autouse=True)
+def _close_leaked_aiosqlite_connections(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None, None, None]:
+    """Stop aiosqlite worker threads a test leaves behind.
+
+    aiosqlite runs every connection on a dedicated NON-daemon worker thread
+    that blocks on its queue until ``close()`` delivers the stop sentinel. A
+    fixture that initialises ``SQLiteStorage`` without closing it therefore
+    leaks a live thread, and any such thread still referenced at interpreter
+    exit is joined in ``threading._shutdown`` BEFORE the final garbage
+    collection — so a fully green run hangs forever after the summary (and the
+    stray ``RuntimeError: Event loop is closed`` warnings in the suite are the
+    same leak delivering late results onto closed per-test loops).
+
+    Track connections opened during each test and stop the stragglers at
+    teardown. ``Connection.stop()`` enqueues the sentinel without needing an
+    event loop, so this works from a synchronous fixture.
+    """
+    import aiosqlite
+
+    live: list[aiosqlite.Connection] = []
+    orig_init = aiosqlite.Connection.__init__
+
+    def tracking_init(self: aiosqlite.Connection, *args: object, **kwargs: object) -> None:
+        orig_init(self, *args, **kwargs)
+        live.append(self)
+
+    monkeypatch.setattr(aiosqlite.Connection, "__init__", tracking_init)
+    yield
+    for conn in live:
+        thread = getattr(conn, "_thread", None)
+        if thread is None or not thread.is_alive():
+            continue
+        with contextlib.suppress(Exception):
+            conn.stop()
+        thread.join(timeout=2.0)

--- a/tests/unit/test_aiosqlite_leak_guard.py
+++ b/tests/unit/test_aiosqlite_leak_guard.py
@@ -1,0 +1,46 @@
+"""Tests for the autouse aiosqlite leak guard in tests/conftest.py.
+
+Leaked (never-closed) aiosqlite connections keep NON-daemon worker threads
+blocked on their queue forever; any such thread still referenced at interpreter
+exit wedges pytest in ``threading._shutdown`` after a green summary. The guard
+closes stragglers at each test's teardown.
+
+The two tests below cooperate and rely on within-file definition order (which
+pytest preserves): the first deliberately leaks a connection, the second
+asserts the guard stopped its worker thread during teardown.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiosqlite
+
+_handoff: dict[str, Any] = {}
+
+
+async def test_leak_a_connection_on_purpose() -> None:
+    conn = await aiosqlite.connect(":memory:")
+    await conn.execute("CREATE TABLE t (x INTEGER)")  # prove the worker is live
+    thread = conn._thread
+    assert thread.is_alive()
+    _handoff["thread"] = thread
+    # Deliberately NOT closed — the autouse guard must stop it at teardown.
+
+
+async def test_the_guard_stopped_the_leaked_worker_thread() -> None:
+    thread = _handoff.pop("thread")
+    thread.join(timeout=2.0)
+    assert not thread.is_alive(), (
+        "the leak guard should have stopped the worker thread leaked by the previous test"
+    )
+
+
+async def test_a_properly_closed_connection_is_untouched() -> None:
+    async with aiosqlite.connect(":memory:") as conn:
+        cursor = await conn.execute("SELECT 1")
+        row = await cursor.fetchone()
+        assert row == (1,)
+    thread = conn._thread
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()

--- a/tests/unit/test_schema_statement_parser.py
+++ b/tests/unit/test_schema_statement_parser.py
@@ -1,0 +1,98 @@
+"""Regression tests for the schema statement parser (dropped-DDL bug).
+
+The old parser split SCHEMA_SQL on ";" and discarded any chunk whose stripped
+text started with "--". A statement sitting directly under an explanatory
+comment block therefore vanished before it ever reached the connection: all 26
+DEFINE TABLE statements and — critically since 2.7.4 — the smem_content
+FULLTEXT analyzer, without which idx_neuron_content_fts fails to build and the
+@@ operator behind find_neurons matches nothing.
+"""
+
+from __future__ import annotations
+
+import re
+
+from surreal_memory.storage.surrealdb.schema import (
+    SCHEMA_SQL,
+    _parse_schema_statements,
+    ensure_schema,
+)
+
+
+class TestParseSchemaStatements:
+    def test_statement_under_a_comment_block_survives(self) -> None:
+        sql = (
+            "-- ====================\n"
+            "-- Explanatory header\n"
+            "-- ====================\n"
+            "\n"
+            "-- This comment explains the analyzer in some detail,\n"
+            "-- spanning several lines.\n"
+            "DEFINE ANALYZER a TOKENIZERS blank;\n"
+            "DEFINE TABLE t SCHEMAFULL;\n"
+        )
+        statements = _parse_schema_statements(sql)
+        assert "DEFINE ANALYZER a TOKENIZERS blank" in statements
+        assert "DEFINE TABLE t SCHEMAFULL" in statements
+
+    def test_pure_comment_chunks_are_dropped(self) -> None:
+        sql = "-- only a comment\n\n-- another one;\nDEFINE TABLE t SCHEMALESS;"
+        statements = _parse_schema_statements(sql)
+        assert statements == ["DEFINE TABLE t SCHEMALESS"]
+
+    def test_no_comment_line_leaks_into_any_statement(self) -> None:
+        for stmt in _parse_schema_statements(SCHEMA_SQL):
+            for line in stmt.splitlines():
+                assert not line.strip().startswith("--"), stmt
+
+    def test_every_define_in_the_real_schema_survives_parsing(self) -> None:
+        # Every DEFINE line present in the raw script must reach the executable
+        # statement list — this is exactly the invariant the old parser broke.
+        expected = re.findall(r"^DEFINE [A-Z]+ [^\n;]+", SCHEMA_SQL, flags=re.M)
+        assert expected, "sanity: the schema script contains DEFINE statements"
+        joined = "\n".join(_parse_schema_statements(SCHEMA_SQL))
+        missing = [head for head in expected if head not in joined]
+        assert not missing, f"DEFINE statements dropped by the parser: {missing}"
+
+    def test_fulltext_analyzer_index_and_tables_present(self) -> None:
+        statements = _parse_schema_statements(SCHEMA_SQL)
+        assert any(
+            s.startswith("DEFINE ANALYZER IF NOT EXISTS smem_content") for s in statements
+        ), "the smem_content analyzer must survive parsing (2.7.4 FTS regression)"
+        assert any("idx_neuron_content_fts" in s for s in statements)
+        table_defines = [s for s in statements if s.startswith("DEFINE TABLE ")]
+        assert len(table_defines) >= 26, table_defines
+
+
+class _RecordingConn:
+    """Minimal storage-connection stub recording every executed statement."""
+
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+
+    async def query(self, sql: str) -> None:
+        self.executed.append(sql)
+
+
+class TestEnsureSchemaExecution:
+    async def test_analyzer_fts_index_and_tables_reach_the_connection(self) -> None:
+        conn = _RecordingConn()
+        await ensure_schema(conn, embedding_dim=1024)
+        joined = "\n".join(conn.executed)
+        assert "DEFINE ANALYZER IF NOT EXISTS smem_content" in joined
+        assert "idx_neuron_content_fts" in joined
+        assert "DEFINE TABLE neuron SCHEMAFULL" in joined
+        assert "HNSW DIMENSION 1024" in joined
+
+    async def test_a_failing_statement_does_not_abort_the_rest(self) -> None:
+        class _FlakyConn(_RecordingConn):
+            async def query(self, sql: str) -> None:
+                await super().query(sql)
+                if "DEFINE TABLE neuron " in sql:
+                    raise RuntimeError("The table 'neuron' already exists")
+
+        conn = _FlakyConn()
+        await ensure_schema(conn, embedding_dim=1024)
+        # Statements after the failing one still execute — including the
+        # analyzer-dependent FULLTEXT index.
+        assert any("idx_neuron_content_fts" in s for s in conn.executed)


### PR DESCRIPTION
Hi Toni!

First things first: the 2.7.4 recall work is superb. We rebased our fork onto it the moment it landed — the swarm's memory engine has been humming along beautifully on surreal-memory + SurrealDB 3.2.0, and it is genuinely delightful how often our choices converge: same database, same appetite for its newest capabilities (the BM25 FULLTEXT machinery in #54 is exactly the kind of feature adoption we love to see), and even the same conclusion on embeddings — we also ended up on BGE-M3 with the community's favourite reranker beside it, which for a self-hosted, sovereignty-minded stack still feels like the SOTA sweet spot. Great minds, and all that.

Whilst bringing 2.7.4 into production we hit two things I'd rather hand you as finished work than as bug reports. Knowing the pace you ship at, you'd have found and fixed both within days — but hardening the engine we both depend on seemed like the friendliest possible reason to jump the queue, and I'm glad to lay a small brick of my own onto the impressive thing you're building. From an AI-security standpoint both issues are the quiet kind — no crashes, no errors, everything green — which is precisely what makes them worth killing quickly.

## 1. `ensure_schema` silently drops DDL that sits under a comment block — so the 2.7.4 FULLTEXT analyzer never gets created

**Mechanism.** `ensure_schema` splits `SCHEMA_SQL` on `";"` and discards any chunk whose stripped text *starts* with `--`. Any statement that sits directly beneath an explanatory comment block therefore lives in a chunk that begins with a comment — and is dropped wholesale before it ever reaches the connection. In the current script that silently discards **all 26 `DEFINE TABLE` statements** and, since 2.7.4, the **`smem_content` analyzer**. The follow-up `DEFINE INDEX idx_neuron_content_fts … FULLTEXT ANALYZER smem_content BM25` then fails ("analyzer not found") and the bare `except: pass` in the apply loop swallows the evidence.

**Impact.** Since #54 switched `find_neurons` from `CONTAINS` to `@@`, and `@@` without its index simply matches nothing, **keyword/entity content matching returns zero rows on any database that relies on `ensure_schema`** — i.e. every MCP/CLI deployment. No error, no log line; recall's keyword path is just quietly gone. (Your station presumably has the index because you created it by hand whilst profiling #54 — ours didn't until we did the same.)

**Live verification on our production brain** (~3.1k neurons, BGE-M3 1024-dim, SurrealDB 3.2.0): straight after upgrading, `INFO FOR TABLE neuron` showed no `idx_neuron_content_fts` and `INFO FOR DB` no analyzer, and `content @@ 'uruboros'` returned 0 rows. After applying the two DDL statements manually: **146 rows in 22 ms** — your #54 speed-up is every bit as good as advertised once the index actually exists, which is rather the point of this patch.

**The bug is older than #54** — the chunk filter dates back to #28 — but it was latent while everything it dropped already existed in everyone's databases. The analyzer is the first critical DDL delivered *only* through this path, which is what armed it.

**Fix.** Strip comment *lines* inside each chunk rather than discarding whole chunks (`_parse_schema_statements()`, now a named, testable function), and stop the apply loop from swallowing failures invisibly: an `AlreadyExists` re-`DEFINE` — expected on every start — logs at debug, anything else at warning. Behaviour is otherwise unchanged, and bare re-`DEFINE`s on existing tables still fail safely with `AlreadyExists` (verified against 3.2.0: fields and rows untouched).

**Tests** (`tests/unit/test_schema_statement_parser.py`): a regression pin that *every* `DEFINE` present in the raw script survives parsing; that a statement under a comment block survives; that no comment line leaks into an executable statement; and an `ensure_schema` run against a recording stub asserting the analyzer, the FTS index, `DEFINE TABLE neuron` and the parameterised HNSW dimension all actually reach the connection — plus one asserting a failing statement doesn't abort the rest.

## 2. The unit suite hangs forever after a green summary — test fixtures leak aiosqlite worker threads

**Mechanism.** aiosqlite runs every connection on a dedicated **non-daemon** worker thread that blocks on its queue until `close()` delivers the stop sentinel. A good number of fixtures build a `SQLiteStorage`, `await storage.initialize()`, and never close it (e.g. the `store` fixture in `test_alerts.py`). Instrumenting `aiosqlite.Connection.__init__` across a full run counts **1,223 connections created and 316 still alive at sessionfinish**. The garbage collector rescues most of them mid-run, but anything still referenced at interpreter exit gets joined in `threading._shutdown` — which runs *before* final GC — so pytest prints its green summary and then sits there for ever. (We found one such process on our station that had been "finishing" for two and a half days.) The stray `RuntimeError: Event loop is closed` warnings sprinkled through the suite are the same leak, delivering late results onto closed per-test loops.

**Impact.** Any CI or automation that waits on the pytest exit code hangs despite a perfectly green run — the failure mode looks like flaky infrastructure rather than what it is.

**Fix.** A single autouse fixture in `tests/conftest.py` tracks connections opened during each test and stops any stragglers at teardown (`Connection.stop()` enqueues the sentinel without needing an event loop, so a synchronous fixture handles it cleanly). No changes to production code and none to well-behaved tests; properly closed connections are untouched.

**Tests** (`tests/unit/test_aiosqlite_leak_guard.py`): one test leaks a connection on purpose, the next asserts the guard stopped its worker thread, and a third pins that a properly closed connection is left alone.

## Verification

- Full unit suite on this branch: **5,817 passed, 33 skipped in ~30 s** — and, for the first time in a while, **the process actually exits** (31 s wall, end to end, no kill required). The `Event loop is closed` warnings are gone too.
- `ruff check` / `ruff format` clean; `mypy --strict` clean on the touched source file.
- Live-DB checks against SurrealDB 3.2.0 as above (analyzer + FTS index created; `@@` fast and correct; bare re-`DEFINE` on existing tables safely rejected with `AlreadyExists`).

Both fixes are deliberately tiny and surgical. Between your #54 and the parser fix here, deep recall on a big brain goes from flirting with the MCP client's 30-second ceiling to comfortably index-backed end-to-end — for everyone, out of the box, which is exactly where a sovereign, self-hosted memory stack ought to be.

As ever — run the suite with suspicion and tell me if you'd like anything reshaped. It's a pleasure watching this engine mature at the speed you're driving it.

Robert
