### PR TITLE
chore(release): 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0] — 2026-07-11
+
 ### Removed
 
 - **Vietnamese language support and the cross-language "translation" layer.** The

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.0] — 2026-07-11
+
 ### Removed
 
 - **Vietnamese language support and the cross-language "translation" layer**
@@ -20,6 +22,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `[nlp-vi]` extra (`underthesea` / `pyvi`). Embedding-level multilingual recall is
   unaffected — it is a property of the embedding model, not the extraction layer. See
   [architecture/vietnamese-removal.md](architecture/vietnamese-removal.md).
+
+### Fixed
+
+- **Auto-mode keyword/concept extraction** — clause-boundary-aware bigrams and a
+  Polish stop-word set; the Vietnamese stop-word set is gone (English-only).
+- **`SurrealDBStorage` reconnects after a dropped transport**, not only on a 401,
+  so long-lived MCP/CLI clients survive a DB restart instead of returning `-32000`.
+
+### Security
+
+- **Hardened `_to_surreal_id` against record-id / SurQL injection** — every
+  character outside `[A-Za-z0-9_]` is folded to `_`, with a fail-closed
+  `_safe_brain_id` guard, consolidating 13 duplicated sanitisers into one.
 
 ## [2.7.4] — 2026-07-11
 

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.7.4",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "2.7.4",
+      "version": "2.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.7.4",
+  "version": "2.8.0",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "2.7.4",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "2.7.4",
+      "version": "2.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.7.4",
+  "version": "2.8.0",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.7.4"
+version = "2.8.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.7.4"
+__version__ = "2.8.0"
 
 __all__ = [
     "__version__",

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.7.4"
+        assert surreal_memory.__version__ == "2.8.0"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "2.7.4",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "2.7.4",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.7.4",
+  "version": "2.8.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
Release **2.8.0** — version parity bump (2.7.4 → 2.8.0) across `pyproject.toml`, `src/surreal_memory/__init__.py`, `TestVersionBump`, and the three npm `package.json` + `package-lock.json` roots; `[Unreleased]` promoted to `[2.8.0]` in both changelogs.

### Contents since 2.7.4
- **Removed** — Vietnamese language support and the cross-language "translation" layer; extraction is English-only (#60). Includes the dashboard i18n Vietnamese translation + rebuilt served bundle, and a full docs refresh.
- **Fixed** — clause-boundary-aware bigrams + Polish stop-words + auto-mode language-set hygiene (#57); `SurrealDBStorage` reconnects on a dropped transport, not only on a 401 (#59); schema parser no longer drops DDL under comment blocks + leaked aiosqlite threads (#56).
- **Security** — hardened `_to_surreal_id` against record-id / SurQL injection (#58).

### Gate (local)
`ruff check` ✓ · `ruff format --check` (636) ✓ · `mypy` (348) ✓ · `pytest tests/unit -m "not stress"` → 6049 passed · `TestVersionBump` pins 2.8.0 ✓

Merging this, then tagging `v2.8.0` triggers `release.yml` (PyPI + npm + VS Code + ClawHub + GitHub Release).