### PR TITLE
Release 2.10.2 — faster inline embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.2] — Faster inline embedding
+
+A follow-up performance patch to [2.10.1]'s inline embedding.
+
+### Fixed
+
+- **Faster memory saves on large brains.** [2.10.1] embeds a memory's neurons as
+  part of the save, but wrote each vector with its own database round-trip. Those
+  writes are now batched into a single query, so a permanent `remember` on a
+  66k-neuron SurrealDB brain drops from ~6s to ~3s. (SurrealDB backend; other
+  backends keep the per-neuron path.)
+
 ## [2.10.1] — Local-first performance
 
 A performance and correctness patch for the SurrealDB backend, focused on large

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.10.1"
+version = "2.10.2"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.10.1"
+__version__ = "2.10.2"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/encoder.py
+++ b/src/surreal_memory/engine/encoder.py
@@ -504,6 +504,16 @@ class MemoryEncoder:
             logger.debug("Inline embedding skipped (provider unavailable)", exc_info=True)
             return
 
+        # Prefer a single batched write when the backend offers one (SurrealDB):
+        # inline embedding otherwise costs one round-trip per created neuron.
+        pairs = [(n.id, list(v)) for n, v in zip(candidates, vectors, strict=False)]
+        batch_update = getattr(self._storage, "update_neuron_embeddings", None)
+        if batch_update is not None:
+            try:
+                await batch_update(pairs)
+                return
+            except Exception:
+                logger.debug("Batch inline embed update failed; falling back", exc_info=True)
         for neuron, vector in zip(candidates, vectors, strict=False):
             try:
                 await self._storage.update_neuron(neuron.with_metadata(_embedding=list(vector)))

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -789,6 +789,29 @@ class SurrealDBStorage(
         await conn.merge(f"neuron:{sid}", update_data)
         await self._record_change_internal("neuron", neuron.id, "update", neuron)
 
+    async def update_neuron_embeddings(self, pairs: list[tuple[str, list[float]]]) -> None:
+        """Write embedding vectors for many neurons in a single round-trip.
+
+        Inline embedding on write (encoder) would otherwise issue one ``merge`` per
+        neuron — tens of round-trips per save. This batches them into one
+        multi-statement ``UPDATE`` (param-bound, so injection-safe), setting only
+        ``embedding_vec``/``updated_at``. The change-log is intentionally skipped:
+        the vector is derived from content that already logged its create, and a
+        peer can re-embed locally, so it needn't sync as a separate delta.
+        """
+        if not pairs:
+            return
+        stmts: list[str] = []
+        params: dict[str, Any] = {}
+        for i, (nid, vec) in enumerate(pairs):
+            params[f"id{i}"] = _to_surreal_id(nid)
+            params[f"v{i}"] = list(vec)
+            stmts.append(
+                f"UPDATE type::record('neuron', $id{i}) "
+                f"SET embedding_vec = $v{i}, updated_at = time::now()"
+            )
+        await self._query(";\n".join(stmts) + ";", **params)
+
     async def delete_neuron(self, neuron_id: str) -> bool:
         conn = self._ensure_conn()
         brain_id = self._get_brain_id()

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.10.1"
+        assert surreal_memory.__version__ == "2.10.2"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Follow-up performance patch to 2.10.1's inline embedding.

- **perf(encode): batch inline-embed vector writes into one query.** 2.10.1 embeds a memory's neurons as part of the save but wrote each vector with its own `merge` round-trip (plus a change-log write) — tens of round-trips per save on a large brain. New `SurrealDBStorage.update_neuron_embeddings()` writes all vectors in a single param-bound multi-statement `UPDATE` (change-log skipped: the vector is derived and a peer can re-embed locally). `encoder._embed_created_neurons` uses it when the backend offers it, else falls back to per-neuron `update_neuron`. Uses `type::record` (SurrealDB 3.x renamed `type::thing`, which had silently parse-errored → the batch fell back to the slow path).

## Verification
- Live 66k-neuron brain: a permanent `remember` drops from **~6s to ~3.0s**, embeddings still stored (1024-dim).
- 134 encoder/storage unit tests pass.

## Test plan
- [ ] CI green
- [ ] After tag: verify PyPI + both npm packages published