### PR TITLE
feat: mine tool_events into habits + idempotent habit learning (2.10.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.4] — Tool-usage habits
+
+Tool calls now feed habit learning: repeated tool workflows (Read → Edit →
+Bash, …) become listable habits, closing the gap where a months-old brain with
+thousands of buffered tool events had almost nothing to show in
+`smem habits list`.
+
+### Added
+
+- **Tool-usage habit mining.** The `learn_habits` consolidation strategy now
+  also mines the `tool_events` buffer. Tool events carry no session id, so the
+  history is treated as one time-ordered stream segmented by the sequential
+  window; same-tool self-pairs (Bash → Bash) are dropped, and at most 25 new
+  tool habits materialize per run (repeated runs drain the backlog). Learned
+  habits are regular `_habit_pattern` WORKFLOW fibers — they show up in
+  `smem habits list` alongside action habits, tagged
+  `_habit_source: tool_events`. Backends without a tool-event buffer are a
+  graceful no-op (`get_tool_events_for_mining` defaults to empty).
+
+### Fixed
+
+- **Habit learning is now idempotent.** Every consolidation run re-created the
+  same action habit (e.g. a duplicate `recall-remember` fiber per run) because
+  nothing consumed the mined events. Both action and tool habit mining now skip
+  step-sequences that already exist as `_habit_pattern` fibers.
+- **Habit confidence is clamped to [0, 1]** for tool habits — without session
+  data the confidence formula degenerated to the raw frequency and
+  `smem habits list` printed values like `Confidence: 93.00`.
+
 ## [2.10.3] — Prune completes, habits stick
 
 Two user-reported bugs on large, months-old brains: `consolidate`'s prune step

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.10.3"
+version = "2.10.4"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.10.3"
+__version__ = "2.10.4"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -1539,6 +1539,17 @@ class ConsolidationEngine:
         except Exception:
             logger.debug("Query pattern learning failed (non-critical)", exc_info=True)
 
+        # Also learn tool-usage habits from the tool_events buffer (Read → Edit →
+        # Bash, …). Unlike query patterns these ARE listable `_habit_pattern`
+        # fibers, so they count toward habits_learned.
+        try:
+            from surreal_memory.engine.sequence_mining import learn_tool_habits
+
+            _, tool_report = await learn_tool_habits(self._storage, brain.config, reference_time)
+            report.habits_learned += tool_report.habits_learned
+        except Exception:
+            logger.debug("Tool-usage habit learning failed (non-critical)", exc_info=True)
+
     async def _dedup(
         self,
         report: ConsolidationReport,

--- a/src/surreal_memory/engine/sequence_mining.py
+++ b/src/surreal_memory/engine/sequence_mining.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
+from dataclasses import replace as dc_replace
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -336,8 +337,53 @@ async def learn_habits(
     if not candidates:
         return [], report
 
+    # Idempotency: skip candidates already materialized as habit fibers. Without
+    # this every consolidation run re-created the same habit (e.g. a duplicate
+    # `recall-remember` fiber per run) because nothing consumed the mined events.
+    existing_steps = await _existing_habit_steps(storage)
+    candidates = [c for c in candidates if tuple(c.steps) not in existing_steps]
+    if not candidates:
+        return [], report
+
     # 4. Materialize qualifying candidates
+    learned = await _materialize_habits(storage, candidates, config, report, source="action_log")
+
+    # 5. Prune old action events (>60 days)
+    prune_cutoff = reference_time - timedelta(days=60)
+    pruned = await storage.prune_action_events(prune_cutoff)
+    report.action_events_pruned = pruned
+
+    return learned, report
+
+
+async def _existing_habit_steps(storage: NeuralStorage) -> set[tuple[str, ...]]:
+    """Step-sequences of habits already materialized as `_habit_pattern` fibers."""
+    existing = await storage.find_fibers(metadata_key="_habit_pattern", limit=1000)
+    return {
+        tuple(f.metadata.get("_workflow_actions", []))
+        for f in existing
+        if f.metadata.get("_workflow_actions")
+    }
+
+
+async def _materialize_habits(
+    storage: NeuralStorage,
+    candidates: list[HabitCandidate],
+    config: BrainConfig,
+    report: HabitReport,
+    source: str,
+) -> list[LearnedHabit]:
+    """Create ACTION neurons + BEFORE synapses + WORKFLOW fibers for candidates.
+
+    Shared by action-log habits (``learn_habits``) and tool-usage habits
+    (``learn_tool_habits``). ``source`` is stored on each fiber as
+    ``_habit_source`` for observability; both remain ``_habit_pattern=True`` so
+    ``smem habits list`` shows them. Mutates *report* (habits_learned,
+    pairs_strengthened).
+    """
     learned: list[LearnedHabit] = []
+    if not candidates:
+        return learned
 
     # Batch-fetch all unique step names across all candidates
     all_steps = {step for candidate in candidates for step in candidate.steps}
@@ -376,12 +422,9 @@ async def learn_habits(
 
         # Create WORKFLOW fiber
         name = heuristic_habit_name(candidate.steps)
-        synapse_id_set = {s.id for s in sequence_synapses}
-        neuron_id_set = set(neuron_ids)
-
         workflow_fiber = Fiber.create(
-            neuron_ids=neuron_id_set,
-            synapse_ids=synapse_id_set,
+            neuron_ids=set(neuron_ids),
+            synapse_ids={s.id for s in sequence_synapses},
             anchor_neuron_id=neuron_ids[0],
             pathway=neuron_ids,
             summary=name,
@@ -391,6 +434,7 @@ async def learn_habits(
                 "_habit_pattern": True,
                 "_habit_frequency": candidate.frequency,
                 "_habit_confidence": candidate.confidence,
+                "_habit_source": source,
             },
         )
         await storage.add_fiber(workflow_fiber)
@@ -406,9 +450,99 @@ async def learn_habits(
         )
         report.habits_learned += 1
 
-    # 5. Prune old action events (>60 days)
-    prune_cutoff = reference_time - timedelta(days=60)
-    pruned = await storage.prune_action_events(prune_cutoff)
-    report.action_events_pruned = pruned
+    return learned
 
+
+# Tool-usage habit mining tunables (module-level — no BrainConfig migration).
+_TOOL_HABIT_LOOKBACK_DAYS = 30
+_TOOL_HABIT_MAX_EVENTS = 5000
+_TOOL_HABIT_MAX = 25  # cap materialized tool habits per run to avoid flooding
+
+
+async def learn_tool_habits(
+    storage: NeuralStorage,
+    config: BrainConfig,
+    reference_time: datetime,
+) -> tuple[list[LearnedHabit], HabitReport]:
+    """Learn habits from tool-usage sequences (e.g. Read → Edit → Bash).
+
+    Mirrors ``learn_habits`` but mines the ``tool_events`` buffer instead of the
+    action_log. Tool events carry no session_id, so the whole history is treated
+    as one time-ordered stream, segmented by the sequential window. Same-tool
+    self-pairs (Bash → Bash) are dropped — they are not workflows. Idempotent:
+    candidates whose step-sequence already exists as a ``_habit_pattern`` fiber
+    are skipped, so repeated consolidation runs don't accumulate duplicates.
+    Backends without a tool_events buffer (get_tool_events_for_mining → []) are
+    a graceful no-op.
+    """
+    from surreal_memory.core.action_event import ActionEvent
+
+    report = HabitReport()
+    brain_id = storage.current_brain_id
+    if not brain_id:
+        return [], report
+
+    since = reference_time - timedelta(days=_TOOL_HABIT_LOOKBACK_DAYS)
+    rows = await storage.get_tool_events_for_mining(
+        brain_id, since=since, limit=_TOOL_HABIT_MAX_EVENTS
+    )
+    if len(rows) < 2:
+        return [], report
+
+    # Build one time-ordered ActionEvent stream (tool_name as action_type).
+    events: list[ActionEvent] = []
+    for r in rows:
+        created = r.get("created_at")
+        if isinstance(created, str):
+            try:
+                created = datetime.fromisoformat(created.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+        if not isinstance(created, datetime):
+            continue
+        if created.tzinfo is not None:
+            created = created.replace(tzinfo=None)  # naive UTC (tool events are UTC)
+        tool = str(r.get("tool_name") or "").strip()
+        if not tool:
+            continue
+        events.append(
+            ActionEvent(
+                brain_id=brain_id,
+                session_id=None,
+                action_type=tool,
+                created_at=created,
+            )
+        )
+    report.sequences_analyzed = len(events)
+    if len(events) < 2:
+        return [], report
+
+    pairs = mine_sequential_pairs(events, config.sequential_window_seconds)
+    # Drop self-pairs (Bash → Bash): repetition of one tool is not a workflow.
+    pairs = [p for p in pairs if p.action_a != p.action_b]
+    if not pairs:
+        return [], report
+
+    candidates = extract_habit_candidates(pairs, config.habit_min_frequency, total_sessions=1)
+    if not candidates:
+        return [], report
+
+    # No session data → extract's confidence degenerates to raw frequency; clamp
+    # to [0, 1] so `smem habits list` doesn't print "Confidence: 93.00".
+    candidates = [
+        dc_replace(c, confidence=min(1.0, c.confidence)) if c.confidence > 1.0 else c
+        for c in candidates
+    ]
+
+    # Idempotency: skip candidates already materialized as habit fibers, so
+    # repeated consolidation doesn't accumulate duplicate tool habits.
+    existing_steps = await _existing_habit_steps(storage)
+    fresh = [c for c in candidates if tuple(c.steps) not in existing_steps]
+    if not fresh:
+        return [], report
+
+    # Cap to the strongest N (candidates are frequency-sorted) to avoid flooding.
+    fresh = fresh[:_TOOL_HABIT_MAX]
+
+    learned = await _materialize_habits(storage, fresh, config, report, source="tool_events")
     return learned, report

--- a/src/surreal_memory/engine/sequence_mining.py
+++ b/src/surreal_memory/engine/sequence_mining.py
@@ -457,6 +457,12 @@ async def _materialize_habits(
 _TOOL_HABIT_LOOKBACK_DAYS = 30
 _TOOL_HABIT_MAX_EVENTS = 5000
 _TOOL_HABIT_MAX = 25  # cap materialized tool habits per run to avoid flooding
+# Tool events are orders of magnitude denser than action events (hundreds per
+# session vs a handful), so the configured habit_min_frequency (default 3) lets
+# nearly every tool combination qualify — live-tested at ~1.7k events it drained
+# a 134-habit backlog of mostly freq-3 noise. Scale the frequency floor with
+# volume: 1 per this many events (e.g. 1700 events → floor 17).
+_TOOL_HABIT_FREQ_DIVISOR = 100
 
 
 async def learn_tool_habits(
@@ -523,7 +529,10 @@ async def learn_tool_habits(
     if not pairs:
         return [], report
 
-    candidates = extract_habit_candidates(pairs, config.habit_min_frequency, total_sessions=1)
+    # Volume-scaled frequency floor: only genuinely habitual tool workflows
+    # qualify on dense streams; small brains keep the configured threshold.
+    effective_min_freq = max(config.habit_min_frequency, len(events) // _TOOL_HABIT_FREQ_DIVISOR)
+    candidates = extract_habit_candidates(pairs, effective_min_freq, total_sessions=1)
     if not candidates:
         return [], report
 

--- a/src/surreal_memory/storage/base.py
+++ b/src/surreal_memory/storage/base.py
@@ -1179,6 +1179,21 @@ class NeuralStorage(ABC):
         """
         raise NotImplementedError
 
+    async def get_tool_events_for_mining(
+        self,
+        brain_id: str,
+        since: datetime | None = None,
+        limit: int = 5000,
+    ) -> list[dict[str, Any]]:
+        """Return tool events (tool_name + created_at) oldest-first for habit mining.
+
+        Default: no tool-event storage → empty list, so habit mining is a no-op
+        on backends without a tool_events buffer. Backends that buffer tool
+        events (SurrealDB, SQLite, in-memory) override this. Ignores the
+        ``processed`` flag — mining reads the full history and never mutates it.
+        """
+        return []
+
     async def add_retrieval_trace(self, trace: RetrievalTrace) -> str:
         """Persist a retrieval trace. Returns the trace ID."""
         raise NotImplementedError

--- a/src/surreal_memory/storage/memory_store.py
+++ b/src/surreal_memory/storage/memory_store.py
@@ -795,6 +795,34 @@ class InMemoryStorage(
         """Return unprocessed tool events (in-memory: always empty)."""
         return []
 
+    async def get_tool_events_for_mining(
+        self,
+        brain_id: str,
+        since: datetime | None = None,
+        limit: int = 5000,
+    ) -> list[dict[str, Any]]:
+        """Return buffered tool events (tool_name + created_at) oldest-first.
+
+        In-memory ``insert_tool_events`` appends onto ``_action_events``; pick
+        the entries that carry a ``tool_name`` (tool events) and order by time.
+        """
+        out: list[dict[str, Any]] = []
+        for ev in self._action_events.get(brain_id, []):
+            if "tool_name" not in ev:
+                continue
+            created = ev.get("created_at")
+            if since is not None and isinstance(created, datetime) and created <= since:
+                continue
+            out.append(
+                {
+                    "tool_name": ev.get("tool_name", ""),
+                    "session_id": ev.get("session_id", ""),
+                    "created_at": created,
+                }
+            )
+        out.sort(key=lambda e: str(e["created_at"]))
+        return out[: min(int(limit), 20000)]
+
     async def mark_events_processed(self, brain_id: str, event_ids: list[int]) -> None:
         """Mark events as processed (no-op for in-memory storage)."""
 

--- a/src/surreal_memory/storage/sqlite_tool_events.py
+++ b/src/surreal_memory/storage/sqlite_tool_events.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 from surreal_memory.utils.timeutils import utcnow
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     import aiosqlite
 
 logger = logging.getLogger(__name__)
@@ -105,6 +107,38 @@ class SQLiteToolEventsMixin:
                         "duration_ms": row["duration_ms"],
                         "session_id": row["session_id"],
                         "task_context": row["task_context"],
+                        "created_at": row["created_at"],
+                    }
+                )
+        return results
+
+    async def get_tool_events_for_mining(
+        self,
+        brain_id: str,
+        since: datetime | None = None,
+        limit: int = 5000,
+    ) -> list[dict[str, Any]]:
+        """Return tool events (tool_name + created_at) oldest-first for habit mining.
+
+        Ignores the ``processed`` flag — habit mining reads the full history and
+        never mutates it.
+        """
+        conn = self._ensure_read_conn()
+        safe_limit = min(int(limit), 20000)
+        query = "SELECT tool_name, session_id, created_at FROM tool_events WHERE brain_id = ?"
+        params: list[Any] = [brain_id]
+        if since is not None:
+            query += " AND created_at > ?"
+            params.append(since.isoformat())
+        query += " ORDER BY created_at ASC LIMIT ?"
+        params.append(safe_limit)
+        results: list[dict[str, Any]] = []
+        async with conn.execute(query, params) as cursor:
+            async for row in cursor:
+                results.append(
+                    {
+                        "tool_name": row["tool_name"],
+                        "session_id": row["session_id"],
                         "created_at": row["created_at"],
                     }
                 )

--- a/src/surreal_memory/storage/surrealdb/tool_events.py
+++ b/src/surreal_memory/storage/surrealdb/tool_events.py
@@ -112,6 +112,35 @@ class SurrealDBToolEventsMixin:
             for r in rows
         ]
 
+    async def get_tool_events_for_mining(
+        self,
+        brain_id: str,
+        since: datetime | None = None,
+        limit: int = 5000,
+    ) -> list[dict[str, Any]]:
+        """Return tool events (tool_name + created_at) oldest-first for habit mining.
+
+        Unlike ``get_unprocessed_events`` this ignores the ``processed`` flag —
+        habit mining observes the full accumulated history and never mutates it
+        (tool events carry no session_id, so mining treats them as one stream).
+        """
+        safe_limit = min(int(limit), 20000)
+        sql = "SELECT tool_name, session_id, created_at FROM tool_events WHERE brain_id = $bid"
+        params: dict[str, Any] = {"bid": brain_id}
+        if since is not None:
+            sql += " AND created_at > $since"
+            params["since"] = since
+        sql += f" ORDER BY created_at ASC LIMIT {safe_limit}"
+        rows = await self._query(sql, **params)
+        return [
+            {
+                "tool_name": r.get("tool_name", ""),
+                "session_id": r.get("session_id", ""),
+                "created_at": _iso(r.get("created_at")),
+            }
+            for r in rows
+        ]
+
     async def mark_events_processed(
         self,
         brain_id: str,

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.10.3"
+        assert surreal_memory.__version__ == "2.10.4"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_sequence_mining.py
+++ b/tests/unit/test_sequence_mining.py
@@ -504,6 +504,39 @@ class TestToolHabits:
         assert learned == []
         assert report.habits_learned == 0
 
+    async def test_volume_scaled_frequency_floor(self, store: InMemoryStorage) -> None:
+        """On dense streams, low-frequency combos must not qualify as habits.
+
+        400 events raise the effective floor to 400/100 = 4, so a pair seen only
+        3 times (= config threshold) is rejected as noise.
+        """
+        now = utcnow()
+        t = now - timedelta(hours=8)
+        events = []
+        # Dense filler: 394 alternating Bash/Read (self-pair-free noise floor
+        # carrier; Bash→Read itself is frequent and WILL qualify).
+        for i in range(394):
+            events.append(_tool_event("Bash" if i % 2 == 0 else "Read", t))
+            t += timedelta(seconds=20)
+        # Rare pair Grep→Write occurs exactly 3 times — below the scaled floor.
+        for _ in range(3):
+            events.append(_tool_event("Grep", t))
+            t += timedelta(seconds=10)
+            events.append(_tool_event("Write", t))
+            t += timedelta(minutes=10)
+        await store.insert_tool_events(store.current_brain_id, events)
+
+        config = BrainConfig(habit_min_frequency=3, sequential_window_seconds=60.0)
+        learned, _ = await learn_tool_habits(store, config, now)
+
+        names = {h.name for h in learned}
+        assert not any("Grep" in n for n in names), (
+            "freq-3 pair must be rejected when the volume-scaled floor is 4"
+        )
+        assert any("Bash" in n and "Read" in n for n in names), (
+            "genuinely frequent pairs must still qualify"
+        )
+
     async def test_action_habits_idempotent_across_runs(self, store: InMemoryStorage) -> None:
         """learn_habits must not re-create the same habit on every consolidation.
 

--- a/tests/unit/test_sequence_mining.py
+++ b/tests/unit/test_sequence_mining.py
@@ -16,6 +16,7 @@ from surreal_memory.engine.sequence_mining import (
     extract_habit_candidates,
     heuristic_habit_name,
     learn_habits,
+    learn_tool_habits,
     mine_sequential_pairs,
 )
 from surreal_memory.storage.memory_store import InMemoryStorage
@@ -424,3 +425,105 @@ class TestLearnHabits:
         assert report.habits_learned >= 1
         assert report.pairs_strengthened >= 1
         assert isinstance(report.action_events_pruned, int)
+
+
+# ── learn_tool_habits (tool_events → habits) ─────────────────────
+
+
+def _tool_event(tool: str, at: datetime) -> dict:
+    """Synthetic tool-event row as buffered by insert_tool_events."""
+    return {"tool_name": tool, "session_id": "", "created_at": at, "success": True}
+
+
+class TestToolHabits:
+    """Tool-usage sequences from the tool_events buffer become habit fibers."""
+
+    async def test_tool_sequences_become_habit_fibers(self, store: InMemoryStorage) -> None:
+        """Repeated Read → Edit → Bash runs materialize a _habit_pattern fiber."""
+        now = utcnow()
+        t = now - timedelta(minutes=30)
+        events = []
+        for _ in range(3):  # 3 repetitions ≥ habit_min_frequency=2
+            for tool in ("Read", "Edit", "Bash"):
+                events.append(_tool_event(tool, t))
+                t += timedelta(seconds=10)  # within 60s window
+            t += timedelta(minutes=10)  # gap breaks the sequence between runs
+        await store.insert_tool_events(store.current_brain_id, events)
+
+        config = BrainConfig(habit_min_frequency=2, sequential_window_seconds=60.0)
+        learned, report = await learn_tool_habits(store, config, now)
+
+        assert report.habits_learned >= 1
+        habits = await store.find_fibers(metadata_key="_habit_pattern", limit=100)
+        assert habits, "tool habits must be listable via the _habit_pattern marker"
+        assert any(h.metadata.get("_habit_source") == "tool_events" for h in habits)
+        names = {h.name for h in learned}
+        assert any("Read" in n and "Edit" in n for n in names)
+
+    async def test_self_pairs_do_not_form_habits(self, store: InMemoryStorage) -> None:
+        """Bash → Bash repetition is not a workflow and must not become a habit."""
+        now = utcnow()
+        t = now - timedelta(minutes=5)
+        events = [_tool_event("Bash", t + timedelta(seconds=5 * i)) for i in range(10)]
+        await store.insert_tool_events(store.current_brain_id, events)
+
+        config = BrainConfig(habit_min_frequency=2, sequential_window_seconds=60.0)
+        learned, report = await learn_tool_habits(store, config, now)
+
+        assert learned == []
+        assert report.habits_learned == 0
+
+    async def test_idempotent_across_runs(self, store: InMemoryStorage) -> None:
+        """A second mining run must not duplicate already-materialized habits."""
+        now = utcnow()
+        t = now - timedelta(minutes=30)
+        events = []
+        for _ in range(3):
+            for tool in ("Grep", "Read"):
+                events.append(_tool_event(tool, t))
+                t += timedelta(seconds=10)
+            t += timedelta(minutes=10)
+        await store.insert_tool_events(store.current_brain_id, events)
+
+        config = BrainConfig(habit_min_frequency=2, sequential_window_seconds=60.0)
+        _, first = await learn_tool_habits(store, config, now)
+        assert first.habits_learned >= 1
+        count_after_first = len(await store.find_fibers(metadata_key="_habit_pattern", limit=100))
+
+        _, second = await learn_tool_habits(store, config, now)
+        count_after_second = len(await store.find_fibers(metadata_key="_habit_pattern", limit=100))
+
+        assert second.habits_learned == 0
+        assert count_after_second == count_after_first
+
+    async def test_no_tool_events_is_noop(self, store: InMemoryStorage) -> None:
+        """Backends/brains without tool events return an empty report."""
+        config = BrainConfig(habit_min_frequency=2, sequential_window_seconds=60.0)
+        learned, report = await learn_tool_habits(store, config, utcnow())
+
+        assert learned == []
+        assert report.habits_learned == 0
+
+    async def test_action_habits_idempotent_across_runs(self, store: InMemoryStorage) -> None:
+        """learn_habits must not re-create the same habit on every consolidation.
+
+        Regression: each `consolidate` run created another `recall-remember`
+        fiber because nothing consumed the mined action events.
+        """
+        for session_num in range(3):
+            sid = f"s{session_num}"
+            await store.record_action("recall", session_id=sid)
+            await store.record_action("remember", session_id=sid)
+
+        config = BrainConfig(habit_min_frequency=2, sequential_window_seconds=60.0)
+        now = utcnow()
+
+        _, first = await learn_habits(store, config, now)
+        assert first.habits_learned >= 1
+        count_first = len(await store.find_fibers(metadata_key="_habit_pattern", limit=100))
+
+        _, second = await learn_habits(store, config, now)
+        count_second = len(await store.find_fibers(metadata_key="_habit_pattern", limit=100))
+
+        assert second.habits_learned == 0
+        assert count_second == count_first

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

- Tool calls now feed habit learning: repeated tool workflows (Read → Edit → Bash, …) become listable `_habit_pattern` WORKFLOW fibers via a new `learn_tool_habits` stage inside the `learn_habits` consolidation strategy.
- New `get_tool_events_for_mining` storage method on all backends (SurrealDB / SQLite / in-memory), with a base default of `[]` so bufferless backends are a graceful no-op. It ignores the `processed` flag — mining reads the full history and never mutates it.
- **Idempotency fix (found during live verification):** every consolidation run re-created the same action habit (a duplicate `recall-remember` fiber per run) because nothing consumed the mined events. Both action and tool mining now skip step-sequences already materialized as `_habit_pattern` fibers.
- Tool-habit confidence clamped to [0, 1] (no session data → the formula degenerated to raw frequency; the CLI printed `Confidence: 93.00`).
- Shared `_materialize_habits` helper extracted (used by both paths); tool habits are tagged `_habit_source: tool_events`.

## Why

A months-old brain with ~1.7k buffered tool events had almost nothing in `smem habits list` — habit mining read only the `action_log` (recall/remember rows), never the tool-usage stream. Tool events carry no session id, so they're treated as one time-ordered stream segmented by the sequential window; same-tool self-pairs (Bash → Bash) are dropped; at most 25 new tool habits materialize per run so repeated consolidations drain the backlog gradually instead of flooding the graph.

Verified live on the reporting brain: 1679 tool events → habits like `Read-Bash` (freq 93), `Read-Edit-Bash`, `Write-Bash-Edit` visible in `smem habits list`; repeated runs produce **zero duplicates** (grouped-by-summary check in SurrealDB).

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` — 6359 passed, 64 skipped locally (CI parity, no live DB)
- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] New unit tests: tool sequences → habit fibers; self-pairs rejected; idempotent across runs (tool AND action paths); no-tool-events no-op
- [x] Live verification against a 67k-neuron brain (habits listed, no duplicates, backlog drains 25/run)
- [ ] CI green on this PR

Ships as **2.10.4**.