### PR TITLE
fix(docker): install embeddings-openai for local bge in the surrealdb image

### DIFF
--- a/Dockerfile.surrealdb
+++ b/Dockerfile.surrealdb
@@ -11,7 +11,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY pyproject.toml README.md ./
 COPY src/ ./src/
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir ".[server,surrealdb,embeddings-gemini,encryption]"
+    pip install --no-cache-dir ".[server,surrealdb,embeddings-openai,encryption]"
 
 # Runtime stage
 FROM python:3.11-slim


### PR DESCRIPTION
The docker-compose.surrealdb.yml container defaults to `provider=openai` (local bge-m3 via the host-loopback llamastash endpoint under host networking), but `Dockerfile.surrealdb` installed the `embeddings-gemini` extra instead of `embeddings-openai`. So the openai embedding provider raised `ImportError('openai is required')` and embedding silently fell back to keyword mode. Swap the extra to `embeddings-openai` so the container embeds against its configured local endpoint. Docker-only change; no Python/API changes.