### PR TITLE
fix(extraction): treat the en-dash as a clause boundary too, and pin hyphen non-boundary

### DIFF
--- a/src/surreal_memory/extraction/keywords.py
+++ b/src/surreal_memory/extraction/keywords.py
@@ -554,12 +554,13 @@ STOP_WORDS: frozenset[str] = (
 )
 
 # Clause boundary: bigrams never pair words that cross one of these.
-# Em-dash is included — it sets off a parenthetical/separate clause the same as a
-# comma (live-proven: "keywords.py — bigramy" otherwise lets the "py" filename
-# fragment glue onto the next clause's first word). Plain ASCII hyphen is
+# Em-dash (—) and en-dash are both included — each sets off a parenthetical /
+# separate clause the same as a comma (live-proven: "keywords.py — bigramy"
+# otherwise lets the "py" filename fragment glue onto the next clause's first
+# word; editors and OSes emit the en-dash just as often). Plain ASCII hyphen is
 # deliberately NOT included: it's mid-word in compounds like "write-gate", which
 # must still yield the useful bigram "write gate".
-_CLAUSE_BOUNDARY = re.compile(r"[.,;:!?\n\r—]+")
+_CLAUSE_BOUNDARY = re.compile(r"[.,;:!?\n\r—–]+")  # noqa: RUF001 (literal en-dash intended)
 
 
 def _get_stop_words(language: str, text: str) -> frozenset[str]:

--- a/tests/unit/test_polish_keywords.py
+++ b/tests/unit/test_polish_keywords.py
@@ -70,6 +70,25 @@ class TestClauseBoundaryBigrams:
         assert "py" in unigrams
         assert "bigramy" in unigrams
 
+    def test_no_bigram_across_en_dash(self) -> None:
+        # The en-dash (U+2013) is a clause boundary too, not only the em-dash
+        # (—, U+2014): editors and OSes emit it for ranges and asides, so without
+        # it the same cross-clause junk bigram (a filename fragment glued onto the
+        # next clause) slips through.
+        text = "blad w keywords.py – bigramy nie powinny przecinac granic"  # noqa: RUF001
+        bigrams = _bigrams(text)
+        assert "py bigramy" not in bigrams
+        unigrams = _unigrams(text)
+        assert "py" in unigrams
+        assert "bigramy" in unigrams
+
+    def test_hyphen_is_not_a_clause_boundary(self) -> None:
+        # A hyphen inside a compound term must NOT split a clause: the two halves
+        # are adjacent content words and should still pair as a bigram (contrast
+        # with the en-/em-dash, which do split).
+        bigrams = _bigrams("modul cache-aside dziala szybko")
+        assert "cache aside" in bigrams
+
     def test_phase1_junk_bigrams_eliminated(self) -> None:
         junk = {
             "reguly czy",


### PR DESCRIPTION
Hi Toni!

The two non-blockers you flagged on #57, folded into one small change.

## En-dash as a clause boundary
`_CLAUSE_BOUNDARY` had the em-dash (—) but not the en-dash (–, U+2013). Editors and operating systems emit the en-dash just as often for ranges and asides, so the same cross-clause junk bigram the em-dash fix targets (a filename fragment glued onto the next clause) still slipped through when the separator was an en-dash. Added it to the set.

## Hyphen non-boundary — now pinned
You noted the hyphen-non-boundary behaviour had no dedicated test. Added one: a plain ASCII hyphen must NOT split a clause, so compound halves like `cache-aside` still pair as a bigram — kept as an explicit contrast to the en-/em-dash, which do split.

## Type of Change
- [x] Bug fix + regression test (non-breaking)

## Testing
- `test_no_bigram_across_en_dash` and `test_hyphen_is_not_a_clause_boundary` added to `TestClauseBoundaryBigrams`.
- Full unit suite (rebased on `main`): **6,082 passed, 33 skipped in ~30 s** (`-n0`). `ruff` + `mypy` clean. (The literal en-dash in the regex and one test string carry a `# noqa: RUF001` — ruff flags a bare en-dash as confusable with a hyphen, but here we want it literal.)

## Note on the ma/na/co/sa question (separate)
I ran the collision audit you suggested for the four Polish stop-words; it points at a different fix than removal (the `N/A`/`S.A.` collisions don't actually reproduce), so I opened #64 for that discussion rather than bundling it here.

Robert
