### PR TITLE
Release 2.10.1 — local-first performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.1] — Local-first performance
+
+A performance and correctness patch for the SurrealDB backend, focused on large
+brains and local (self-hosted) embedding. No schema migration; recall ranking is
+unchanged if you don't change your embedding config.
+
+### What's now possible (and wasn't)
+
+- **Point the embedder at a local, OpenAI-compatible server.** Reranking could
+  already run against a local endpoint (`SURREAL_MEMORY_RERANKER_ENDPOINT`); the
+  embedder now has the same knob: `SURREAL_MEMORY_EMBEDDING_ENDPOINT`. Set
+  `provider = "openai"`, `model = "bge-m3"` (or your model), and
+  `SURREAL_MEMORY_EMBEDDING_ENDPOINT = http://127.0.0.1:11435/v1` to embed and
+  rerank entirely on your own GPU (e.g. bge-m3 + bge-reranker via llama.cpp /
+  llamastash) with no cloud calls. A placeholder API key is supplied automatically
+  for keyless local servers.
+
+- **Fresh memories are semantically searchable immediately.** Previously a
+  just-saved memory only got its embedding vector on the next batch
+  `smem reindex`, so semantic recall missed it until then; it was keyword-only in
+  the meantime. `remember`/encode now embed the memory inline as part of the save.
+  Fully fail-soft: with embeddings disabled or no provider reachable, saves behave
+  exactly as before (keyword-only, no error, no slowdown).
+
+### Fixed
+
+- **`smem consolidate` no longer times out on large brains.** The `prune` strategy
+  issued one query *per candidate source neuron* (tens of thousands on a 66k-neuron
+  brain) for bridge detection, blowing the 120s per-strategy budget. It now groups
+  the already-loaded synapses in memory — zero extra queries — dropping prune's read
+  path from ~110s to a few seconds.
+
+- **No more `FLEXIBLE can only be used in SCHEMAFULL tables` warnings on upgraded
+  databases.** Tables that carry an arbitrary-key `metadata`/`config` object
+  (neuron, fiber, brain, typed_memory, source, alerts, brain_versions) are now
+  declared `SCHEMALESS`, which accepts nested keys without `FLEXIBLE`. On a database
+  whose tables were first created `SCHEMALESS`, the old `SCHEMAFULL` + `FLEXIBLE`
+  definitions failed on every `ensure_schema()`/`consolidate`; converting such
+  tables to `SCHEMAFULL` was unsafe (it breaks updates of any row holding a legacy
+  field). `synapse` and `retrieval_trace` stay `SCHEMAFULL`.
+
+- **Session-end dedup recognizes a local OpenAI-compatible embedder.** The stop
+  hook treated only `ollama` as a cheap local embedder and fell back to simhash for
+  everything else; a loopback `SURREAL_MEMORY_EMBEDDING_ENDPOINT` (llamastash bge-m3)
+  is now recognized as local-and-cheap, so end-of-session semantic dedup uses it.
+
 ## [2.10.0] — Ecosystem
 
 The ecosystem release: recall gains a geographic dimension, and surreal-memory plugs

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.10.0"
+version = "2.10.1"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.10.0"
+__version__ = "2.10.1"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -463,14 +463,16 @@ class ConsolidationEngine:
                 for nid in fib.neuron_ids:
                     fiber_salience_cache.setdefault(nid, []).append(fib)
 
-        # Pre-fetch neighbor counts for bridge detection (avoid N+1 queries)
-        # Collect all unique source neuron IDs from synapses eligible for pruning
-        candidate_source_ids = list({s.source_id for s in all_synapses if s.weight >= 0.02})
+        # Bridge detection (below) needs, per source neuron, its outgoing synapses.
+        # We ALREADY hold every synapse for the brain in ``all_synapses``, so group
+        # them in-memory instead of asking the storage layer. The SurrealDB backend
+        # has no batched ``get_synapses_for_neurons``, so the previous call fanned out
+        # into one query PER candidate source neuron — tens of thousands on a large
+        # brain — which blew the per-strategy prune budget (120s timeout). Grouping the
+        # already-loaded list is O(n) in Python and issues zero extra queries.
         neighbor_synapses_map: dict[str, list[Synapse]] = {}
-        if candidate_source_ids:
-            neighbor_synapses_map = await self._storage.get_synapses_for_neurons(
-                candidate_source_ids, direction="out"
-            )
+        for s in all_synapses:
+            neighbor_synapses_map.setdefault(s.source_id, []).append(s)
 
         for syn_idx, synapse in enumerate(all_synapses):
             if syn_idx % 500 == 0 and syn_idx > 0:

--- a/src/surreal_memory/engine/embedding/openai_embedding.py
+++ b/src/surreal_memory/engine/embedding/openai_embedding.py
@@ -44,15 +44,18 @@ class OpenAIEmbedding(EmbeddingProvider):
         # reranker's SURREAL_MEMORY_RERANKER_ENDPOINT so embeddings can be served by
         # a local server with no cloud round-trip. Subclasses that pass their own
         # base_url (e.g. OpenRouter) are unaffected.
-        resolved_base = base_url or os.environ.get("SURREAL_MEMORY_EMBEDDING_ENDPOINT", "").strip()
+        env_endpoint = os.environ.get("SURREAL_MEMORY_EMBEDDING_ENDPOINT", "").strip()
+        resolved_base = base_url or env_endpoint
         self._base_url = resolved_base.rstrip("/") if resolved_base else None
         self._api_key_env = api_key_env
         self._provider_label = provider_label
         self._api_key = api_key or os.getenv(api_key_env)
-        # A local endpoint (llamastash / llama.cpp) needs no real key, but the
-        # OpenAI SDK still requires a non-empty string — fall back to a placeholder
-        # instead of failing hard when a base_url is configured.
-        if not self._api_key and self._base_url:
+        # A locally-configured endpoint (SURREAL_MEMORY_EMBEDDING_ENDPOINT, e.g.
+        # llamastash / llama.cpp bge-m3) needs no real key, but the OpenAI SDK still
+        # requires a non-empty string — fall back to a placeholder instead of failing
+        # hard. This applies ONLY to that local-endpoint env knob: a subclass that
+        # passes its own base_url (e.g. OpenRouter) still requires a real key.
+        if not self._api_key and env_endpoint and not base_url:
             self._api_key = "sk-local"
         if not self._api_key:
             raise ValueError(

--- a/src/surreal_memory/engine/embedding/openai_embedding.py
+++ b/src/surreal_memory/engine/embedding/openai_embedding.py
@@ -13,6 +13,9 @@ _MODEL_DIMENSIONS: dict[str, int] = {
     "text-embedding-3-small": 1536,
     "text-embedding-3-large": 3072,
     "text-embedding-ada-002": 1536,
+    # Local llama.cpp / llamastash models served over the OpenAI-compatible API.
+    "bge-m3": 1024,
+    "bge-large-en-v1.5": 1024,
 }
 
 _DEFAULT_MODEL = "text-embedding-3-small"
@@ -35,10 +38,22 @@ class OpenAIEmbedding(EmbeddingProvider):
         provider_label: str = "OpenAI",
     ) -> None:
         self._model = model
-        self._base_url = base_url.rstrip("/") if base_url else None
+        # Default to a local OpenAI-compatible embedding endpoint when
+        # SURREAL_MEMORY_EMBEDDING_ENDPOINT is set and no explicit base_url is
+        # passed (e.g. llamastash bge-m3 at http://127.0.0.1:11435/v1). Mirrors the
+        # reranker's SURREAL_MEMORY_RERANKER_ENDPOINT so embeddings can be served by
+        # a local server with no cloud round-trip. Subclasses that pass their own
+        # base_url (e.g. OpenRouter) are unaffected.
+        resolved_base = base_url or os.environ.get("SURREAL_MEMORY_EMBEDDING_ENDPOINT", "").strip()
+        self._base_url = resolved_base.rstrip("/") if resolved_base else None
         self._api_key_env = api_key_env
         self._provider_label = provider_label
         self._api_key = api_key or os.getenv(api_key_env)
+        # A local endpoint (llamastash / llama.cpp) needs no real key, but the
+        # OpenAI SDK still requires a non-empty string — fall back to a placeholder
+        # instead of failing hard when a base_url is configured.
+        if not self._api_key and self._base_url:
+            self._api_key = "sk-local"
         if not self._api_key:
             raise ValueError(
                 f"A {provider_label} API key is required. Pass it directly or set "

--- a/src/surreal_memory/engine/encoder.py
+++ b/src/surreal_memory/engine/encoder.py
@@ -506,9 +506,7 @@ class MemoryEncoder:
 
         for neuron, vector in zip(candidates, vectors, strict=False):
             try:
-                await self._storage.update_neuron(
-                    neuron.with_metadata(_embedding=list(vector))
-                )
+                await self._storage.update_neuron(neuron.with_metadata(_embedding=list(vector)))
             except Exception:
                 logger.debug("Inline embed update failed: %s", neuron.id, exc_info=True)
 

--- a/src/surreal_memory/engine/encoder.py
+++ b/src/surreal_memory/engine/encoder.py
@@ -433,6 +433,10 @@ class MemoryEncoder:
         if ctx.anchor_neuron is not None:
             await self._post_encode_neuro(ctx.anchor_neuron)
 
+        # Embed the freshly-created neurons inline so semantic recall works on
+        # them immediately, instead of only after a batch ``smem reindex``.
+        await self._embed_created_neurons(ctx)
+
         return EncodingResult(
             fiber=fiber,
             neurons_created=ctx.neurons_created,
@@ -446,6 +450,67 @@ class MemoryEncoder:
             },
             pending_supersessions=list(ctx.pending_supersessions),
         )
+
+    async def _embed_created_neurons(self, ctx: PipelineContext) -> None:
+        """Embed the non-ephemeral neurons this encode just created so semantic
+        recall works on them immediately.
+
+        Embeddings used to be populated only by a batch ``smem reindex``, so a
+        freshly-saved memory was keyword-recallable but NOT semantically
+        recallable until the next reindex ran. One ``embed_batch`` call covers
+        the whole memory; against a local endpoint (bge-m3 via llamastash,
+        ~15 ms) this adds negligible latency. Fully fail-soft: if embeddings are
+        disabled or no provider is available, memories stay keyword-only — no
+        error, no slowdown — exactly the prior behaviour. Ephemeral and TIME
+        neurons are skipped (disposable / not semantically meaningful).
+        """
+        logger = logging.getLogger(__name__)
+        try:
+            from surreal_memory.engine.semantic_discovery import (
+                _create_provider,
+                _effective_embedding,
+            )
+
+            enabled, _, _ = _effective_embedding(self._config)
+        except Exception:
+            return
+        if not enabled:
+            return
+
+        from surreal_memory.core.neuron import NeuronType
+
+        seen: set[str] = set()
+        candidates: list[Neuron] = []
+        for n in [*ctx.neurons_created, ctx.anchor_neuron]:
+            if n is None or n.id in seen:
+                continue
+            if getattr(n, "ephemeral", False):
+                continue  # disposable (24 h) — not worth an embedding
+            if n.type == NeuronType.TIME:
+                continue  # timestamps are not semantically meaningful
+            if not n.content or len(n.content) < 3:
+                continue
+            if "_embedding" in n.metadata:
+                continue
+            seen.add(n.id)
+            candidates.append(n)
+        if not candidates:
+            return
+
+        try:
+            provider = _create_provider(self._config, task_type="RETRIEVAL_DOCUMENT")
+            vectors = await provider.embed_batch([n.content for n in candidates])
+        except Exception:
+            logger.debug("Inline embedding skipped (provider unavailable)", exc_info=True)
+            return
+
+        for neuron, vector in zip(candidates, vectors, strict=False):
+            try:
+                await self._storage.update_neuron(
+                    neuron.with_metadata(_embedding=list(vector))
+                )
+            except Exception:
+                logger.debug("Inline embed update failed: %s", neuron.id, exc_info=True)
 
     async def _post_encode_neuro(self, anchor: Neuron) -> None:
         """Run post-encode neuroscience hooks (schema assimilation + interference).

--- a/src/surreal_memory/hooks/stop.py
+++ b/src/surreal_memory/hooks/stop.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import re
 import sys
 from pathlib import Path
@@ -251,10 +252,20 @@ async def _embedding_dedup(
         from surreal_memory.engine.embedding.provider import EmbeddingProvider
 
         embed_provider: EmbeddingProvider
+        endpoint = os.environ.get("SURREAL_MEMORY_EMBEDDING_ENDPOINT", "")
+        is_local_endpoint = any(h in endpoint for h in ("127.0.0.1", "localhost", "::1"))
         if provider_name == "ollama":
             from surreal_memory.engine.embedding.ollama_embedding import OllamaEmbedding
 
             embed_provider = OllamaEmbedding(model=model_name)
+        elif provider_name in ("openai", "openrouter") and is_local_endpoint:
+            # A local OpenAI-compatible server (e.g. llamastash bge-m3 at
+            # http://127.0.0.1:11435/v1) is GPU-served at ~15ms/embed — as cheap as
+            # Ollama — so use it for higher-quality semantic dedup. Only a *local*
+            # (loopback) endpoint qualifies; remote/cloud bases are skipped below.
+            from surreal_memory.engine.embedding.openai_embedding import OpenAIEmbedding
+
+            embed_provider = OpenAIEmbedding(model=model_name)
         else:
             # Stop hook runs in a fresh, uncached process on every session save.
             # Never load a heavy local model (sentence-transformers pulls in torch

--- a/src/surreal_memory/storage/surrealdb/schema.py
+++ b/src/surreal_memory/storage/surrealdb/schema.py
@@ -20,14 +20,28 @@ SCHEMA_SQL = """
 -- full-scanning with CONTAINS.
 DEFINE ANALYZER IF NOT EXISTS smem_content TOKENIZERS blank, class FILTERS lowercase, ascii;
 
+-- Tables that carry an arbitrary-key ``metadata``/``config`` object are declared
+-- SCHEMALESS (not SCHEMAFULL). Those nested keys require FLEXIBLE on a SCHEMAFULL
+-- table, but SurrealDB rejects ``DEFINE FIELD ... FLEXIBLE`` on any table that is
+-- already SCHEMALESS ("FLEXIBLE can only be used in SCHEMAFULL tables"). Because a
+-- bare ``DEFINE TABLE X SCHEMAFULL`` is swallowed as "already exists" on an upgraded
+-- DB, a legacy table first created SCHEMALESS never converges to SCHEMAFULL, so
+-- every FLEXIBLE field-def then errors on each ensure_schema()/consolidate. And
+-- converting such a table to SCHEMAFULL would BRICK updates on any row still holding
+-- a legacy field absent from the schema. A SCHEMALESS table already accepts
+-- arbitrary nested object keys WITHOUT FLEXIBLE, so these tables are SCHEMALESS +
+-- plain ``TYPE object`` — correct and identical on fresh and upgraded databases.
+-- (synapse + retrieval_trace stay SCHEMAFULL: a migration drops & recreates them,
+-- so their FLEXIBLE fields are always valid.)
+
 -- Neurons (primary memory units)
-DEFINE TABLE neuron SCHEMAFULL;
+DEFINE TABLE neuron SCHEMALESS;
 DEFINE FIELD id              ON neuron TYPE string;
 DEFINE FIELD brain_id        ON neuron TYPE string;
 DEFINE FIELD type            ON neuron TYPE string;
 DEFINE FIELD content         ON neuron TYPE string;
 DEFINE FIELD content_hash    ON neuron TYPE int DEFAULT 0;
-DEFINE FIELD metadata        ON neuron TYPE object FLEXIBLE DEFAULT {};
+DEFINE FIELD metadata        ON neuron TYPE object DEFAULT {};
 DEFINE FIELD embedding_vec   ON neuron TYPE option<array<float>>;
 DEFINE FIELD ephemeral       ON neuron TYPE bool DEFAULT false;
 DEFINE FIELD created_at      ON neuron TYPE datetime DEFAULT time::now();
@@ -70,7 +84,7 @@ DEFINE INDEX idx_state_neuron  ON neuron_state FIELDS brain_id, neuron_id UNIQUE
 DEFINE TABLE schema_meta SCHEMALESS;
 
 -- Fibers (memory clusters / signal pathways)
-DEFINE TABLE fiber SCHEMAFULL;
+DEFINE TABLE fiber SCHEMALESS;
 DEFINE FIELD id              ON fiber TYPE string;
 DEFINE FIELD brain_id        ON fiber TYPE string;
 DEFINE FIELD neuron_ids      ON fiber TYPE array<string>;
@@ -88,7 +102,7 @@ DEFINE FIELD summary         ON fiber TYPE option<string>;
 DEFINE FIELD essence         ON fiber TYPE option<string>;
 DEFINE FIELD auto_tags       ON fiber TYPE array<string> DEFAULT [];
 DEFINE FIELD agent_tags      ON fiber TYPE array<string> DEFAULT [];
-DEFINE FIELD metadata        ON fiber TYPE object FLEXIBLE DEFAULT {};
+DEFINE FIELD metadata        ON fiber TYPE object DEFAULT {};
 DEFINE FIELD compression_tier ON fiber TYPE int DEFAULT 0;
 DEFINE FIELD pinned           ON fiber TYPE bool DEFAULT false;
 DEFINE FIELD created_at       ON fiber TYPE datetime DEFAULT time::now();
@@ -97,11 +111,11 @@ DEFINE INDEX idx_fiber_brain  ON fiber FIELDS brain_id;
 DEFINE INDEX idx_fiber_anchor ON fiber FIELDS brain_id, anchor_neuron_id;
 
 -- Brains (top-level containers)
-DEFINE TABLE brain SCHEMAFULL;
+DEFINE TABLE brain SCHEMALESS;
 DEFINE FIELD id          ON brain TYPE string;
 DEFINE FIELD name        ON brain TYPE string;
-DEFINE FIELD config      ON brain TYPE object FLEXIBLE DEFAULT {};
-DEFINE FIELD metadata    ON brain TYPE object FLEXIBLE DEFAULT {};
+DEFINE FIELD config      ON brain TYPE object DEFAULT {};
+DEFINE FIELD metadata    ON brain TYPE object DEFAULT {};
 DEFINE FIELD created_at  ON brain TYPE datetime DEFAULT time::now();
 DEFINE FIELD updated_at  ON brain TYPE datetime DEFAULT time::now();
 -- Removed unique index on name - multiple brains can have same name
@@ -140,7 +154,7 @@ DEFINE FIELD computed_at   ON merkle_hash TYPE datetime DEFAULT time::now();
 DEFINE INDEX idx_merkle    ON merkle_hash FIELDS brain_id, entity_type, prefix UNIQUE;
 
 -- Typed memories
-DEFINE TABLE typed_memory SCHEMAFULL;
+DEFINE TABLE typed_memory SCHEMALESS;
 DEFINE FIELD fiber_id      ON typed_memory TYPE string;
 DEFINE FIELD brain_id      ON typed_memory TYPE string;
 DEFINE FIELD memory_type   ON typed_memory TYPE string;
@@ -152,7 +166,7 @@ DEFINE FIELD source        ON typed_memory TYPE option<string>;
 DEFINE FIELD project_id    ON typed_memory TYPE option<string>;
 DEFINE FIELD expires_at    ON typed_memory TYPE option<datetime>;
 DEFINE FIELD tier          ON typed_memory TYPE string DEFAULT 'warm';
-DEFINE FIELD metadata      ON typed_memory TYPE object FLEXIBLE DEFAULT {};
+DEFINE FIELD metadata      ON typed_memory TYPE object DEFAULT {};
 DEFINE FIELD created_at    ON typed_memory TYPE datetime DEFAULT time::now();
 DEFINE FIELD updated_at    ON typed_memory TYPE datetime DEFAULT time::now();
 DEFINE FIELD valid_from    ON typed_memory TYPE option<datetime>;
@@ -173,7 +187,7 @@ DEFINE INDEX idx_project_brain ON project FIELDS brain_id;
 DEFINE INDEX idx_project_uid   ON project FIELDS brain_id, uid UNIQUE;
 
 -- Sources (memory origin registry)
-DEFINE TABLE source SCHEMAFULL;
+DEFINE TABLE source SCHEMALESS;
 DEFINE FIELD id             ON source TYPE string;
 DEFINE FIELD brain_id       ON source TYPE string;
 DEFINE FIELD name           ON source TYPE string;
@@ -183,7 +197,7 @@ DEFINE FIELD effective_date ON source TYPE option<datetime>;
 DEFINE FIELD expires_at     ON source TYPE option<datetime>;
 DEFINE FIELD status         ON source TYPE string DEFAULT 'active';
 DEFINE FIELD file_hash      ON source TYPE string DEFAULT '';
-DEFINE FIELD metadata       ON source TYPE object FLEXIBLE DEFAULT {};
+DEFINE FIELD metadata       ON source TYPE object DEFAULT {};
 DEFINE FIELD created_at     ON source TYPE datetime DEFAULT time::now();
 DEFINE FIELD updated_at     ON source TYPE datetime DEFAULT time::now();
 DEFINE FIELD trust          ON source TYPE option<float>;
@@ -207,7 +221,7 @@ DEFINE INDEX idx_trace_brain   ON retrieval_trace FIELDS brain_id;
 DEFINE INDEX idx_trace_created ON retrieval_trace FIELDS brain_id, created_at;
 
 -- Alerts (system-generated warnings and recommendations)
-DEFINE TABLE alerts SCHEMAFULL;
+DEFINE TABLE alerts SCHEMALESS;
 DEFINE FIELD id                 ON alerts TYPE string;
 DEFINE FIELD brain_id           ON alerts TYPE string;
 DEFINE FIELD alert_type         ON alerts TYPE string;
@@ -219,7 +233,7 @@ DEFINE FIELD created_at         ON alerts TYPE datetime DEFAULT time::now();
 DEFINE FIELD seen_at            ON alerts TYPE option<datetime>;
 DEFINE FIELD acknowledged_at    ON alerts TYPE option<datetime>;
 DEFINE FIELD resolved_at        ON alerts TYPE option<datetime>;
-DEFINE FIELD metadata           ON alerts TYPE object FLEXIBLE DEFAULT {};
+DEFINE FIELD metadata           ON alerts TYPE object DEFAULT {};
 DEFINE INDEX idx_alerts_brain   ON alerts FIELDS brain_id;
 DEFINE INDEX idx_alerts_status  ON alerts FIELDS brain_id, status;
 
@@ -294,7 +308,7 @@ DEFINE INDEX idx_maturation_fiber     ON maturation FIELDS brain_id, fiber_id UN
 DEFINE INDEX idx_maturation_stage     ON maturation FIELDS brain_id, stage;
 
 -- Brain versions (snapshot/checkpoint history with compressed snapshots)
-DEFINE TABLE brain_versions SCHEMAFULL;
+DEFINE TABLE brain_versions SCHEMALESS;
 DEFINE FIELD id              ON brain_versions TYPE string;
 DEFINE FIELD brain_id        ON brain_versions TYPE string;
 DEFINE FIELD version_name    ON brain_versions TYPE string DEFAULT '';
@@ -306,7 +320,7 @@ DEFINE FIELD fiber_count     ON brain_versions TYPE int DEFAULT 0;
 DEFINE FIELD snapshot_hash   ON brain_versions TYPE string DEFAULT '';
 DEFINE FIELD snapshot_data   ON brain_versions TYPE string DEFAULT '';
 DEFINE FIELD created_at      ON brain_versions TYPE datetime DEFAULT time::now();
-DEFINE FIELD metadata        ON brain_versions TYPE object FLEXIBLE DEFAULT {};
+DEFINE FIELD metadata        ON brain_versions TYPE object DEFAULT {};
 DEFINE INDEX idx_versions_brain  ON brain_versions FIELDS brain_id;
 DEFINE INDEX idx_versions_number ON brain_versions FIELDS brain_id, version_number;
 

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.10.0"
+        assert surreal_memory.__version__ == "2.10.1"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_schema_statement_parser.py
+++ b/tests/unit/test_schema_statement_parser.py
@@ -81,7 +81,10 @@ class TestEnsureSchemaExecution:
         joined = "\n".join(conn.executed)
         assert "DEFINE ANALYZER IF NOT EXISTS smem_content" in joined
         assert "idx_neuron_content_fts" in joined
-        assert "DEFINE TABLE neuron SCHEMAFULL" in joined
+        # neuron (and the other arbitrary-``metadata`` tables) are SCHEMALESS so
+        # their ``TYPE object`` metadata accepts nested keys without FLEXIBLE, which
+        # SurrealDB rejects on a SCHEMALESS table — see SCHEMA_SQL rationale comment.
+        assert "DEFINE TABLE neuron SCHEMALESS" in joined
         assert "HNSW DIMENSION 1024" in joined
 
     async def test_a_failing_statement_does_not_abort_the_rest(self) -> None:

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Performance + correctness patch for the SurrealDB backend, focused on large brains and local (self-hosted) embedding. No schema migration; recall ranking is unchanged unless you change your embedding config.

Five changes:

1. **feat(embedding): configurable local embedding endpoint** — `SURREAL_MEMORY_EMBEDDING_ENDPOINT` lets the `openai` provider target a local OpenAI-compatible server (bge-m3 via llama.cpp / llamastash), mirroring the reranker's `SURREAL_MEMORY_RERANKER_ENDPOINT`. Placeholder api-key for keyless local servers.
2. **feat(encode): inline embedding on write** — freshly-saved memories are embedded as part of the save instead of only on the next batch `smem reindex`, so semantic recall works immediately. Fail-soft (embeddings off / no provider → keyword-only, no error, no slowdown).
3. **fix(consolidation): prune N+1 timeout** — `prune` bridge-detection issued one query per candidate source neuron (tens of thousands on a 66k-neuron brain), blowing the 120s per-strategy budget. Now groups the already-loaded synapses in memory (0 extra queries); read path ~110s → seconds.
4. **fix(surrealdb): SCHEMALESS metadata tables** — the 7 arbitrary-`metadata`/`config` tables are declared `SCHEMALESS` (accept nested keys without `FLEXIBLE`), stopping `FLEXIBLE can only be used in SCHEMAFULL tables` errors on databases whose tables were first created `SCHEMALESS`. `synapse` + `retrieval_trace` stay `SCHEMAFULL`.
5. **fix(hooks): stop-hook recognizes local embedder** — session-end semantic dedup treats a loopback `SURREAL_MEMORY_EMBEDDING_ENDPOINT` (llamastash bge-m3) as local-and-cheap instead of falling back to simhash.

## Verification
- 162 encoder/pipeline unit tests pass; inline-embed is fail-soft (no provider → early return).
- prune: 46 consolidation/perf/pinned tests pass; in-memory grouping measured 0.04s vs ~100s N+1.
- schema: full `SCHEMA_SQL` applied to fresh + legacy-schemaless DBs → 0 FLEXIBLE errors, nested `metadata` writes work.
- inline-embed: verified against a live 66k-neuron brain — a permanent `remember` now stores a 1024-dim `embedding_vec` (was `NONE`).

## Test plan
- [ ] CI green (lint, mypy, tests 3.11+3.12, docs freshness, security, build)
- [ ] After tag: verify PyPI + both npm packages published against live registries