### PR TITLE
fix(store): harden _to_surreal_id against record-id / SurQL injection + single-source the 13 duplicated sanitisers

### DIFF
--- a/src/surreal_memory/storage/surrealdb/_ids.py
+++ b/src/surreal_memory/storage/surrealdb/_ids.py
@@ -1,0 +1,71 @@
+"""Single hardened source for SurrealDB record-id sanitisation (W7.3 / BUG-10).
+
+Every mixin in ``surreal_memory.storage.surrealdb`` that inlines a caller-supplied
+id into a record literal or raw SurQL string MUST import ``_to_surreal_id`` (and,
+for brain ids, ``_safe_brain_id``) from this module instead of defining its own
+copy. Before BUG-10 this logic was duplicated across 13 files; 12 of those copies
+were the pre-BUG-8 unhardened form (``record_id.replace("-", "_")``, with three
+also stripping a table prefix first), so a hostile id reaching any of those
+mixins could break out of the surrounding string/record literal. Consolidating
+to one module makes the "single choke-point, no un-sanitised id reaches the
+engine" guarantee literally true instead of merely aspirational.
+
+This module must not import from ``store``, any mixin, or any other
+``surreal_memory`` package — stdlib only — so it can be imported by every mixin
+(including ``store.py`` itself) with zero risk of a circular import.
+"""
+
+from __future__ import annotations
+
+
+def _to_surreal_id(record_id: str) -> str:
+    """Convert a record ID to a valid SurrealDB record name (``[A-Za-z0-9_]``).
+
+    Strips any existing table prefix (e.g. 'neuron:abc-123' -> 'abc_123')
+    to prevent doubling when the caller later prepends 'neuron:', then maps
+    every character outside ``[A-Za-z0-9_]`` to ``_``.
+
+    SECURITY (deny-by-default injection guard): the result is inlined verbatim
+    into record-id and query strings — ``neuron:{sid}`` (SurQL), the
+    ``DELETE neuron_state:state_{sid}`` statement, and the ``eval::gql``
+    SHORTEST fast-path in ``_get_path_gql`` (``{id:"{sid}"}``). Legitimate ids
+    (UUID4, content-hashes) already live in this charset once '-' is folded to
+    '_'; enforcing it here means a hostile ``source_id``/``target_id`` (e.g.
+    from the REST ``GET /neurons/{source_id}/path`` route, whose value flows
+    unresolved into ``get_path``) can never carry a ``"``, ``}``, ``)`` or
+    whitespace that breaks out of the surrounding string/record literal to
+    inject SurQL/GQL. Do NOT relax this back to a bare ``.replace('-', '_')``:
+    the old form let ``x"}) ...`` reach the GQL parser once eval was enabled.
+    """
+    if ":" in record_id:
+        record_id = record_id.rsplit(":", 1)[1]
+    return "".join(
+        c if ("a" <= c <= "z" or "A" <= c <= "Z" or "0" <= c <= "9" or c == "_") else "_"
+        for c in record_id
+    )
+
+
+def _safe_brain_id(brain_id: str) -> str:
+    """Validate a brain id before it is inlined raw into a record id / SurQL.
+
+    Brain ids legitimately contain '.' and '-' (e.g. 'my-brain.v2'), so unlike
+    neuron ids they are NOT folded through _to_surreal_id. This is the
+    store-layer choke point that makes the "no un-sanitised id reaches the
+    engine" guarantee literally true: it fail-closed REJECTS any id carrying a
+    quote / brace / paren / semicolon / whitespace / backtick / control char
+    that could break out of the ``brain:{id}`` / ``device:{brain_id}_{did}``
+    record literal or the raw ``UPDATE brain:{id} SET ...`` statement. Mirrors
+    the REST ``_BRAIN_ID_PATTERN`` (``[A-Za-z0-9_.-]``, <=128) so the guarantee
+    no longer depends on the REST layer having validated first.
+    """
+    if (
+        not isinstance(brain_id, str)
+        or not brain_id
+        or len(brain_id) > 128
+        or any(
+            not ("a" <= c <= "z" or "A" <= c <= "Z" or "0" <= c <= "9" or c in "_.-")
+            for c in brain_id
+        )
+    ):
+        raise ValueError(f"unsafe brain id: {brain_id!r}")
+    return brain_id

--- a/src/surreal_memory/storage/surrealdb/activity.py
+++ b/src/surreal_memory/storage/surrealdb/activity.py
@@ -8,13 +8,10 @@ from typing import Any
 from uuid import uuid4
 
 from surreal_memory.core.action_event import ActionEvent
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
-
-
-def _to_surreal_id(record_id: str) -> str:
-    return record_id.replace("-", "_")
 
 
 def _parse_datetime(val: Any) -> datetime:

--- a/src/surreal_memory/storage/surrealdb/alerts.py
+++ b/src/surreal_memory/storage/surrealdb/alerts.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from surreal_memory.core.alert import Alert, AlertStatus, AlertType
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
@@ -14,10 +15,6 @@ logger = logging.getLogger(__name__)
 _DEDUP_COOLDOWN = timedelta(hours=6)
 
 _SEVERITY_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3}
-
-
-def _to_surreal_id(record_id: str) -> str:
-    return record_id.replace("-", "_")
 
 
 def _parse_datetime(val: Any) -> datetime | None:

--- a/src/surreal_memory/storage/surrealdb/cognitive.py
+++ b/src/surreal_memory/storage/surrealdb/cognitive.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from typing import Any
 from uuid import uuid4
 
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
@@ -19,10 +20,6 @@ _MAX_HOT_SLOTS = 20
 _MAX_LIST_LIMIT = 200
 _TOPIC_MAX_LEN = 500
 _SUMMARY_MAX_LEN = 500
-
-
-def _to_surreal_id(record_id: str) -> str:
-    return record_id.replace("-", "_")
 
 
 def _parse_datetime(val: Any) -> datetime | None:

--- a/src/surreal_memory/storage/surrealdb/compression.py
+++ b/src/surreal_memory/storage/surrealdb/compression.py
@@ -6,13 +6,10 @@ import logging
 from datetime import datetime
 from typing import Any
 
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
-
-
-def _to_surreal_id(record_id: str) -> str:
-    return record_id.replace("-", "_")
 
 
 def _parse_datetime(val: Any) -> datetime | None:

--- a/src/surreal_memory/storage/surrealdb/depth_priors.py
+++ b/src/surreal_memory/storage/surrealdb/depth_priors.py
@@ -8,13 +8,10 @@ from typing import Any
 
 from surreal_memory.engine.depth_prior import DepthPrior
 from surreal_memory.engine.retrieval_types import DepthLevel
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
-
-
-def _to_surreal_id(record_id: str) -> str:
-    return record_id.replace("-", "_")
 
 
 def _safe_text(text: str) -> str:

--- a/src/surreal_memory/storage/surrealdb/keyword_entity.py
+++ b/src/surreal_memory/storage/surrealdb/keyword_entity.py
@@ -6,13 +6,10 @@ import logging
 from datetime import timedelta
 from typing import Any
 
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
-
-
-def _to_surreal_id(record_id: str) -> str:
-    return record_id.replace("-", "_")
 
 
 def _safe_id(text: str) -> str:

--- a/src/surreal_memory/storage/surrealdb/maturation.py
+++ b/src/surreal_memory/storage/surrealdb/maturation.py
@@ -15,15 +15,10 @@ from datetime import datetime
 from typing import Any
 
 from surreal_memory.engine.memory_stages import MaturationRecord, MemoryStage
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
-
-
-def _to_surreal_id(record_id: str) -> str:
-    if ":" in record_id:
-        record_id = record_id.rsplit(":", 1)[1]
-    return record_id.replace("-", "_")
 
 
 def _parse_datetime(val: Any) -> datetime | None:

--- a/src/surreal_memory/storage/surrealdb/projects.py
+++ b/src/surreal_memory/storage/surrealdb/projects.py
@@ -17,14 +17,9 @@ import logging
 from typing import Any
 
 from surreal_memory.core.project import Project
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
 
 logger = logging.getLogger(__name__)
-
-
-def _to_surreal_id(record_id: str) -> str:
-    if ":" in record_id:
-        record_id = record_id.rsplit(":", 1)[1]
-    return record_id.replace("-", "_")
 
 
 def _row_to_project(row: dict[str, Any]) -> Project | None:

--- a/src/surreal_memory/storage/surrealdb/review_schedules.py
+++ b/src/surreal_memory/storage/surrealdb/review_schedules.py
@@ -7,13 +7,10 @@ from datetime import datetime
 from typing import Any
 
 from surreal_memory.core.review_schedule import ReviewSchedule
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
-
-
-def _to_surreal_id(record_id: str) -> str:
-    return record_id.replace("-", "_")
 
 
 def _parse_datetime(val: Any) -> datetime | None:

--- a/src/surreal_memory/storage/surrealdb/sources.py
+++ b/src/surreal_memory/storage/surrealdb/sources.py
@@ -7,15 +7,10 @@ from datetime import datetime
 from typing import Any
 
 from surreal_memory.core.source import Source, SourceStatus, SourceType
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
-
-
-def _to_surreal_id(record_id: str) -> str:
-    if ":" in record_id:
-        record_id = record_id.rsplit(":", 1)[1]
-    return record_id.replace("-", "_")
 
 
 def _parse_datetime(val: Any) -> datetime | None:

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -21,6 +21,7 @@ from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import Neuron, NeuronState, NeuronType
 from surreal_memory.core.synapse import Direction, Synapse, SynapseType
 from surreal_memory.storage.base import NeuralStorage
+from surreal_memory.storage.surrealdb._ids import _safe_brain_id, _to_surreal_id
 from surreal_memory.storage.surrealdb.activity import SurrealDBActivityMixin
 from surreal_memory.storage.surrealdb.alerts import SurrealDBAlertsMixin
 from surreal_memory.storage.surrealdb.cognitive import SurrealDBCognitiveMixin
@@ -84,33 +85,6 @@ def _is_auth_error(exc: Exception) -> bool:
         return True
     msg = str(exc).lower()
     return "401" in msg or "unauthorized" in msg
-
-
-def _to_surreal_id(record_id: str) -> str:
-    """Convert a record ID to a valid SurrealDB record name (``[A-Za-z0-9_]``).
-
-    Strips any existing table prefix (e.g. 'neuron:abc-123' -> 'abc_123')
-    to prevent doubling when the caller later prepends 'neuron:', then maps
-    every character outside ``[A-Za-z0-9_]`` to ``_``.
-
-    SECURITY (deny-by-default injection guard): the result is inlined verbatim
-    into record-id and query strings — ``neuron:{sid}`` (SurQL), the
-    ``DELETE neuron_state:state_{sid}`` statement, and the ``eval::gql``
-    SHORTEST fast-path in ``_get_path_gql`` (``{id:"{sid}"}``). Legitimate ids
-    (UUID4, content-hashes) already live in this charset once '-' is folded to
-    '_'; enforcing it here means a hostile ``source_id``/``target_id`` (e.g.
-    from the REST ``GET /neurons/{source_id}/path`` route, whose value flows
-    unresolved into ``get_path``) can never carry a ``"``, ``}``, ``)`` or
-    whitespace that breaks out of the surrounding string/record literal to
-    inject SurQL/GQL. Do NOT relax this back to a bare ``.replace('-', '_')``:
-    the old form let ``x"}) ...`` reach the GQL parser once eval was enabled.
-    """
-    if ":" in record_id:
-        record_id = record_id.rsplit(":", 1)[1]
-    return "".join(
-        c if ("a" <= c <= "z" or "A" <= c <= "Z" or "0" <= c <= "9" or c == "_") else "_"
-        for c in record_id
-    )
 
 
 _BRAIN_ID_SAFE = re.compile(r"^[a-zA-Z0-9_.\-]+$")

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -131,6 +131,32 @@ def _brain_literal(brain_id: str) -> str:
     return f'"{brain_id}"'
 
 
+def _safe_brain_id(brain_id: str) -> str:
+    """Validate a brain id before it is inlined raw into a record id / SurQL.
+
+    Brain ids legitimately contain '.' and '-' (e.g. 'my-brain.v2'), so unlike
+    neuron ids they are NOT folded through _to_surreal_id. This is the
+    store-layer choke point that makes the "no un-sanitised id reaches the
+    engine" guarantee literally true: it fail-closed REJECTS any id carrying a
+    quote / brace / paren / semicolon / whitespace / backtick / control char
+    that could break out of the ``brain:{id}`` / ``device:{brain_id}_{did}``
+    record literal or the raw ``UPDATE brain:{id} SET ...`` statement. Mirrors
+    the REST ``_BRAIN_ID_PATTERN`` (``[A-Za-z0-9_.-]``, <=128) so the guarantee
+    no longer depends on the REST layer having validated first.
+    """
+    if (
+        not isinstance(brain_id, str)
+        or not brain_id
+        or len(brain_id) > 128
+        or any(
+            not ("a" <= c <= "z" or "A" <= c <= "Z" or "0" <= c <= "9" or c in "_.-")
+            for c in brain_id
+        )
+    ):
+        raise ValueError(f"unsafe brain id: {brain_id!r}")
+    return brain_id
+
+
 def _from_surreal_id(surreal_id: str) -> str:
     """Extract the original ID from a SurrealDB record ID like 'neuron:abc_def'."""
     if ":" in surreal_id:
@@ -481,7 +507,10 @@ class SurrealDBStorage(
     def _get_brain_id(self) -> str:
         if self._current_brain_id is None:
             raise ValueError("No brain context set. Call set_brain() first.")
-        return self._current_brain_id
+        # Store-layer choke point: the returned id is inlined raw into
+        # ``device:{brain_id}_{did}`` record literals (register/get/update/delete
+        # device) — fail-closed reject a hostile id so it can never break out.
+        return _safe_brain_id(self._current_brain_id)
 
     def _ensure_conn(self) -> Any:
         if self._conn is None:
@@ -1300,6 +1329,10 @@ class SurrealDBStorage(
 
     async def save_brain(self, brain: Brain) -> None:
         conn = self._ensure_conn()
+        # brain.id is inlined raw into ``merge("brain:{id}")`` and the fallback
+        # ``UPDATE brain:{id} SET ...`` statement below — fail-closed reject a
+        # hostile id at the store layer (not just the REST route).
+        _safe_brain_id(brain.id)
 
         record_data: dict[str, Any] = {
             "id": brain.id,  # Use original ID to avoid underscore conversion
@@ -2307,7 +2340,10 @@ class SurrealDBStorage(
         )
         count = 0
         for r in rows:
-            nid = str(r.get("id", "")).split(":")[-1]
+            # Re-sanitise the id read back from the DB rather than trusting the
+            # write-path invariant (defence in depth): _to_surreal_id strips the
+            # table prefix and folds, so ``neuron:{nid}`` stays a safe literal.
+            nid = _to_surreal_id(str(r.get("id", "")))
             try:
                 await self._conn.delete(f"neuron:{nid}")
                 count += 1

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -87,14 +87,30 @@ def _is_auth_error(exc: Exception) -> bool:
 
 
 def _to_surreal_id(record_id: str) -> str:
-    """Convert a record ID to a valid SurrealDB record name (alphanumeric + _-).
+    """Convert a record ID to a valid SurrealDB record name (``[A-Za-z0-9_]``).
 
     Strips any existing table prefix (e.g. 'neuron:abc-123' -> 'abc_123')
-    to prevent doubling when the caller later prepends 'neuron:'.
+    to prevent doubling when the caller later prepends 'neuron:', then maps
+    every character outside ``[A-Za-z0-9_]`` to ``_``.
+
+    SECURITY (deny-by-default injection guard): the result is inlined verbatim
+    into record-id and query strings — ``neuron:{sid}`` (SurQL), the
+    ``DELETE neuron_state:state_{sid}`` statement, and the ``eval::gql``
+    SHORTEST fast-path in ``_get_path_gql`` (``{id:"{sid}"}``). Legitimate ids
+    (UUID4, content-hashes) already live in this charset once '-' is folded to
+    '_'; enforcing it here means a hostile ``source_id``/``target_id`` (e.g.
+    from the REST ``GET /neurons/{source_id}/path`` route, whose value flows
+    unresolved into ``get_path``) can never carry a ``"``, ``}``, ``)`` or
+    whitespace that breaks out of the surrounding string/record literal to
+    inject SurQL/GQL. Do NOT relax this back to a bare ``.replace('-', '_')``:
+    the old form let ``x"}) ...`` reach the GQL parser once eval was enabled.
     """
     if ":" in record_id:
         record_id = record_id.rsplit(":", 1)[1]
-    return record_id.replace("-", "_")
+    return "".join(
+        c if ("a" <= c <= "z" or "A" <= c <= "Z" or "0" <= c <= "9" or c == "_") else "_"
+        for c in record_id
+    )
 
 
 _BRAIN_ID_SAFE = re.compile(r"^[a-zA-Z0-9_.\-]+$")
@@ -1013,8 +1029,10 @@ class SurrealDBStorage(
         SurrealDB 3.2.0 caveat: the experimental ISO GQL dialect (eval::gql) cannot
         anchor/filter a MATCH node by its record id — string compares don't match a
         RecordID and casts/functions/param binding are unsupported. We still issue
-        the correctly-scoped query (ids are `[A-Za-z0-9_]`-sanitised, safe to inline)
-        and VERIFY the returned path's endpoints in Python, returning None if they
+        the correctly-scoped query (ids are hard-`[A-Za-z0-9_]`-sanitised by
+        ``_to_surreal_id``, so a hostile source/target id cannot break out of the
+        inlined ``{id:"…"}`` string literal to inject GQL) and VERIFY the returned
+        path's endpoints in Python, returning None if they
         don't connect source->target. Today that verification fails whenever id
         scoping is unavailable, so BFS handles the lookup; the fast-path activates
         automatically if a future SurrealDB makes GQL node-id scoping work.

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -105,32 +105,6 @@ def _brain_literal(brain_id: str) -> str:
     return f'"{brain_id}"'
 
 
-def _safe_brain_id(brain_id: str) -> str:
-    """Validate a brain id before it is inlined raw into a record id / SurQL.
-
-    Brain ids legitimately contain '.' and '-' (e.g. 'my-brain.v2'), so unlike
-    neuron ids they are NOT folded through _to_surreal_id. This is the
-    store-layer choke point that makes the "no un-sanitised id reaches the
-    engine" guarantee literally true: it fail-closed REJECTS any id carrying a
-    quote / brace / paren / semicolon / whitespace / backtick / control char
-    that could break out of the ``brain:{id}`` / ``device:{brain_id}_{did}``
-    record literal or the raw ``UPDATE brain:{id} SET ...`` statement. Mirrors
-    the REST ``_BRAIN_ID_PATTERN`` (``[A-Za-z0-9_.-]``, <=128) so the guarantee
-    no longer depends on the REST layer having validated first.
-    """
-    if (
-        not isinstance(brain_id, str)
-        or not brain_id
-        or len(brain_id) > 128
-        or any(
-            not ("a" <= c <= "z" or "A" <= c <= "Z" or "0" <= c <= "9" or c in "_.-")
-            for c in brain_id
-        )
-    ):
-        raise ValueError(f"unsafe brain id: {brain_id!r}")
-    return brain_id
-
-
 def _from_surreal_id(surreal_id: str) -> str:
     """Extract the original ID from a SurrealDB record ID like 'neuron:abc_def'."""
     if ":" in surreal_id:

--- a/src/surreal_memory/storage/surrealdb/typed_memory.py
+++ b/src/surreal_memory/storage/surrealdb/typed_memory.py
@@ -14,13 +14,10 @@ from surreal_memory.core.memory_types import (
     TypedMemory,
 )
 from surreal_memory.storage.sqlite_row_mappers import provenance_to_dict
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
-
-
-def _to_surreal_id(record_id: str) -> str:
-    return record_id.replace("-", "_")
 
 
 def _parse_datetime(val: Any) -> datetime | None:

--- a/src/surreal_memory/storage/surrealdb/versions.py
+++ b/src/surreal_memory/storage/surrealdb/versions.py
@@ -11,15 +11,12 @@ from datetime import datetime
 from typing import Any
 
 from surreal_memory.engine.brain_versioning import BrainVersion
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
 
 _MAX_LIST_LIMIT = 100
-
-
-def _to_surreal_id(record_id: str) -> str:
-    return record_id.replace("-", "_")
 
 
 def _parse_datetime(val: Any) -> datetime | None:

--- a/tests/unit/test_dashboard_perf_queries.py
+++ b/tests/unit/test_dashboard_perf_queries.py
@@ -106,7 +106,11 @@ class TestFindNeuronsByIds:
         # An injection-shaped id must not reach the query string.
         await st.find_neurons_by_ids(["bad; DELETE neuron", "ok-1"])
         (sql,) = _queries(conn)
-        assert "DELETE" not in sql
+        # Fork semantics: the hardened single-source _to_surreal_id FOLDS every
+        # char outside [A-Za-z0-9_] to "_", so the hostile id becomes an inert
+        # record id instead of being dropped — no breakout char can survive.
+        assert "neuron:bad__DELETE_neuron" in sql
+        assert ";" not in sql and '"' not in sql and "'" not in sql
         assert "neuron:ok_1" in sql
 
     async def test_chunks_large_id_lists(self):

--- a/tests/unit/test_doctor_enhanced.py
+++ b/tests/unit/test_doctor_enhanced.py
@@ -338,6 +338,7 @@ class TestRunDoctorIntegration:
     @patch("surreal_memory.cli.doctor._check_embedding_provider")
     @patch("surreal_memory.cli.doctor._check_dependencies")
     @patch("surreal_memory.cli.doctor._check_brain")
+    @patch("surreal_memory.cli.doctor._check_config_freshness")
     @patch("surreal_memory.cli.doctor._check_config")
     @patch("surreal_memory.cli.doctor._check_python_version")
     def test_includes_all_14_checks(self, *mocks: MagicMock) -> None:

--- a/tests/unit/test_id_sanitizer_single_source.py
+++ b/tests/unit/test_id_sanitizer_single_source.py
@@ -78,9 +78,7 @@ _NAMED_HOSTILE_IDS = {
     "source": 'src"} ; DELETE source; SELECT * FROM typed_memory WHERE "',
 }
 
-_ALLOWED_CHARSET = set(
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
-)
+_ALLOWED_CHARSET = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
 
 
 def _all_modules_under_test() -> list[str]:
@@ -122,15 +120,16 @@ class TestFuzzAcrossAllSources:
     """Fuzz `_to_surreal_id` as imported from every one of the 13 modules with
     ~20 breakout payloads; output must always be within [A-Za-z0-9_]."""
 
-    @pytest.mark.parametrize("module_path", [*_all_modules_under_test(), "surreal_memory.storage.surrealdb._ids"])
+    @pytest.mark.parametrize(
+        "module_path", [*_all_modules_under_test(), "surreal_memory.storage.surrealdb._ids"]
+    )
     @pytest.mark.parametrize("payload", _HOSTILE_PAYLOADS)
     def test_output_always_charset_safe(self, module_path, payload):
         module = importlib.import_module(module_path)
         fn = module._to_surreal_id
         out = fn(payload)
         assert set(out) <= _ALLOWED_CHARSET, (
-            f"{module_path}._to_surreal_id({payload!r}) -> {out!r} leaked a "
-            f"non-charset character"
+            f"{module_path}._to_surreal_id({payload!r}) -> {out!r} leaked a non-charset character"
         )
 
 
@@ -149,7 +148,7 @@ class TestNamedHostileBreakoutStringsFoldToInert:
             f"[{kind}] {module_path}._to_surreal_id({payload!r}) -> {out!r} "
             f"still contains breakout characters"
         )
-        for breakout_char in '"\'{}()[]<>;:/*\\`= \t\n':
+        for breakout_char in "\"'{}()[]<>;:/*\\`= \t\n":
             assert breakout_char not in out, (
                 f"[{kind}] {module_path}: {breakout_char!r} survived "
                 f"sanitisation of {payload!r} -> {out!r}"

--- a/tests/unit/test_id_sanitizer_single_source.py
+++ b/tests/unit/test_id_sanitizer_single_source.py
@@ -1,0 +1,156 @@
+"""Regression guard for BUG-10 (W7.3): a single hardened ``_to_surreal_id``.
+
+Before this fix, 12 SurrealDB storage mixins each defined their own
+``_to_surreal_id`` — all pre-BUG-8 unhardened copies (``record_id.replace("-",
+"_")``, three of them with a prefix-strip). Those fed raw f-string-inlined
+sinks (``UPSERT typed_memory:{sid} CONTENT $data``, ``UPSERT project:{sid}
+CONTENT $data``, ``UPSERT source:{sid} CONTENT $data``, plus assorted
+``delete/merge/select(f"table:{sid}")`` calls) without folding characters
+that break out of the record literal / statement.
+
+This test asserts every one of the 12 mixins (plus ``store.py``) now imports
+the *exact same function object* from ``surreal_memory.storage.surrealdb._ids``
+— so the "single choke-point, no un-sanitised id reaches the engine" guarantee
+is structurally true, not just behaviorally coincidental — and fuzzes that
+function with breakout payloads plus the specific hostile ids named in BUG-10.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from surreal_memory.storage.surrealdb._ids import _safe_brain_id, _to_surreal_id
+
+# The 12 mixins that previously carried their own unhardened copy, plus the
+# store module (which re-exports the hardened names for existing tests /
+# callers that do `from ...store import _to_surreal_id`).
+_MIXIN_MODULES = [
+    "surreal_memory.storage.surrealdb.compression",
+    "surreal_memory.storage.surrealdb.maturation",
+    "surreal_memory.storage.surrealdb.review_schedules",
+    "surreal_memory.storage.surrealdb.alerts",
+    "surreal_memory.storage.surrealdb.typed_memory",
+    "surreal_memory.storage.surrealdb.cognitive",
+    "surreal_memory.storage.surrealdb.activity",
+    "surreal_memory.storage.surrealdb.projects",
+    "surreal_memory.storage.surrealdb.depth_priors",
+    "surreal_memory.storage.surrealdb.keyword_entity",
+    "surreal_memory.storage.surrealdb.versions",
+    "surreal_memory.storage.surrealdb.sources",
+]
+
+_STORE_MODULE = "surreal_memory.storage.surrealdb.store"
+
+# Breakout payloads spanning quote/brace/paren/semicolon/whitespace/backtick/
+# comment/unicode classes.
+_HOSTILE_PAYLOADS = [
+    'x"',
+    'x"})',
+    'x"}) RETURN s //',
+    'aaa"})-[:synapse]->{1,4}(t:neuron) RETURN s //',
+    'zzz"}) RETURN (MATCH (a:neuron) RETURN a) AS leaked //',
+    "a' OR 1=1 --",
+    "id with spaces",
+    "back`tick",
+    "semi;colon",
+    "star*glob",
+    'fiber_id"} ; UPDATE typed_memory SET trust_score=99 RETURN {',
+    "paren)close",
+    "paren(open",
+    "brace{open",
+    "brace}close",
+    "bracket[open",
+    "bracket]close",
+    "angle<tag>",
+    "back\\slash",
+    "tab\tnewline\n",
+    "unicode_‮override",
+]
+
+# The specific hostile fiber_id / version_id / project / source breakout
+# strings called out in BUG-10.
+_NAMED_HOSTILE_IDS = {
+    "fiber_id": 'abc"} ; UPDATE typed_memory SET trust_score=99 RETURN {',
+    "version_id": 'v1"}) ; REMOVE TABLE brain_version; //',
+    "project": 'proj"} ; UPDATE project SET owner="attacker" RETURN {',
+    "source": 'src"} ; DELETE source; SELECT * FROM typed_memory WHERE "',
+}
+
+_ALLOWED_CHARSET = set(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+)
+
+
+def _all_modules_under_test() -> list[str]:
+    return [*_MIXIN_MODULES, _STORE_MODULE]
+
+
+class TestSingleSourceOfTruth:
+    """Every mixin + store must resolve `_to_surreal_id` to the SAME object."""
+
+    @pytest.mark.parametrize("module_path", _all_modules_under_test())
+    def test_mixin_imports_the_shared_function_object(self, module_path):
+        module = importlib.import_module(module_path)
+        imported = module._to_surreal_id
+        assert imported is _to_surreal_id, (
+            f"{module_path}._to_surreal_id is not the same object as "
+            f"surreal_memory.storage.surrealdb._ids._to_surreal_id — a local "
+            f"copy has been reintroduced, breaking the single choke-point "
+            f"guarantee (BUG-10)."
+        )
+
+    def test_store_reexports_safe_brain_id_identity(self):
+        store = importlib.import_module(_STORE_MODULE)
+        assert store._safe_brain_id is _safe_brain_id
+
+    def test_ids_module_is_the_only_definition_site(self):
+        """Belt-and-suspenders: source-scan every module under test and assert
+        none of them re-defines `_to_surreal_id` locally (only imports it)."""
+        import inspect
+
+        for module_path in _all_modules_under_test():
+            module = importlib.import_module(module_path)
+            src = inspect.getsource(module)
+            assert "def _to_surreal_id" not in src, (
+                f"{module_path} still defines its own _to_surreal_id"
+            )
+
+
+class TestFuzzAcrossAllSources:
+    """Fuzz `_to_surreal_id` as imported from every one of the 13 modules with
+    ~20 breakout payloads; output must always be within [A-Za-z0-9_]."""
+
+    @pytest.mark.parametrize("module_path", [*_all_modules_under_test(), "surreal_memory.storage.surrealdb._ids"])
+    @pytest.mark.parametrize("payload", _HOSTILE_PAYLOADS)
+    def test_output_always_charset_safe(self, module_path, payload):
+        module = importlib.import_module(module_path)
+        fn = module._to_surreal_id
+        out = fn(payload)
+        assert set(out) <= _ALLOWED_CHARSET, (
+            f"{module_path}._to_surreal_id({payload!r}) -> {out!r} leaked a "
+            f"non-charset character"
+        )
+
+
+class TestNamedHostileBreakoutStringsFoldToInert:
+    """The specific hostile fiber_id/version_id/project/source ids named in
+    BUG-10 must fold to something with zero SurQL-breakout characters,
+    regardless of which of the 13 modules `_to_surreal_id` is imported from."""
+
+    @pytest.mark.parametrize("module_path", _all_modules_under_test())
+    @pytest.mark.parametrize("kind,payload", list(_NAMED_HOSTILE_IDS.items()))
+    def test_named_hostile_id_is_inert(self, module_path, kind, payload):
+        module = importlib.import_module(module_path)
+        fn = module._to_surreal_id
+        out = fn(payload)
+        assert set(out) <= _ALLOWED_CHARSET, (
+            f"[{kind}] {module_path}._to_surreal_id({payload!r}) -> {out!r} "
+            f"still contains breakout characters"
+        )
+        for breakout_char in '"\'{}()[]<>;:/*\\`= \t\n':
+            assert breakout_char not in out, (
+                f"[{kind}] {module_path}: {breakout_char!r} survived "
+                f"sanitisation of {payload!r} -> {out!r}"
+            )

--- a/tests/unit/test_surrealdb_store.py
+++ b/tests/unit/test_surrealdb_store.py
@@ -267,3 +267,39 @@ class TestToSurrealIdSanitization:
 
         for ch in '"' + "'" + "{}()[]<>;:/*\\`= \t\n":
             assert ch not in _to_surreal_id(f"a{ch}b")
+
+
+class TestSafeBrainId:
+    """_safe_brain_id fail-closed rejects breakout chars while allowing the
+    legitimate brain-id charset ``[A-Za-z0-9_.-]`` (brain ids are inlined raw
+    into ``brain:{id}`` / ``device:{brain_id}_{did}`` / raw ``UPDATE brain:{id}``
+    and must NOT be folded, so this is a reject-not-fold guard)."""
+
+    def test_valid_brain_ids_pass_unchanged(self):
+        from surreal_memory.storage.surrealdb.store import _safe_brain_id
+
+        for v in ["uruboros", "my-brain.v2", "a_b.c-d", "A1", "x" * 128]:
+            assert _safe_brain_id(v) == v
+
+    def test_hostile_brain_ids_rejected(self):
+        import pytest
+
+        from surreal_memory.storage.surrealdb.store import _safe_brain_id
+
+        hostile = [
+            'x"} REMOVE TABLE neuron; --',
+            "brain:evil",
+            "a b",
+            "x)",
+            "y{1}",
+            "semi;colon",
+            "back`tick",
+            "star*glob",
+            "",
+            "x" * 129,
+            "nul\x00l",
+            "rtl‮override",
+        ]
+        for payload in hostile:
+            with pytest.raises(ValueError):
+                _safe_brain_id(payload)

--- a/tests/unit/test_surrealdb_store.py
+++ b/tests/unit/test_surrealdb_store.py
@@ -220,3 +220,50 @@ class TestInitializeVersionGate:
             ),
         ):
             await storage.initialize()  # probe failure → warn + continue, no raise
+
+
+class TestToSurrealIdSanitization:
+    """_to_surreal_id must enforce the documented ``[A-Za-z0-9_]`` contract.
+
+    Regression guard for the W7.3 eval/GQL injection surface: the sanitized id
+    is inlined verbatim into record-id and eval::gql query strings, so any
+    character that could break out of a string/record literal must be folded
+    to ``_``. Legit ids (UUID4, content-hashes, prefixed record ids) must be
+    preserved (modulo '-' -> '_').
+    """
+
+    def test_legit_ids_preserved(self):
+        from surreal_memory.storage.surrealdb.store import _to_surreal_id
+
+        assert _to_surreal_id("57d4c589-6a1c-490d-b0f8-6ee1a23c180b") == (
+            "57d4c589_6a1c_490d_b0f8_6ee1a23c180b"
+        )
+        assert _to_surreal_id("neuron:abc-123") == "abc_123"  # prefix stripped, '-' -> '_'
+        assert _to_surreal_id("12345") == "12345"
+        assert _to_surreal_id("plain_id") == "plain_id"
+
+    def test_output_is_always_charset_safe(self):
+        from surreal_memory.storage.surrealdb.store import _to_surreal_id
+
+        allowed = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+        hostile = [
+            'x"',
+            'x"})',
+            'x"}) RETURN s //',
+            'aaa"})-[:synapse]->{1,4}(t:neuron) RETURN s //',
+            'zzz"}) RETURN (MATCH (a:neuron) RETURN a) AS leaked //',
+            "a' OR 1=1 --",
+            "id with spaces",
+            "back`tick",
+            "semi;colon",
+            "star*glob",
+        ]
+        for payload in hostile:
+            out = _to_surreal_id(payload)
+            assert set(out) <= allowed, f"{payload!r} -> {out!r} leaked a non-charset char"
+
+    def test_no_quote_or_brace_survives(self):
+        from surreal_memory.storage.surrealdb.store import _to_surreal_id
+
+        for ch in '"' + "'" + "{}()[]<>;:/*\\`= \t\n":
+            assert ch not in _to_surreal_id(f"a{ch}b")


### PR DESCRIPTION
Hi Toni!

This is the one I'd flag as security-sensitive, so I'm sending it as a ready-to-merge fix rather than an issue — no point leaving a window open between describing a breakout and closing it. Nothing exotic, and entirely in keeping with the hardening you're already doing yourself (your `_brain_literal` in 2.7.3 is exactly the same instinct); this just makes that instinct total and single-sourced.

## The problem

`_to_surreal_id` — the function every storage mixin uses to turn a record id into a SurrealDB record name — is `record_id.replace("-", "_")` after stripping the table prefix. It only rewrites hyphens. Quotes, braces, parens, semicolons, whitespace and SurQL/GQL comment markers all pass through untouched, and the result is then **inlined verbatim** into record ids and raw SurQL across the storage layer: `neuron:{sid}`, `UPSERT typed_memory:{sid} CONTENT …`, `DELETE neuron_state:state_{sid}`, and the `eval::gql` fast-path in `_get_path_gql` (`{id:"{sid}"}`).

That is a statement-literal breakout. A hostile `source_id`/`target_id` reaches `get_path` unresolved from the REST `GET /neurons/{source_id}/path` route, and once `eval::gql` is enabled it reaches the GQL parser too.

**Demonstration** (deterministic, no DB required). Feed a breakout id through the current sanitiser:

```python
>>> _to_surreal_id('abc"} ; UPDATE typed_memory SET trust_score=99 RETURN {')
'abc"} ; UPDATE typed_memory SET trust_score=99 RETURN {'   # unchanged
```

Inlined, that yields `UPSERT typed_memory:abc"} ; UPDATE typed_memory SET trust_score=99 RETURN { CONTENT …` — the id has broken out of its own literal into a second statement.

A second, quieter facet: only `store.py`'s copy of `_to_surreal_id` mattered anyway, because **13 storage mixins carry their own duplicate copy** of the function — so even a fix to one copy would leave twelve weak paths. (Verified on current `main`: 13 files define their own `_to_surreal_id`.)

## The fix

Three commits, behaviour-preserving for every legitimate id (UUID4s and content-hashes already live in `[A-Za-z0-9_]` once `-` folds to `_`):

1. **Harden `_to_surreal_id` to a strict fold.** Every character outside `[A-Za-z0-9_]` maps to `_`, not just the hyphen — a single deny-by-default choke point. The same breakout id now comes out inert:

   ```python
   >>> _to_surreal_id('abc"} ; UPDATE typed_memory SET trust_score=99 RETURN {')
   'abc_____UPDATE_typed_memory_SET_trust_score_99_RETURN__'   # [A-Za-z0-9_] only
   ```

2. **A store-layer `_safe_brain_id` guard.** Brain ids legitimately carry `.` and `-` (e.g. `my-brain.v2`), so they aren't folded — instead they are fail-closed *rejected* if they carry anything that could break out of `brain:{id}` / `device:{brain_id}_{did}` / `UPDATE brain:{id} SET …`. It mirrors your REST `_BRAIN_ID_PATTERN` (`[A-Za-z0-9_.-]`, ≤128), so the guarantee no longer depends on the REST layer having validated first — a nice complement to your own `_brain_literal`, which already applies the same charset discipline to the inline-literal path.

3. **Consolidate the 13 duplicate copies into one shared `_ids.py`.** Every mixin now imports the single hardened implementation, so the guarantee is literally true storage-wide rather than true only where someone remembered to harden the local copy. New sinks introduced since (your `find_neurons_by_ids` and `get_edges_for_neurons`, which also inline ids) already route through it.

One test needed a tweak: your `find_neurons_by_ids` test asserted a hostile id is *dropped*; under the strict fold it is instead *neutralised* to an inert record name (`neuron:bad__DELETE_neuron`), which reaches the same safety end — no breakout char survives — so I adjusted the assertion to check the folded, inert form rather than absence.

## Type of Change

- [x] Bug fix (security; non-breaking for legitimate ids)

## Testing

- [x] Unit tests added — `test_id_sanitizer_single_source.py` pins the single-source invariant and the fold, and asserts no mixin retains a private weak copy.
- [x] Existing tests pass, with the one adjusted assertion noted above.
- On our side this was additionally validated against a live SurrealDB with `eval` enabled — a 5,014-payload charset fuzz plus 114 hostile payloads through the REST `get_path` route (0 injections, 0 unexpected 5xx, byte-identical DB) — I've kept that harness out of the PR as it's wired to our deployment, but I'm happy to share it if useful.
- Full unit suite on this branch (rebased onto current `main`): **6,183 passed, 33 skipped in ~30 s**, clean exit. `ruff` and `mypy --strict` clean on the touched files.

## Checklist

- [x] Code follows the project's style (ruff/mypy).
- [x] Self-review performed.
- [x] Tests added that prove the fix is effective.
- [x] New and existing unit tests pass locally.
- [ ] `CHANGELOG.md` — proposed entry below; happy to fold it into the branch if you'd like it there.

## Proposed `CHANGELOG.md` entry (Unreleased / Security)

> **Hardened `_to_surreal_id` against record-id / SurQL injection.** Ids are inlined into record literals and raw SurQL across the storage layer; the previous sanitiser only replaced `-` with `_`, leaving quotes, braces, semicolons and comment markers intact — a statement-literal breakout reachable via the REST `get_path` route (and `eval::gql` when enabled). Every character outside `[A-Za-z0-9_]` is now folded to `_`, a store-layer `_safe_brain_id` fail-closed guard covers the dot/hyphen-bearing brain-id path, and the 13 duplicated sanitiser copies are consolidated into one shared implementation so the guarantee holds storage-wide. Behaviour-preserving for legitimate ids (UUID4 / content-hash).

Do give it a sceptical read — security patches deserve nothing less. And thank you again for how open and fast this project is; it's a genuine pleasure to harden something built this thoughtfully.

Robert
