### PR TITLE
fix(extraction): don't treat prose-with-commas as CSV

### DIFF
--- a/src/surreal_memory/extraction/structure_detector.py
+++ b/src/surreal_memory/extraction/structure_detector.py
@@ -155,9 +155,19 @@ def _detect_csv_row(content: str) -> StructuredContent | None:
         )
         confidence = 0.9
     else:
-        # Single row — columns unnamed
+        # Single row — columns unnamed. This is the ambiguous case that most
+        # often misfires on prose that merely contains commas, so apply a
+        # stricter bar than the header+data case.
         values = [v.strip() for v in lines[0].split(delimiter)]
         if len(values) < 3:
+            return None
+        # Prose guard: real headerless CSV cells are short, token-like values.
+        # A cell that reads like a sentence (long or multi-word free text) means
+        # this is prose with commas, not CSV data — storing it creates spurious
+        # `col_N` entity-cell entries that pollute downstream extraction. The
+        # all-text guard below is not enough on its own: a single date or number
+        # in one cell used to slip prose through.
+        if any(len(v) > 40 or len(v.split()) > 6 for v in values):
             return None
         fields = tuple(
             StructuredField(name=f"col_{i}", value=v, field_type=_detect_field_type(v))

--- a/tests/unit/test_structured_data.py
+++ b/tests/unit/test_structured_data.py
@@ -193,3 +193,24 @@ class TestVerbatimCompressionSkip:
             metadata={"_verbatim": True},
         )
         assert fiber.metadata.get("_verbatim") is True
+
+
+class TestCsvProseGuard:
+    """_detect_csv_row must not treat prose-with-commas as CSV. Such misfires
+    create spurious col_N entity-cell entries from ordinary sentences that
+    happen to contain a date or number in one comma-separated fragment."""
+
+    def test_prose_with_commas_and_a_date_not_csv(self):
+        from surreal_memory.extraction.structure_detector import _detect_csv_row
+
+        prose = (
+            "On 2026-06-26 we reviewed the orchestration architecture, "
+            "swept the extraction path, and rotated the credentials"
+        )
+        assert _detect_csv_row(prose) is None
+
+    def test_short_cell_row_still_detected(self):
+        from surreal_memory.extraction.structure_detector import _detect_csv_row
+
+        # date + number + currency → genuine headerless data row, keep detecting.
+        assert _detect_csv_row("2026-01-01,500,USD") is not None


### PR DESCRIPTION
Hi Toni!

Last of the noise-quality fixes our production usage surfaced — small, but it's a memory-poisoning source that hits anyone feeding free-form text through auto-mode extraction (so, most auto-capture setups).

## The problem

`_detect_csv_row` treats any single line with ≥2 commas and ≥3 fields as a headerless CSV row. The only prose guard rejects the row when **all** fields are plain text — so ordinary prose that happens to contain one date, price or number in any comma-separated fragment slips through. A line like `"Met the team on 2026-01-14, reviewed the roadmap, and signed off the budget"` is stored as `ContentFormat.CSV_ROW` with synthetic `col_0`/`col_1`/… fields, each of which becomes an entity-cell entry. Over time these accumulate and surface in recall as `col_0 | col_1 | col_2 …` garbage — we saw exactly that in our store's recall output.

## The fix

One guard on the headerless branch: if any cell is long (`> 40` chars) or multi-word (`> 6` words), the line is prose, not CSV. Real headerless CSV cells are short, token-like values, so the false-negative risk is negligible — genuine short-cell data rows (dates, numbers, currency) still detect. The existing all-text guard stays; this just closes the "one number rescues the whole prose line" gap in front of it.

## Type of Change
- [x] Bug fix (data quality; non-breaking)

## Testing
- [x] Unit tests added — `TestCsvProseGuard` (2 cases): a prose line with an embedded date is now rejected, and a genuine short-cell row (`2026-01-01,500,USD`) still detects.
- Full unit suite on this branch (rebased on current `main`): **6,082 passed, 33 skipped in ~35 s** (`-n0`), clean exit. `ruff` and `mypy` clean on the touched file.

## Checklist
- [x] Code follows the project's style (ruff/mypy).
- [x] Self-review performed.
- [x] Tests added that prove the fix.
- [ ] `CHANGELOG.md` — proposed entry below; happy to fold it into the branch.

## Optional extra hardening (open to discussion)

If you'd rather be stricter, a headerless single-line row could additionally require ≥2 non-text field types, or its confidence (currently `0.7`) could be dropped below the encode threshold — I kept the change minimal here, but I'm glad to adjust to whatever bar you prefer.

## Proposed `CHANGELOG.md` entry (Unreleased / Fixed)

> **`_detect_csv_row` no longer classifies prose-with-commas as a CSV row.** A single comma-separated line was accepted as headerless CSV whenever any one cell held a date/number, so ordinary sentences were stored with synthetic `col_N` fields that polluted extraction. A prose guard now rejects the row when any cell is long (>40 chars) or multi-word (>6 words); genuine short-cell data rows still detect.

Robert
