### PR TITLE
fix: consolidation scales + prune data-integrity guard + tool graph forms (2.10.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.5] — Consolidation scales, tool graph forms
+
+Full `smem consolidate` now finishes without per-strategy timeouts on large
+brains, and session-less tool events finally build the USED_WITH tool graph.
+
+### Fixed
+
+- **`compress` no longer times out on large brains.** On a ~67k-neuron brain
+  the strategy hit the 120s per-strategy budget: `compress_fiber` made one
+  `get_synapse` round trip per synapse id per fiber (~66k across 4.2k eligible
+  fibers) and fetched synapses even for tiers that never use them. Synapses
+  are now fetched in one bounded-concurrent batch and only for the
+  ENTITY_ONLY/TEMPLATE tiers that actually render relations; neuron batch
+  fetches are bounded-concurrent too. The compression run also takes a time
+  budget (80% of the strategy timeout) and reports any remainder as
+  `fibers_deferred` instead of being cancelled mid-run — deferred fibers stay
+  eligible, so repeated runs drain the backlog in O(batch) work per run.
+  Measured live: compress 120s-timeout → 72s clean; full `smem consolidate`
+  zero timeouts. Note: on SurrealDB 3.2.0 a single `id IN [...]` query over
+  RecordIDs measured ~8x *slower* than per-id direct selects (IN-membership
+  skips the primary index), hence concurrency-shaped batching rather than an
+  IN query.
+- **Session-less tool events now form USED_WITH/EFFECTIVE_FOR synapses.**
+  `process_events` dropped every tool event with an empty `session_id` from
+  co-occurrence grouping, so on brains where tool events carry no session
+  (all of them on a hook-fed brain) the tool graph never formed — 0 USED_WITH
+  synapses. Session-less events now fold into one shared time-ordered stream
+  (the same treatment tool-habit mining already uses), still bounded by the
+  co-occurrence window. Verified live: 16 USED_WITH synapses formed from the
+  pending backlog.
+- **Test suite: deflaked the aiosqlite leak-guard pair under `pytest-xdist`**
+  (`KeyError: 'thread'` when its two cooperating tests landed on different
+  workers) by pinning them to one worker via `xdist_group` +
+  `--dist loadgroup`, and isolated two env-sensitive tests from ambient
+  `SURREAL_MEMORY_EMBEDDING_ENDPOINT`/`SURREAL_MEMORY_RERANKER_ENDPOINT`
+  developer environments.
+
+### Added
+
+- `get_synapses_batch` on all storage backends (batched on SQLite/SurrealDB,
+  sequential fallback on the base class), mirroring `get_neurons_batch`.
+
 ## [2.10.4] — Tool-usage habits
 
 Tool calls now feed habit learning: repeated tool workflows (Read → Edit →

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,15 @@ below before relying on `prune`/`consolidate` on an existing brain.
   `--dist loadgroup`, and isolated two env-sensitive tests from ambient
   `SURREAL_MEMORY_EMBEDDING_ENDPOINT`/`SURREAL_MEMORY_RERANKER_ENDPOINT`
   developer environments.
+- **Test suite: the e2e API tests can no longer write into a configured live
+  SurrealDB.** The `client` fixture redirected `SURREAL_MEMORY_DIR` to a temp
+  dir, but a fresh config inherits `storage_backend` from the
+  `SURREAL_MEMORY_STORAGE` env var — on a dev shell exporting
+  `surrealdb` + `SURREALDB_URL`/`SURREALDB_PASS`, the suite created dozens of
+  test brains in the production DB and xdist workers aborted each other with
+  `Transaction write conflict` setup errors. The fixture now forces the
+  sqlite fixture backend, strips the live-DB env vars, and resets the cached
+  `_surrealdb_storage` singleton (which bypasses `_storage_cache`).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.10.5] — Consolidation scales, tool graph forms
+## [2.10.5] — Consolidation scales, prune stops eating memories
 
 Full `smem consolidate` now finishes without per-strategy timeouts on large
-brains, and session-less tool events finally build the USED_WITH tool graph.
+brains, session-less tool events finally build the USED_WITH tool graph, and
+a data-integrity bug in dead-neuron pruning is fixed — see the first entry
+below before relying on `prune`/`consolidate` on an existing brain.
 
 ### Fixed
 
+- **`prune` no longer deletes live memory content.** Dead-neuron pruning
+  (`access_frequency == 0` + old enough) never checked fiber membership,
+  unlike orphan detection right above it in the same loop, which does.
+  `reinforce()` only bumps `access_frequency` for the top-10
+  highest-activation neurons per recall, so most neurons that are genuinely
+  part of an actively-recalled fiber read `access_frequency == 0` forever —
+  once prune's delete phase could actually complete (see the next entry),
+  this deleted real memory content instead of dead junk. Measured live:
+  57150 of 63380 neuron_states were fiber members reading
+  `access_frequency == 0` (nearly the whole brain was wrongly eligible).
+  Dead-neuron pruning now skips any neuron that belongs to a fiber, mirroring
+  the orphan-detection guard. **If you've run `consolidate` (prune or `all`)
+  non-dry-run on 2.10.0–2.10.4, check your brain's neuron/synapse counts
+  against a recent backup** — this bug could only fire once prune's delete
+  phase ran to completion, which the timeout below usually prevented, but a
+  smaller brain (or one that later grew past the point where prune was
+  timing out) could have been silently affected.
+- **`prune`'s delete phase no longer costs ~1.2s per neuron.**
+  `delete_neuron`'s synapse-cleanup query — `... WHERE brain_id = $b AND
+  (in = X OR out = X)` — doesn't hit either `idx_synapse_in`/`idx_synapse_out`
+  on SurrealDB 3.2.0: its planner falls back to a full scan across an OR of
+  two different fields regardless of whether brain_id/the record id are
+  inlined or param-bound. Splitting into two single-field DELETEs (each hits
+  its own index) measured ~5ms total instead of ~1.2s — the dominant cost
+  behind prune's 120s timeout once the read-side N+1 was fixed. Added
+  `delete_neurons_batch`/`delete_synapses_batch` to the SurrealDB backend
+  (previously SQLite-only); both are sequential, not concurrent — concurrent
+  deletes raised live `Transaction conflict` errors under SurrealDB's
+  transaction isolation, unlike concurrent reads, which are safe.
 - **`compress` no longer times out on large brains.** On a ~67k-neuron brain
   the strategy hit the 120s per-strategy budget: `compress_fiber` made one
   `get_synapse` round trip per synapse id per fiber (~66k across 4.2k eligible

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,7 +292,10 @@ warn_return_any = false
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
-addopts = "-v --tb=short"
+# --dist loadgroup: honor @pytest.mark.xdist_group so cooperating tests (e.g.
+# the aiosqlite leak-guard pair) share one xdist worker; ungrouped tests are
+# scheduled exactly like the default `load`.
+addopts = "-v --tb=short --dist loadgroup"
 timeout = 60
 markers = [
     "stress: real-world workflow stress tests with SQLiteStorage",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.10.4"
+version = "2.10.5"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.10.4"
+__version__ = "2.10.5"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/compression.py
+++ b/src/surreal_memory/engine/compression.py
@@ -30,7 +30,6 @@ from surreal_memory.utils.timeutils import ensure_naive_utc, utcnow
 
 if TYPE_CHECKING:
     from surreal_memory.core.fiber import Fiber
-    from surreal_memory.core.synapse import Synapse
     from surreal_memory.storage.base import NeuralStorage
 
 logger = logging.getLogger(__name__)
@@ -158,6 +157,7 @@ class CompressionReport:
     duration_ms: float = 0.0
     fibers_compressed: int = 0
     fibers_skipped: int = 0
+    fibers_deferred: int = 0
     tokens_saved: int = 0
     backups_created: int = 0
     dry_run: bool = False
@@ -174,6 +174,8 @@ class CompressionReport:
             f"  Backups created: {self.backups_created}",
             f"  Duration: {self.duration_ms:.1f}ms",
         ]
+        if self.fibers_deferred:
+            lines.append(f"  Fibers deferred to next run (time budget): {self.fibers_deferred}")
         return "\n".join(lines)
 
 
@@ -584,14 +586,20 @@ class CompressionEngine:
         neurons = await self._storage.get_neurons_batch(list(fiber.neuron_ids))
         neuron_contents = [n.content for n in neurons.values()]
 
-        # Fetch synapses for entity-level relation labels.
-        all_synapses: list[Synapse] = []
-        if fiber.synapse_ids:
-            for syn_id in fiber.synapse_ids:
-                syn = await self._storage.get_synapse(syn_id)
-                if syn is not None:
-                    all_synapses.append(syn)
-        relations = [str(s.type) for s in all_synapses]
+        # Fetch synapses for entity-level relation labels — only ENTITY_ONLY and
+        # TEMPLATE tiers consume `relations` (see compress_tier2_entity_preserving /
+        # compress_tier3_template below). EXTRACTIVE/GRAPH_ONLY never read it, so
+        # skipping the fetch for those tiers halves the per-fiber DB round trips
+        # on a brain where most eligible fibers land in EXTRACTIVE (measured: 63%
+        # on the `default` brain, the dominant contributor to the 120s compress
+        # timeout alongside the neuron fetch).
+        relations: list[str] = []
+        if fiber.synapse_ids and target_tier in (
+            CompressionTier.ENTITY_ONLY,
+            CompressionTier.TEMPLATE,
+        ):
+            synapses_map = await self._storage.get_synapses_batch(list(fiber.synapse_ids))
+            relations = [str(s.type) for s in synapses_map.values()]
 
         # Build a representative "content" string from neuron contents for
         # tiers that operate on text (1-2).
@@ -923,6 +931,7 @@ class CompressionEngine:
         *,
         reference_time: datetime | None = None,
         dry_run: bool = False,
+        time_budget_seconds: float | None = None,
     ) -> CompressionReport:
         """Compress all eligible fibers in the current brain.
 
@@ -933,6 +942,13 @@ class CompressionEngine:
         Args:
             reference_time: UTC reference time for age calculation (default: now).
             dry_run: If True, compute but do not apply changes.
+            time_budget_seconds: If set, stop compressing once elapsed time
+                exceeds this budget and report the remainder as
+                ``fibers_deferred`` instead of running unbounded. A fiber only
+                becomes ineligible once actually compressed, so deferred work
+                is picked up by the next run — the strategy is O(batch) per
+                call rather than O(brain size), which is what lets it keep up
+                as the brain grows instead of eventually timing out again.
 
         Returns:
             A CompressionReport with aggregate statistics.
@@ -950,7 +966,7 @@ class CompressionEngine:
 
         fibers = await self._storage.get_fibers(limit=10000)
 
-        for fiber in fibers:
+        for idx, fiber in enumerate(fibers):
             # Pinned (KB) fibers stay at tier 0 forever
             if fiber.pinned:
                 report.fibers_skipped += 1
@@ -975,6 +991,18 @@ class CompressionEngine:
                 report.fibers_skipped += 1
                 continue
 
+            if (
+                time_budget_seconds is not None
+                and time.perf_counter() - start > time_budget_seconds
+            ):
+                report.fibers_deferred += len(fibers) - idx
+                logger.info(
+                    "Compression time budget (%.0fs) reached; deferring %d fibers to the next run",
+                    time_budget_seconds,
+                    report.fibers_deferred,
+                )
+                break
+
             try:
                 result = await self.compress_fiber(fiber, target_tier, dry_run=dry_run)
             except Exception:
@@ -994,9 +1022,10 @@ class CompressionEngine:
 
         report.duration_ms = (time.perf_counter() - start) * 1000
         logger.info(
-            "Compression run complete: %d compressed, %d skipped, %d tokens saved",
+            "Compression run complete: %d compressed, %d skipped, %d deferred, %d tokens saved",
             report.fibers_compressed,
             report.fibers_skipped,
+            report.fibers_deferred,
             report.tokens_saved,
         )
         return report

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -1690,13 +1690,21 @@ class ConsolidationEngine:
             return
 
         engine = CompressionEngine(self._storage)
+        # Leave headroom under the per-strategy timeout for the initial
+        # get_fibers() scan and report assembly — compressing right up to the
+        # wire risks the outer asyncio.wait_for cancelling mid-fiber instead of
+        # returning a clean, resumable report.
+        time_budget = self._config.strategy_timeout_seconds * 0.8
         compression_report = await engine.run(
             reference_time=reference_time,
             dry_run=dry_run,
+            time_budget_seconds=time_budget,
         )
 
         report.fibers_compressed += compression_report.fibers_compressed
         report.tokens_saved += compression_report.tokens_saved
+        if compression_report.fibers_deferred:
+            report.extra["compress_fibers_deferred"] = compression_report.fibers_deferred
 
     async def _lifecycle(
         self,

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -649,7 +649,19 @@ class ConsolidationEngine:
                     orphan_ids.append(neuron.id)
                     continue
 
-                # Dead neuron: has connections but never accessed, old enough
+                # Dead neuron: has connections but never accessed, old enough.
+                # Never applies to fiber members: reinforce() (retrieval.py) only
+                # bumps access_frequency for the top-10 highest-activation neurons
+                # per recall, so most neurons that are genuinely part of an
+                # actively-recalled fiber still read access_frequency == 0 forever.
+                # Without this guard, "dead" pruning deletes real memory content
+                # (measured live: 57150/63380 neuron_states were fiber members with
+                # access_frequency == 0 — nearly the whole brain was wrongly
+                # eligible). Only a neuron with NO fiber membership at all (already
+                # excluded from is_orphan above only because it still has a direct
+                # synapse connection) is a genuine dead-neuron candidate.
+                if neuron.id in fiber_neuron_ids:
+                    continue
                 state = states.get(neuron.id)
                 freq = state.access_frequency if state else 0
                 if freq > 0:

--- a/src/surreal_memory/engine/tool_memory.py
+++ b/src/surreal_memory/engine/tool_memory.py
@@ -254,12 +254,17 @@ async def process_events(
     # Only process tools that meet frequency threshold
     frequent_tools = {t for t, c in tool_freq.items() if c >= config.min_frequency}
 
-    # Group events by session for co-occurrence detection
+    # Group events by session for co-occurrence detection. Tool events commonly
+    # carry no session_id (background/subagent tool calls) — those still form a
+    # valid, shared time-ordered stream rather than being dropped entirely, the
+    # same treatment `learn_tool_habits` (sequence_mining.py) already gives the
+    # session-less tool_events buffer. The sliding-window check below already
+    # bounds pairing to events within `cooccurrence_window_s`, so folding all
+    # session-less events into one bucket doesn't change its complexity.
     sessions: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for ev in events:
-        sid = ev.get("session_id", "")
-        if sid:
-            sessions[sid].append(ev)
+        sid = ev.get("session_id") or "_no_session"
+        sessions[sid].append(ev)
 
     # USED_WITH detection: sliding window within each session
     seen_pairs: set[tuple[str, str]] = set()

--- a/src/surreal_memory/storage/base.py
+++ b/src/surreal_memory/storage/base.py
@@ -302,6 +302,25 @@ class NeuralStorage(ABC):
         """
         ...
 
+    async def get_synapses_batch(self, synapse_ids: list[str]) -> dict[str, Synapse]:
+        """Get multiple synapses by ID in a single operation.
+
+        Default implementation falls back to sequential get_synapse.
+        Backends should override for batch efficiency.
+
+        Args:
+            synapse_ids: List of synapse IDs to fetch
+
+        Returns:
+            Dict mapping synapse_id to Synapse for found synapses
+        """
+        results: dict[str, Synapse] = {}
+        for sid in synapse_ids:
+            synapse = await self.get_synapse(sid)
+            if synapse is not None:
+                results[sid] = synapse
+        return results
+
     @abstractmethod
     async def get_synapses(
         self,

--- a/src/surreal_memory/storage/factory.py
+++ b/src/surreal_memory/storage/factory.py
@@ -224,6 +224,9 @@ class HybridStorage:
     async def get_synapses(self, **kwargs: Any) -> list[Synapse]:
         return await self._local.get_synapses(**kwargs)
 
+    async def get_synapses_batch(self, synapse_ids: list[str]) -> dict[str, Synapse]:
+        return await self._local.get_synapses_batch(synapse_ids)
+
     async def update_synapse(self, synapse: Synapse) -> None:
         await self._local.update_synapse(synapse)
         if self._auto_sync:

--- a/src/surreal_memory/storage/sqlite_synapses.py
+++ b/src/surreal_memory/storage/sqlite_synapses.py
@@ -448,7 +448,7 @@ class SQLiteSynapseMixin:
         neuron_ids = [nid for nid, _ in path]
         synapse_ids = [sid for _, sid in path]
         neurons = await self.get_neurons_batch(neuron_ids)
-        synapses_map = await self._get_synapses_batch(synapse_ids)
+        synapses_map = await self.get_synapses_batch(synapse_ids)
         result: list[tuple[Neuron, Synapse]] = []
         for neuron_id, synapse_id in path:
             neuron = neurons.get(neuron_id)
@@ -457,7 +457,7 @@ class SQLiteSynapseMixin:
                 result.append((neuron, synapse))
         return result
 
-    async def _get_synapses_batch(self, synapse_ids: list[str]) -> dict[str, Synapse]:
+    async def get_synapses_batch(self, synapse_ids: list[str]) -> dict[str, Synapse]:
         """Batch fetch synapses by ID list."""
         if not synapse_ids:
             return {}

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -91,6 +91,13 @@ def _is_auth_error(exc: Exception) -> bool:
 
 _BRAIN_ID_SAFE = re.compile(r"^[a-zA-Z0-9_.\-]+$")
 
+# Bounded concurrency for per-id batch fetches (get_neurons_batch/get_synapses_batch).
+# Pipelines direct record selects over the one shared AsyncSurreal connection;
+# measured ~1.7x over sequential on a 67k-neuron brain, with diminishing
+# returns above this value (single-connection multiplexing, not true parallel
+# sockets).
+_BATCH_FETCH_CONCURRENCY = 16
+
 
 def _brain_literal(brain_id: str) -> str:
     """Return ``brain_id`` as a safe inline SurrealQL string literal.
@@ -634,21 +641,34 @@ class SurrealDBStorage(
         return None
 
     async def get_neurons_batch(self, neuron_ids: list[str]) -> dict[str, Neuron]:
+        """Fetch multiple neurons by id, concurrently over the shared connection.
+
+        A single ``id IN [...]`` query was measured *slower* than per-id direct
+        selects on this SurrealDB version (3.2.0) — IN-membership against a
+        RecordID primary key doesn't use the primary index the way a direct
+        ``neuron:{id}`` fetch does, so it falls back to a scan-like path (same
+        family of index-selection gap as the brain_id-literal-vs-param gotcha
+        elsewhere in this store). Bounded concurrency instead pipelines the
+        direct selects over the one shared connection (~1.7x measured on a
+        67k-neuron brain) without the IN-query regression.
+        """
         if not neuron_ids:
             return {}
-        # Use direct select for each ID (more reliable than IN query with params)
-        results: dict[str, Neuron] = {}
-        for nid in neuron_ids:
+        semaphore = asyncio.Semaphore(_BATCH_FETCH_CONCURRENCY)
+
+        async def _fetch_one(nid: str) -> tuple[str, Neuron | None]:
             sid = _to_surreal_id(nid)
-            try:
-                result = await self._conn.select(f"neuron:{sid}")
-                if result and isinstance(result, list) and len(result) > 0:
-                    neuron = _row_to_neuron(result[0])
-                    # Use the converted ID as key
-                    results[nid] = neuron
-            except Exception:
-                pass
-        return results
+            async with semaphore:
+                try:
+                    result = await self._conn.select(f"neuron:{sid}")
+                except Exception:
+                    return nid, None
+            if result and isinstance(result, list) and len(result) > 0:
+                return nid, _row_to_neuron(result[0])
+            return nid, None
+
+        pairs = await asyncio.gather(*(_fetch_one(nid) for nid in neuron_ids))
+        return {nid: neuron for nid, neuron in pairs if neuron is not None}
 
     async def find_neurons(
         self,
@@ -950,6 +970,31 @@ class SurrealDBStorage(
         except Exception:
             pass
         return None
+
+    async def get_synapses_batch(self, synapse_ids: list[str]) -> dict[str, Synapse]:
+        """Fetch multiple synapses by id, concurrently over the shared connection.
+
+        See ``get_neurons_batch`` for why this is bounded-concurrent per-id
+        selects rather than a single ``id IN [...]`` query.
+        """
+        if not synapse_ids:
+            return {}
+        conn = self._ensure_conn()
+        semaphore = asyncio.Semaphore(_BATCH_FETCH_CONCURRENCY)
+
+        async def _fetch_one(syn_id: str) -> tuple[str, Synapse | None]:
+            sid = _to_surreal_id(syn_id)
+            async with semaphore:
+                try:
+                    result = await conn.select(f"synapse:{sid}")
+                except Exception:
+                    return syn_id, None
+            if result:
+                return syn_id, _row_to_synapse(result[0] if isinstance(result, list) else result)
+            return syn_id, None
+
+        pairs = await asyncio.gather(*(_fetch_one(sid) for sid in synapse_ids))
+        return {sid: synapse for sid, synapse in pairs if synapse is not None}
 
     async def get_synapses(
         self,

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -835,16 +835,21 @@ class SurrealDBStorage(
     async def delete_neuron(self, neuron_id: str) -> bool:
         conn = self._ensure_conn()
         brain_id = self._get_brain_id()
+        safe_brain = _safe_brain_id(brain_id)
         sid = _to_surreal_id(neuron_id)
 
         # Delete connected synapses first (belt-and-braces: SurrealDB also auto-cleans
         # edges when the neuron record is deleted). Endpoints are native in/out now.
-        await self._query(
-            "DELETE synapse WHERE brain_id = $brain_id AND "
-            "(in = type::record('neuron', $nid) OR out = type::record('neuron', $nid))",
-            brain_id=brain_id,
-            nid=sid,
-        )
+        #
+        # Measured live: a single "brain_id = $brain_id AND (in = ... OR out = ...)"
+        # query cost ~1.2s/call regardless of whether brain_id/the record id are
+        # inlined or param-bound — SurrealDB 3.2.0's planner doesn't use either
+        # `idx_synapse_in`/`idx_synapse_out` index across an OR of two different
+        # fields, so it falls back to a full scan. Splitting into two single-field
+        # DELETEs (each hits its own index) measured ~5ms total for both — this was
+        # the dominant cost behind prune's non-dry-run timeout on a large brain.
+        await self._query(f"DELETE synapse WHERE brain_id = '{safe_brain}' AND in = neuron:{sid}")
+        await self._query(f"DELETE synapse WHERE brain_id = '{safe_brain}' AND out = neuron:{sid}")
         # Delete state (record id is state_<sid>, matching the writer in add_neuron)
         await self._query(f"DELETE neuron_state:state_{sid}")
 
@@ -854,6 +859,22 @@ class SurrealDBStorage(
             return True
         except Exception:
             return False
+
+    async def delete_neurons_batch(self, neuron_ids: list[str]) -> int:
+        """Delete multiple neurons sequentially.
+
+        Unlike ``get_neurons_batch``'s reads, concurrent deletes here raised
+        live ``Transaction conflict: Transaction write conflict`` errors —
+        SurrealDB's transaction isolation conflicts on concurrent writes to
+        the same tables (``synapse``, ``change_log``), it doesn't just slow
+        down like concurrent reads do. ``delete_neuron`` is cheap now (~ms,
+        see its docstring), so sequential is already well within budget.
+        """
+        count = 0
+        for nid in neuron_ids:
+            if await self.delete_neuron(nid):
+                count += 1
+        return count
 
     async def has_neuron_by_content_hash(self, content_hash: int) -> bool:
         brain_id = self._get_brain_id()
@@ -1054,6 +1075,18 @@ class SurrealDBStorage(
             return True
         except Exception:
             return False
+
+    async def delete_synapses_batch(self, synapse_ids: set[str] | list[str]) -> int:
+        """Delete multiple synapses sequentially.
+
+        See ``delete_neurons_batch`` — concurrent writes conflict under
+        SurrealDB's transaction isolation, unlike concurrent reads.
+        """
+        count = 0
+        for sid in synapse_ids:
+            if await self.delete_synapse(sid):
+                count += 1
+        return count
 
     # ================================================================
     # Graph Traversal

--- a/tests/e2e/test_api.py
+++ b/tests/e2e/test_api.py
@@ -22,8 +22,21 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[TestCli
     # Point all storage to tmp_path instead of ~/.surrealmemory/
     monkeypatch.setenv("SURREAL_MEMORY_DIR", str(tmp_path))
 
-    # Clear cached config and storage so they reinitialize with tmp_path
+    # Force the sqlite fixture backend and strip live-DB env. On a dev box the
+    # shell exports SURREAL_MEMORY_STORAGE=surrealdb + SURREALDB_URL/PASS, and a
+    # fresh tmp_path config.toml inherits storage_backend from that env — so the
+    # e2e suite silently wrote test brains into the PRODUCTION SurrealDB and
+    # xdist workers aborted each other with transaction write conflicts.
+    monkeypatch.setenv("SURREAL_MEMORY_STORAGE", "sqlite")
+    monkeypatch.delenv("SURREALDB_URL", raising=False)
+    monkeypatch.delenv("SURREALDB_PASS", raising=False)
+
+    # Clear cached config and storage so they reinitialize with tmp_path.
+    # _surrealdb_storage is a separate module-level singleton that bypasses
+    # _storage_cache — a previously-cached production connection would be
+    # reused regardless of the env above (monkeypatch restores it on teardown).
     monkeypatch.setattr(uc, "_config", None)
+    monkeypatch.setattr(uc, "_surrealdb_storage", None)
     saved_cache = uc._storage_cache.copy()
     uc._storage_cache.clear()
 

--- a/tests/unit/test_aiosqlite_leak_guard.py
+++ b/tests/unit/test_aiosqlite_leak_guard.py
@@ -7,7 +7,12 @@ closes stragglers at each test's teardown.
 
 The two tests below cooperate and rely on within-file definition order (which
 pytest preserves): the first deliberately leaks a connection, the second
-asserts the guard stopped its worker thread during teardown.
+asserts the guard stopped its worker thread during teardown. That hand-off is
+a plain module-level dict, which only works if both tests run in the same
+process — under ``pytest-xdist -n auto`` a bare dict doesn't survive across
+worker processes, so pin both to the same worker via ``xdist_group`` (a
+KeyError on the hand-off means they landed on different workers, not that the
+guard regressed).
 """
 
 from __future__ import annotations
@@ -15,10 +20,14 @@ from __future__ import annotations
 from typing import Any
 
 import aiosqlite
+import pytest
 
 _handoff: dict[str, Any] = {}
 
+_XDIST_GROUP = "aiosqlite_leak_guard"
 
+
+@pytest.mark.xdist_group(name=_XDIST_GROUP)
 async def test_leak_a_connection_on_purpose() -> None:
     conn = await aiosqlite.connect(":memory:")
     await conn.execute("CREATE TABLE t (x INTEGER)")  # prove the worker is live
@@ -28,6 +37,7 @@ async def test_leak_a_connection_on_purpose() -> None:
     # Deliberately NOT closed — the autouse guard must stop it at teardown.
 
 
+@pytest.mark.xdist_group(name=_XDIST_GROUP)
 async def test_the_guard_stopped_the_leaked_worker_thread() -> None:
     thread = _handoff.pop("thread")
     thread.join(timeout=2.0)

--- a/tests/unit/test_embedding_provider.py
+++ b/tests/unit/test_embedding_provider.py
@@ -343,8 +343,15 @@ class TestOpenAIEmbedding:
 
         from surreal_memory.engine.embedding.openai_embedding import OpenAIEmbedding
 
-        # Clear environment so OPENAI_API_KEY is not set
-        env_without_key = {k: v for k, v in os.environ.items() if k != "OPENAI_API_KEY"}
+        # Clear OPENAI_API_KEY and SURREAL_MEMORY_EMBEDDING_ENDPOINT: a local
+        # endpoint makes OpenAIEmbedding synthesize an "sk-local" key instead of
+        # raising, so an ambient endpoint (e.g. a dev llamastash) breaks this
+        # test's premise.
+        env_without_key = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("OPENAI_API_KEY", "SURREAL_MEMORY_EMBEDDING_ENDPOINT")
+        }
         with unittest.mock.patch.dict(os.environ, env_without_key, clear=True):
             with pytest.raises(ValueError, match="API key"):
                 OpenAIEmbedding()

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.10.4"
+        assert surreal_memory.__version__ == "2.10.5"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_multi_agent.py
+++ b/tests/unit/test_multi_agent.py
@@ -116,8 +116,17 @@ class TestAgentTagInjection:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.xdist_group(name="consolidation_lock")
 class TestConsolidationLock:
-    """Test file-based consolidation lock."""
+    """Test file-based consolidation lock.
+
+    _lock_path() is a real, fixed file under ~/.surrealmemory/ shared across
+    the whole process tree — not test-isolated. Under pytest-xdist's default
+    per-test scheduling, two of these tests can land on different worker
+    processes and race on that one file (reproduced live: a different subset
+    fails each full-suite run, 100% pass in isolation). xdist_group pins the
+    whole class to one worker, same fix as the aiosqlite leak-guard pair.
+    """
 
     @pytest.fixture(autouse=True)
     def _cleanup_lock(self) -> None:

--- a/tests/unit/test_reranker.py
+++ b/tests/unit/test_reranker.py
@@ -186,9 +186,13 @@ class TestCrossEncoderReranker:
 
 
 class TestRerankerAvailable:
+    @patch.dict("os.environ", {"SURREAL_MEMORY_RERANKER_ENDPOINT": ""})
     @patch("surreal_memory.engine.reranker._CROSS_ENCODER_AVAILABLE", None)
     @patch("surreal_memory.engine.reranker._check_cross_encoder", return_value=False)
     def test_not_available(self, mock_check: MagicMock) -> None:
+        # The env patch matters: an ambient SURREAL_MEMORY_RERANKER_ENDPOINT
+        # (e.g. a dev llamastash) makes reranker_available() True regardless of
+        # the CrossEncoder patches.
         assert reranker_available() is False
 
     @patch("surreal_memory.engine.reranker._CROSS_ENCODER_AVAILABLE", True)

--- a/tests/unit/test_surrealdb_synapse_queries.py
+++ b/tests/unit/test_surrealdb_synapse_queries.py
@@ -145,10 +145,19 @@ class TestQueryShapes:
 
     @pytest.mark.asyncio
     async def test_delete_neuron_cascade_uses_in_out(self):
+        """Two single-field DELETEs, not one OR query.
+
+        A single "brain_id = ... AND (in = X OR out = X)" query measured
+        ~1.2s/call live on SurrealDB 3.2.0 — the planner doesn't use either
+        idx_synapse_in/idx_synapse_out across an OR of two different fields.
+        Splitting into two single-field DELETEs (each hits its own index)
+        measured ~5ms total.
+        """
         st, conn = _store_with_mock_conn()
         await st.delete_neuron("a")
-        found = _find_query(conn, "DELETE synapse WHERE")
-        assert found is not None
-        sql, _ = found
-        assert "in = type::record('neuron', $nid)" in sql
-        assert "out = type::record('neuron', $nid)" in sql
+        in_query = _find_query(conn, "AND in = neuron:")
+        out_query = _find_query(conn, "AND out = neuron:")
+        assert in_query is not None
+        assert out_query is not None
+        assert " OR " not in in_query[0]
+        assert " OR " not in out_query[0]

--- a/tests/unit/test_tool_memory.py
+++ b/tests/unit/test_tool_memory.py
@@ -242,6 +242,32 @@ class TestProcessEvents:
         assert len(synapses) >= 1
 
     @pytest.mark.asyncio
+    async def test_used_with_detection_without_session_id(self, storage: SQLiteStorage) -> None:
+        """Session-less tool events still form USED_WITH via the shared stream.
+
+        Regression test: events with an empty session_id used to be dropped
+        entirely from the session-grouping dict, so the co-occurrence loop
+        never ran over them and USED_WITH synapses never formed.
+        """
+        events = [
+            _make_event(tool_name="Grep", session_id="", created_at="2026-03-01T10:00:00"),
+            _make_event(tool_name="Read", session_id="", created_at="2026-03-01T10:00:30"),
+            _make_event(tool_name="Grep", session_id="", created_at="2026-03-01T10:01:00"),
+            _make_event(tool_name="Read", session_id="", created_at="2026-03-01T10:01:30"),
+        ]
+        await storage.insert_tool_events("test-brain", events)
+        config = ToolMemoryConfig(enabled=True, min_frequency=2, cooccurrence_window_s=60)
+        result = await process_events(storage, "test-brain", config)
+
+        assert result.events_processed == 4
+        assert result.synapses_created >= 1
+
+        from surreal_memory.core.synapse import SynapseType
+
+        synapses = await storage.get_synapses(type=SynapseType.USED_WITH)
+        assert len(synapses) >= 1
+
+    @pytest.mark.asyncio
     async def test_frequency_threshold(self, storage: SQLiteStorage) -> None:
         """Tools below frequency threshold don't create neurons."""
         events = [

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

- Full `smem consolidate` completes all strategies with zero per-strategy timeouts on a ~67k-neuron / ~450k-synapse brain (previously `prune` and `compress` both hit the 120s budget).
- **Data-integrity fix:** dead-neuron pruning no longer deletes neurons that belong to fibers — on 2.10.0–2.10.4 it could delete live memory content once prune's delete phase completed (see incident disclosure below).
- Session-less tool events now form `USED_WITH` co-occurrence synapses (previously 0 formed on hook-fed brains where every event has an empty `session_id`).
- `delete_neurons_batch`/`delete_synapses_batch` added to the SurrealDB backend; `delete_neuron`'s synapse-cleanup query restructured (~1.2s → ~5ms per neuron on SurrealDB 3.2.0).
- `compress` batches synapse/neuron fetches (bounded concurrency), skips synapse fetches for tiers that never render relations, and runs under an explicit time budget with `fibers_deferred` reporting.
- Test suite: e2e API tests are now hermetic (can no longer write into a configured live SurrealDB); deflaked aiosqlite leak-guard + consolidation-lock under xdist.

## Why

The `default` brain grows ~2x/quarter and consolidation must scale with it. Profiling live showed three independent root causes: a per-fiber synapse N+1 in compress, a query shape in `delete_neuron` that SurrealDB 3.2.0 cannot index (OR across `in`/`out`), and — masked until those were fixed — a dead-neuron detector that never checked fiber membership. The last one is a data-loss bug shipped in 2.10.0–2.10.4; fixing the performance issues is what exposed it.

## ⚠️ Incident disclosure (pre-existing bug, triggered during live verification)

While verifying the prune fix with a real (non-dry-run) consolidate on the maintainer's live brain, the pre-existing dead-neuron bug fired at scale for the first time (the perf fix let the delete phase complete): ~3.2k neurons and ~295k synapses were wrongly deleted. Full recovery was performed the same day from a pre-session backup (maintainer-approved full restore): 3255/3255 deleted neurons verified restored (full check), 1000/1000 random synapse sample verified, embeddings intact, and a subsequent full consolidate left the brain healthier than before (orphan rate 0.005 → 0.0). The fiber-membership guard in this PR prevents recurrence; the CHANGELOG carries a prominent warning for anyone who ran non-dry-run consolidate on 2.10.0–2.10.4.

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` — 6372 passed, 0 failed (hermetic run; live-gated tests correctly skipped)
- [x] `ruff check src/ tests/` clean; `ruff format --check` clean
- [x] `mypy src/ --ignore-missing-imports` clean (359 files)
- [x] Live evidence (maintainer's ~67k-neuron brain): full `smem consolidate` = zero timeouts, all strategies, 6m43s total; `compress` 120s-timeout → 72s clean; `USED_WITH` 0 → 16 synapses
- [x] e2e suite under xdist: 26 passed with a production-like shell env (previously 26 setup errors + 49 leaked brains in the live DB)

## Verified by

@acidkill
