### PR TITLE
fix: prune completes under budget + habits list/persist correctly (2.10.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,6 +232,10 @@ integrations/surrealmemory/coverage/
 # Local surreal-memory brain data (never commit)
 .surrealmemory/
 .neuralmemory/
+# Brain dumps / backups — never commit (may contain private memory content)
+*.surql
+*.surql.gz
+surrealmemory-backups/
 
 # Serena MCP project cache (never commit)
 .serena/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.3] — Prune completes, habits stick
+
+Two user-reported bugs on large, months-old brains: `consolidate`'s prune step
+timed out, and `smem habits list` was always empty.
+
+### Fixed
+
+- **Prune no longer times out on large brains.** The `prune` strategy fetched
+  every neuron's activation state one row at a time (a hidden N+1 behind the
+  `get_neuron_states_batch` name) and re-ran it for each 5000-neuron page. On a
+  ~67k-neuron / ~420k-synapse brain that single step cost ~140s and blew the
+  120s per-strategy budget. States are now read in one scan and looked up
+  in-memory, and the SurrealDB backend gained a real batched
+  `get_neuron_states_batch`. End-to-end prune drops from ~188s to ~39s on that
+  brain. (Builds on 2.10.1's N+1 synapse fix and the embedding-vector OMIT.)
+- **`smem habits list` now finds learned habits on large brains.** `find_fibers`
+  filtered the `_habit_pattern` marker in Python *after* applying the row limit,
+  so on a brain with more fibers than the fetch window any habit beyond the first
+  1000 rows was invisible. The marker filter is now pushed into the SurrealDB
+  query (`WHERE metadata.<key> != NONE`), and the `habits` CLI commands query the
+  marker directly instead of `get_fibers(1000)` + a Python filter.
+- **`consolidate` reports query patterns separately from habits.** "Habits
+  learned: N" previously also counted query-pattern strengthenings — which are
+  CONCEPT neurons/synapses, not listable `_habit_pattern` fibers — so the number
+  never matched `smem habits list`. Query patterns now have their own
+  "Query patterns learned" line.
+- **Learned habits survive consolidation.** The `merge` strategy could fold a
+  `_habit_pattern` fiber into a summary fiber and drop the marker, silently
+  deleting the habit. Habit fibers are now excluded from merge clusters so
+  habits accumulate over time.
+
 ## [2.10.2] — Faster inline embedding
 
 A follow-up performance patch to [2.10.1]'s inline embedding.

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.10.2"
+version = "2.10.3"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.10.2"
+__version__ = "2.10.3"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/cli/commands/habits.py
+++ b/src/surreal_memory/cli/commands/habits.py
@@ -30,8 +30,10 @@ def habits_list(
         config = get_config()
         storage = await get_storage(config)
         try:
-            fibers = await storage.get_fibers(limit=1000)
-            habits = [f for f in fibers if f.metadata.get("_habit_pattern")]
+            # Query the marker in-store (find_fibers pushes `_habit_pattern` into the
+            # backend WHERE) rather than get_fibers(limit=1000)+Python filter, which on a
+            # large brain returns an arbitrary first-1000 slice that omits habit fibers.
+            habits = await storage.find_fibers(metadata_key="_habit_pattern", limit=1000)
 
             if json_output:
                 output_result(
@@ -88,8 +90,8 @@ def habits_show(
         config = get_config()
         storage = await get_storage(config)
         try:
-            fibers = await storage.get_fibers(limit=1000)
-            habits = [f for f in fibers if f.metadata.get("_habit_pattern") and f.summary == name]
+            habit_fibers = await storage.find_fibers(metadata_key="_habit_pattern", limit=1000)
+            habits = [f for f in habit_fibers if f.summary == name]
 
             if not habits:
                 typer.echo(f"No habit found with name: {name}")
@@ -146,8 +148,7 @@ def habits_clear(
         config = get_config()
         storage = await get_storage(config)
         try:
-            fibers = await storage.get_fibers(limit=1000)
-            habits = [f for f in fibers if f.metadata.get("_habit_pattern")]
+            habits = await storage.find_fibers(metadata_key="_habit_pattern", limit=1000)
 
             if not habits:
                 typer.echo("No habits to clear.")
@@ -233,12 +234,8 @@ def habits_status(
             total_sessions = max(len(session_ids), 1)
 
             # Get existing habits to exclude
-            fibers = await storage.get_fibers(limit=1000)
-            existing_habits = {
-                tuple(f.metadata.get("_workflow_actions", []))
-                for f in fibers
-                if f.metadata.get("_habit_pattern")
-            }
+            habit_fibers = await storage.find_fibers(metadata_key="_habit_pattern", limit=1000)
+            existing_habits = {tuple(f.metadata.get("_workflow_actions", [])) for f in habit_fibers}
 
             # Separate into learned vs emerging
             emerging: list[dict[str, str | int | float]] = []

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -103,6 +103,7 @@ class ConsolidationReport:
     synapses_enriched: int = 0
     dream_synapses_created: int = 0
     habits_learned: int = 0
+    query_patterns_learned: int = 0
     action_events_pruned: int = 0
     retrieval_traces_pruned: int = 0
     duplicates_found: int = 0
@@ -131,6 +132,7 @@ class ConsolidationReport:
             f"  Synapses enriched: {self.synapses_enriched}",
             f"  Dream synapses created: {self.dream_synapses_created}",
             f"  Habits learned: {self.habits_learned}",
+            f"  Query patterns learned: {self.query_patterns_learned}",
             f"  Action events pruned: {self.action_events_pruned}",
             f"  Duplicates found: {self.duplicates_found}",
             f"  Semantic synapses: {self.semantic_synapses_created}",
@@ -170,6 +172,7 @@ class ConsolidationReport:
             + self.synapses_enriched
             + self.dream_synapses_created
             + self.habits_learned
+            + self.query_patterns_learned
             + self.duplicates_found
             + self.semantic_synapses_created
             + self.fibers_compressed
@@ -600,6 +603,21 @@ class ConsolidationEngine:
             batch_size,
             est_batches,
         )
+        # Dead-neuron detection needs each neuron's access_frequency. Fetching states
+        # per page (get_neuron_states_batch → a 5000-id `IN` query) cost ~10s/page on a
+        # 67k-neuron brain — ~140s total, the dominant prune cost after the embedding
+        # OMIT. One brain-wide fetch is a single filtered scan (~1.4s), so load all
+        # states once and look them up in-memory across every page.
+        try:
+            states_by_id: dict[str, Any] = {
+                s.neuron_id: s for s in await self._storage.get_all_neuron_states()
+            }
+            use_prefetched_states = True
+        except Exception:
+            logger.debug("get_all_neuron_states failed; per-page state fallback", exc_info=True)
+            states_by_id = {}
+            use_prefetched_states = False
+
         while True:
             batch = await self._storage.find_neurons(
                 limit=batch_size, offset=offset, ephemeral=False, include_embedding=False
@@ -607,9 +625,12 @@ class ConsolidationEngine:
             if not batch:
                 break
 
-            # Check for dead neurons (never accessed, old enough)
-            batch_ids = [n.id for n in batch]
-            states = await self._storage.get_neuron_states_batch(batch_ids)
+            # Dead-neuron check reads access_frequency from the prefetched states; only
+            # fall back to a per-page batch if the brain-wide fetch was unavailable.
+            if use_prefetched_states:
+                states = states_by_id
+            else:
+                states = await self._storage.get_neuron_states_batch([n.id for n in batch])
 
             for neuron in batch:
                 # Never auto-prune pinned neurons, whether isolated (orphan) or
@@ -739,6 +760,14 @@ class ConsolidationEngine:
             fi_verbatim = fiber_list[i].metadata.get("_verbatim", False)
             fj_verbatim = fiber_list[j].metadata.get("_verbatim", False)
             if fi_verbatim != fj_verbatim:
+                continue
+
+            # Never merge a learned-habit fiber away: the merged fiber drops the
+            # `_habit_pattern` marker and step metadata, so `smem habits list` would
+            # silently lose the habit and habits could never accumulate over time.
+            if fiber_list[i].metadata.get("_habit_pattern") or fiber_list[j].metadata.get(
+                "_habit_pattern"
+            ):
                 continue
 
             set_a = fiber_list[i].neuron_ids
@@ -1502,7 +1531,11 @@ class ConsolidationEngine:
             from surreal_memory.engine.query_pattern_mining import learn_query_patterns
 
             qp_report = await learn_query_patterns(self._storage, brain.config, reference_time)
-            report.habits_learned += qp_report.patterns_learned
+            # Query patterns are CONCEPT-neuron/synapse strengthenings, NOT listable
+            # `_habit_pattern` workflow fibers. Counting them under habits_learned made
+            # `consolidate` report "Habits learned: N" while `smem habits list` (which
+            # lists habit fibers) stayed empty. Keep them as a distinct metric.
+            report.query_patterns_learned += qp_report.patterns_learned
         except Exception:
             logger.debug("Query pattern learning failed (non-critical)", exc_info=True)
 

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -584,14 +584,25 @@ class ConsolidationEngine:
         # Dead neuron pruning: never-accessed + old enough + not pinned
         dead_neuron_days = getattr(self._config, "prune_dead_neuron_days", 14.0)
 
-        # Paginate through all neurons to avoid OOM (batch 5k)
+        # Paginate through all neurons in fixed-size batches. OMIT the embedding
+        # vector: orphan/dead detection needs only id + created_at, so dragging the
+        # 1024-float vector for tens of thousands of neurons (~100 MB per 5k-page on
+        # a large brain, ~1.4 GB total) was the dominant cost that blew the 120s
+        # prune budget after the synapse N+1 was removed.
         batch_size = 5000
         offset = 0
         orphan_ids: list[str] = []
         dead_ids: list[str] = []
+        est_batches = (len(connected_neuron_ids | fiber_neuron_ids) // batch_size) + 1
+        logger.info(
+            "Prune: scanning neurons in %d-row batches (~%d+ batches; embedding "
+            "vectors omitted from the scan)",
+            batch_size,
+            est_batches,
+        )
         while True:
             batch = await self._storage.find_neurons(
-                limit=batch_size, offset=offset, ephemeral=False
+                limit=batch_size, offset=offset, ephemeral=False, include_embedding=False
             )
             if not batch:
                 break

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -859,6 +859,34 @@ class SurrealDBStorage(
             pass
         return None
 
+    async def get_neuron_states_batch(self, neuron_ids: list[str]) -> dict[str, NeuronState]:
+        """Fetch many neuron states in ONE query per chunk.
+
+        The base fallback loops ``get_neuron_state`` once per id. Consolidation's
+        prune scan calls this per 5000-neuron page, so on a ~67k-neuron brain the
+        fallback fired ~67k point selects and dominated the strategy runtime
+        (~170s measured → 120s budget blown). The ``neuron_state`` row carries a
+        plain ``neuron_id``, so a single ``IN $ids`` select returns the whole
+        page; ids are param-bound (injection-safe). Chunked so an oversized id
+        list can't build a pathologically large statement.
+        """
+        result: dict[str, NeuronState] = {}
+        if not neuron_ids:
+            return result
+        brain_id = self._get_brain_id()
+        chunk = 5000
+        for start in range(0, len(neuron_ids), chunk):
+            ids = list(neuron_ids[start : start + chunk])
+            rows = await self._query(
+                "SELECT * FROM neuron_state WHERE brain_id = $brain_id AND neuron_id IN $ids",
+                brain_id=brain_id,
+                ids=ids,
+            )
+            for r in rows:
+                state = _row_to_neuron_state(r)
+                result[state.neuron_id] = state
+        return result
+
     async def update_neuron_state(self, state: NeuronState) -> None:
         conn = self._ensure_conn()
         sid = _to_surreal_id(state.neuron_id)
@@ -1241,6 +1269,16 @@ class SurrealDBStorage(
         if min_salience is not None:
             conditions.append("salience >= $min_salience")
             params["min_salience"] = min_salience
+        if metadata_key is not None:
+            # Push the marker-existence filter into SurQL so LIMIT applies AFTER it.
+            # As a post-LIMIT Python filter it silently dropped any fiber carrying the
+            # key (e.g. a learned `_habit_pattern` workflow) that sat beyond the first
+            # `limit` rows on a large brain — `smem habits list` then showed nothing.
+            # metadata_key is an internal marker constant, but validate it to a bare
+            # identifier so the interpolated field path can never carry an injection.
+            if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", metadata_key):
+                raise ValueError(f"invalid metadata_key: {metadata_key!r}")
+            conditions.append(f"metadata.{metadata_key} != NONE")
         if near is not None:
             # Server-side pre-filter: drop locationless fibers (exercises FLEXIBLE-field
             # traversal). No spatial index exists, so geo::distance would not improve
@@ -1286,8 +1324,7 @@ class SurrealDBStorage(
                 and _ensure_naive(f.time_start) <= end
                 and _ensure_naive(f.time_end) >= start
             ]
-        if metadata_key:
-            fibers = [f for f in fibers if metadata_key in f.metadata]
+        # metadata_key is now filtered in SurQL (see WHERE above), so no post-filter here.
         # Exact geospatial hard filter (haversine) — version-independent source of truth.
         if near is not None:
             fibers = [f for f in fibers if fiber_within(f, near)]

--- a/tests/unit/test_audit_fixes.py
+++ b/tests/unit/test_audit_fixes.py
@@ -374,6 +374,65 @@ class TestMetadataKeyFilter:
 
 
 # ---------------------------------------------------------------------------
+# 2.10.3: metadata_key filter must apply BEFORE limit (habits-empty regression)
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataKeyFilterBeyondLimit:
+    """find_fibers(metadata_key=...) must push the marker into the backend query
+    so LIMIT applies AFTER filtering. When it was a post-LIMIT Python filter, a
+    learned `_habit_pattern` fiber sitting outside the first `limit` rows vanished
+    and `smem habits list` showed nothing on a large brain.
+    """
+
+    @pytest.mark.asyncio
+    async def test_marked_fiber_found_despite_higher_salience_unmarked(
+        self, sqlite_storage: SQLiteStorage
+    ) -> None:
+        # 14 high-salience fibers WITHOUT the marker fill the top of the salience
+        # ordering; a first-`limit` slice would be entirely these.
+        for i in range(14):
+            await _add_fiber_with_neuron(
+                sqlite_storage, f"n-nomark-{i}", metadata={"other": True}, salience=0.9
+            )
+        # One low-salience fiber WITH the marker — the only real habit.
+        marked = await _add_fiber_with_neuron(
+            sqlite_storage, "n-habit", metadata={"_habit_pattern": True}, salience=0.01
+        )
+
+        # limit smaller than the unmarked count: a post-LIMIT filter returns [].
+        results = await sqlite_storage.find_fibers(metadata_key="_habit_pattern", limit=5)
+        assert [f.id for f in results] == [marked.id]
+
+
+# ---------------------------------------------------------------------------
+# 2.10.3: query patterns reported separately from listable habits
+# ---------------------------------------------------------------------------
+
+
+class TestConsolidationReportQueryPatterns:
+    """Query patterns are CONCEPT-neuron/synapse strengthenings, not listable
+    `_habit_pattern` fibers. They must be a distinct metric so `consolidate`
+    stops claiming 'Habits learned: N' for things `smem habits list` can't show.
+    """
+
+    def test_summary_lists_query_patterns_separately(self) -> None:
+        from surreal_memory.engine.consolidation import ConsolidationReport
+
+        report = ConsolidationReport(habits_learned=0, query_patterns_learned=2)
+        text = report.summary()
+        assert "Habits learned: 0" in text
+        assert "Query patterns learned: 2" in text
+
+    def test_query_patterns_count_as_activity(self) -> None:
+        """A run that only learned query patterns must not emit 'nothing changed' hints."""
+        from surreal_memory.engine.consolidation import ConsolidationReport
+
+        report = ConsolidationReport(query_patterns_learned=1)
+        assert "Why nothing changed" not in report.summary()
+
+
+# ---------------------------------------------------------------------------
 # H8: Input validation in _remember, _recall, _todo
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_consolidation.py
+++ b/tests/unit/test_consolidation.py
@@ -379,3 +379,55 @@ async def test_run_strategy_dispatcher(
     await engine._run_strategy(ConsolidationStrategy.DREAM, report, utcnow(), dry_run=True)
 
     assert called
+
+
+@pytest.mark.asyncio
+async def test_merge_never_removes_habit_fiber() -> None:
+    """A `_habit_pattern` fiber must survive _merge even at 100% neuron overlap.
+
+    Merging deletes the member fibers and the merged fiber drops the marker, so
+    without the guard a learned habit would silently vanish from `smem habits
+    list` and habits could never accumulate over time.
+    """
+    store = InMemoryStorage()
+    brain = Brain.create(name="merge_habit_test", brain_id="mh-brain")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    for nid in ("n-a", "n-b", "n-c"):
+        await store.add_neuron(Neuron.create(type=NeuronType.ENTITY, content=nid, neuron_id=nid))
+
+    shared = {"n-a", "n-b", "n-c"}  # 100% overlap → Jaccard 1.0, well above 0.5
+    plain1 = Fiber(
+        id="plain-1",
+        neuron_ids=shared,
+        synapse_ids=set(),
+        anchor_neuron_id="n-a",
+        pathway=["n-a"],
+        frequency=5,
+    )
+    plain2 = Fiber(
+        id="plain-2",
+        neuron_ids=shared,
+        synapse_ids=set(),
+        anchor_neuron_id="n-b",
+        pathway=["n-b"],
+        frequency=5,
+    )
+    habit = Fiber(
+        id="habit-1",
+        neuron_ids=shared,
+        synapse_ids=set(),
+        anchor_neuron_id="n-a",
+        pathway=["n-a"],
+        frequency=5,
+        metadata={"_habit_pattern": True, "_workflow_actions": ["a", "b"]},
+    )
+    for f in (plain1, plain2, habit):
+        await store.add_fiber(f)
+
+    engine = ConsolidationEngine(store, ConsolidationConfig())
+    await engine._merge(ConsolidationReport(), dry_run=False)
+
+    remaining = {f.id for f in await store.get_fibers(limit=100)}
+    assert "habit-1" in remaining, "merge must never delete a _habit_pattern fiber"

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.10.2"
+        assert surreal_memory.__version__ == "2.10.3"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_recall_quality.py
+++ b/tests/unit/test_recall_quality.py
@@ -169,6 +169,11 @@ class TestDeadNeuronPruning:
         storage.get_neuron_states_batch = AsyncMock(
             return_value={"old-dead": self._make_state("old-dead", freq=0)}
         )
+        # Prune now prefetches all states in one scan (get_all_neuron_states) instead
+        # of a per-page batch — mock the primary path it actually reads from.
+        storage.get_all_neuron_states = AsyncMock(
+            return_value=[self._make_state("old-dead", freq=0)]
+        )
         storage.delete_neurons_batch = AsyncMock()
 
         config = ConsolidationConfig()
@@ -195,6 +200,7 @@ class TestDeadNeuronPruning:
         storage.get_neuron_states_batch = AsyncMock(
             return_value={"young": self._make_state("young", freq=0)}
         )
+        storage.get_all_neuron_states = AsyncMock(return_value=[self._make_state("young", freq=0)])
         storage.delete_neurons_batch = AsyncMock()
 
         config = ConsolidationConfig()
@@ -230,6 +236,9 @@ class TestDeadNeuronPruning:
         storage.get_neuron_states_batch = AsyncMock(
             return_value={"accessed": self._make_state("accessed", freq=5)}
         )
+        storage.get_all_neuron_states = AsyncMock(
+            return_value=[self._make_state("accessed", freq=5)]
+        )
         storage.delete_neurons_batch = AsyncMock()
         storage.get_synapses_for_neurons = AsyncMock(return_value={})
 
@@ -264,6 +273,7 @@ class TestDeadNeuronPruning:
         storage.get_neuron_states_batch = AsyncMock(
             return_value={"pinned": self._make_state("pinned", freq=0)}
         )
+        storage.get_all_neuron_states = AsyncMock(return_value=[self._make_state("pinned", freq=0)])
         storage.delete_neurons_batch = AsyncMock()
         storage.get_synapses_for_neurons = AsyncMock(return_value={})
 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Two user-reported bugs on large, months-old brains (~67k neurons / ~420k synapses):
`consolidate`'s **prune** step timed out at 120s, and **`smem habits list`** was always empty.

## Prune — no longer times out

- **N+1 in disguise:** SurrealDB never overrode `get_neuron_states_batch`, so it fell back to the base loop of one point-select per id. Prune calls it per 5000-neuron page → ~67k selects. Added a real single-query batched override.
- **Hoisted the state fetch** out of the per-page loop: read all states once via `get_all_neuron_states` (~1.4s) instead of a 5000-id `IN` query per page (~10s × 14 ≈ 140s).
- **Result:** end-to-end prune **~188s → ~39s** (verified live via `smem consolidate --strategy prune --dry-run`). Builds on 2.10.1's synapse N+1 fix and the embedding-vector `OMIT` (77e5dcc).

## Habits — list now works and habits persist

- `find_fibers(metadata_key=…)` filtered the `_habit_pattern` marker **in Python after the row `LIMIT`**, so any habit beyond the first fetch window was invisible on a large brain. Pushed into the SurQL `WHERE metadata.<key> != NONE` (identifier-validated, injection-safe). SQLite/in-memory backends already filtered correctly.
- The `habits` CLI commands (`list`/`show`/`clear`/`status`) queried via `get_fibers(1000)` + Python filter — same first-1000 bug. Now query the marker directly.
- **Misleading metric:** `consolidate` folded query-pattern strengthenings (CONCEPT neurons/synapses, not listable fibers) into `habits_learned`, so "Habits learned: 1" appeared while the list stayed empty. Query patterns now have their own "Query patterns learned" line.
- **Durability:** the `merge` strategy could fold a `_habit_pattern` fiber into a summary and drop the marker, silently deleting the habit. Habit fibers are now excluded from merge clusters.

Verified live on the reporter's brain: `smem habits status` shows `recall → remember [##########] 6/3 (READY)`, `smem consolidate --strategy learn_habits` materialized it, and `smem habits list` now shows it.

## Tests

- `test_audit_fixes.py`: `find_fibers(metadata_key)` returns a marked fiber beyond the `LIMIT` window; query-pattern metric separated in the report summary.
- `test_consolidation.py`: `_merge` never deletes a `_habit_pattern` fiber at 100% overlap.
- `test_recall_quality.py`: dead-neuron-prune tests updated for the new `get_all_neuron_states` primary path.
- Full suite (CI parity, no live DB, `-n auto`): **6354 passed, 64 skipped, 1 xfailed**. Ruff `check`/`format --check` on `src/ tests/` clean. Docs-freshness clean.

Ships as **2.10.3**.

## Test plan

- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/`
- [x] Full unit suite green (CI parity)
- [x] Prune dry-run <120s on the live 67k-neuron brain (39s)
- [x] `smem habits list` shows the materialized habit end-to-end
- [ ] CI green on this PR