### PR TITLE
fix(tests): stop surrealdb SDK stubs from shadowing the installed SDK; clean up live-test brains

### DIFF
--- a/tests/unit/_surrealdb_live.py
+++ b/tests/unit/_surrealdb_live.py
@@ -1,0 +1,140 @@
+"""Shared helpers for the live-SurrealDB unit tests (gated on SURREALDB_URL).
+
+Two isolation problems used to plague these tests, fixed here in one place:
+
+1. **Stub pollution.** Several unit-test modules stub
+   ``sys.modules["surrealdb"]`` with a ``MagicMock`` so ``store.py`` can be
+   imported where the optional SDK isn't installed. Because ``store.py``
+   imports the SDK lazily (``from surrealdb import AsyncSurreal`` at call
+   time), a stub that leaks into a full-suite run turns every live test into
+   an ERROR at fixture setup (``TypeError: object MagicMock can't be used in
+   'await' expression``) even though the file passes solo.
+   ``ensure_real_surrealdb_sdk()`` heals ``sys.modules`` before a live
+   fixture connects.
+
+2. **Brain leakage.** Every live fixture creates a throwaway brain on the
+   shared DB and used to leave it behind, so ``smem brain list`` accumulated
+   rows like ``all-types-roundtrip`` forever. ``cleanup_live_brains()``
+   deletes the fixture's own brain by record id at teardown, plus any *stale*
+   leftovers carrying a known live-test name. It never touches ``default``
+   (or any name outside the explicit test-name list), and it only deletes by
+   record id — never by a name-pattern DELETE.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+#: Exact names of the throwaway brains the live unit tests create. Cleanup is
+#: strictly limited to these names; anything else on the server is left alone.
+LIVE_TEST_BRAIN_NAMES = frozenset(
+    {
+        "all-types-roundtrip",  # test_surrealdb_typed_memory_all_types.py
+        "u1-retrieval-trace-live",  # test_surrealdb_retrieval_trace_live.py
+        "u3-supersession-live",  # test_surrealdb_supersession_live.py
+        "ub2-fiber-id-norm-live",  # test_surrealdb_fiber_id_norm_live.py
+        "u8-geo-live",  # test_surrealdb_geo_live.py
+        "ub1-recordid-fix-live",  # test_surrealdb_recordid_fix_live.py
+        "parity-test-surreal",  # test_get_project_memories.py
+    }
+)
+
+#: Hard deny-list: rows with these names are never deleted, even if someone
+#: mistakenly adds them to LIVE_TEST_BRAIN_NAMES.
+PROTECTED_BRAIN_NAMES = frozenset({"default", "my-brain.v2"})
+
+#: Leftovers younger than this are assumed to belong to a concurrently
+#: running test (xdist worker / second dev machine) and are skipped; the
+#: fixture that created them deletes them by id anyway.
+_STALE_AFTER = timedelta(hours=1)
+
+
+def ensure_real_surrealdb_sdk() -> None:
+    """Make sure ``sys.modules["surrealdb"]`` is the real installed SDK.
+
+    If another test module replaced it with a mock/stub, drop the stub (and
+    any ``surrealdb.*`` submodule stubs) and import the genuine package so
+    the store's lazy ``from surrealdb import AsyncSurreal`` resolves to a
+    working client. Skips the test when the SDK is genuinely not installed.
+    """
+    mod = sys.modules.get("surrealdb")
+    if isinstance(mod, types.ModuleType) and getattr(mod, "__spec__", None) is not None:
+        return  # real SDK already loaded
+    removed = {
+        name: sys.modules.pop(name)
+        for name in list(sys.modules)
+        if name == "surrealdb" or name.startswith("surrealdb.")
+    }
+    try:
+        importlib.import_module("surrealdb")
+    except ImportError:
+        # SDK genuinely absent: put the stubs back (stub-based tests running
+        # after this one still rely on them) and skip the live test.
+        sys.modules.update(removed)
+        pytest.skip("surrealdb SDK is not installed")
+
+
+def _record_id_raw(rid: Any) -> str:
+    """Bare id part of a brain record id ('brain:⟨x⟩' / RecordID → 'x')."""
+    if hasattr(rid, "id"):  # surrealdb.RecordID
+        return str(rid.id)
+    return str(rid).split(":", 1)[-1].strip("⟨⟩")
+
+
+def _is_stale(created_at: Any) -> bool:
+    """True when a row is old enough to be a leftover from a previous run."""
+    value = created_at
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return True  # unparseable → treat as leftover
+    if not isinstance(value, datetime):
+        return True  # missing/unknown shape → treat as leftover
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return datetime.now(UTC) - value > _STALE_AFTER
+
+
+async def cleanup_live_brains(storage: Any, own_brain_id: str | None = None) -> int:
+    """Delete this run's test brain and stale leftovers, by record id.
+
+    Args:
+        storage: an initialized ``SurrealDBStorage``.
+        own_brain_id: the brain id the calling fixture created this test —
+            always deleted regardless of age.
+
+    Returns the number of brain rows deleted.
+    """
+    rows = await storage._query("SELECT id, name, created_at FROM brain")
+    deleted = 0
+    for row in rows:
+        rid = row.get("id")
+        if rid is None:
+            continue
+        name = str(row.get("name") or "")
+        raw = _record_id_raw(rid)
+        bid = raw.replace("_", "-")
+        if name in PROTECTED_BRAIN_NAMES or bid == "default":
+            continue
+        is_own = own_brain_id is not None and bid == own_brain_id
+        if not is_own:
+            if name not in LIVE_TEST_BRAIN_NAMES or not _is_stale(row.get("created_at")):
+                continue
+        # Data rows key on the dashed brain-id string; legacy rows may carry
+        # the underscored form, so clear both spellings when they differ.
+        await storage.clear(bid)
+        if raw != bid:
+            await storage.clear(raw)
+        if hasattr(rid, "id"):
+            await storage._query("DELETE $rid", rid=rid)
+        else:
+            await storage._query("DELETE type::thing('brain', $raw)", raw=raw)
+        deleted += 1
+    return deleted

--- a/tests/unit/test_case_insensitive_tags.py
+++ b/tests/unit/test_case_insensitive_tags.py
@@ -18,9 +18,13 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 # Stub the optional surrealdb dependency so store.py can be imported in CI.
-if "surrealdb" not in sys.modules:
-    _fake_surrealdb = MagicMock()
-    sys.modules["surrealdb"] = _fake_surrealdb
+# Stub ONLY when the SDK is genuinely not installed: an `if not in sys.modules`
+# guard would shadow an installed SDK for the rest of the pytest session and
+# break the live (SURREALDB_URL) tests that run after this module.
+try:
+    import surrealdb  # noqa: F401
+except ImportError:  # pragma: no cover - CI unit env has no surrealdb SDK
+    sys.modules["surrealdb"] = MagicMock()
     sys.modules["surrealdb.errors"] = MagicMock()
 
 

--- a/tests/unit/test_dashboard_perf_queries.py
+++ b/tests/unit/test_dashboard_perf_queries.py
@@ -21,7 +21,12 @@ from __future__ import annotations
 import sys
 from unittest.mock import AsyncMock, MagicMock
 
-if "surrealdb" not in sys.modules:
+# Stub the optional surrealdb SDK ONLY when it is genuinely not installed: an
+# `if not in sys.modules` guard would shadow an installed SDK for the rest of
+# the pytest session and break the live (SURREALDB_URL) tests running later.
+try:
+    import surrealdb  # noqa: F401
+except ImportError:  # pragma: no cover - CI unit env has no surrealdb SDK
     sys.modules["surrealdb"] = MagicMock()
     sys.modules["surrealdb.errors"] = MagicMock()
 

--- a/tests/unit/test_get_project_memories.py
+++ b/tests/unit/test_get_project_memories.py
@@ -25,6 +25,7 @@ from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.project import Project
 from surreal_memory.storage.base import NeuralStorage
 from surreal_memory.storage.sqlite_store import SQLiteStorage
+from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
 
 SURREALDB_URL = os.getenv("SURREALDB_URL")
 _skip_surrealdb = pytest.mark.skipif(
@@ -110,8 +111,9 @@ async def sqlite_storage(tmp_path: Path) -> SQLiteStorage:
 async def surrealdb_storage():  # type: ignore[no-untyped-def]
     if not SURREALDB_URL:
         pytest.skip("SURREALDB_URL not set")
-    # The surrealdb SDK is an optional dependency; skip when it's absent.
-    pytest.importorskip("surrealdb")
+    # Skips when the SDK is absent, and heals sys.modules when another test
+    # module stubbed `surrealdb` (importorskip would accept the stub).
+    ensure_real_surrealdb_sdk()
     from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
     storage = SurrealDBStorage(url=SURREALDB_URL)
@@ -120,7 +122,12 @@ async def surrealdb_storage():  # type: ignore[no-untyped-def]
     await storage.save_brain(brain)
     storage.set_brain(brain.id)
     yield storage
-    # Best-effort cleanup; SurrealDB doesn't have per-test isolation here
+    # Best-effort cleanup: drop this test's brain (and stale leftovers) so
+    # `smem brain list` doesn't accumulate test brains on the shared DB.
+    try:
+        await cleanup_live_brains(storage, own_brain_id=brain.id)
+    except Exception:
+        pass
     try:
         await storage.close()
     except Exception:

--- a/tests/unit/test_surrealdb_fiber_id_norm_live.py
+++ b/tests/unit/test_surrealdb_fiber_id_norm_live.py
@@ -18,6 +18,7 @@ from surreal_memory.core.brain import Brain
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.memory_types import MemoryType, TypedMemory
 from surreal_memory.core.neuron import Neuron, NeuronType
+from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
 
 SURREALDB_URL = os.getenv("SURREALDB_URL")
 
@@ -29,6 +30,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 async def storage():  # type: ignore[no-untyped-def]
+    ensure_real_surrealdb_sdk()
     from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
     store = SurrealDBStorage(url=SURREALDB_URL)
@@ -37,6 +39,10 @@ async def storage():  # type: ignore[no-untyped-def]
     await store.save_brain(brain)
     store.set_brain(brain.id)
     yield store
+    try:
+        await cleanup_live_brains(store, own_brain_id=brain.id)
+    except Exception:
+        pass
     try:
         await store.close()
     except Exception:

--- a/tests/unit/test_surrealdb_geo_live.py
+++ b/tests/unit/test_surrealdb_geo_live.py
@@ -19,6 +19,7 @@ from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.engine.retrieval import ReflexPipeline
 from surreal_memory.utils.geo import GeoFilter, GeoPoint
+from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
 
 SURREALDB_URL = os.getenv("SURREALDB_URL")
 
@@ -42,6 +43,7 @@ def _norm(fiber_id: str) -> str:
 
 @pytest.fixture
 async def storage():  # type: ignore[no-untyped-def]
+    ensure_real_surrealdb_sdk()
     from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
     store = SurrealDBStorage(url=SURREALDB_URL)
@@ -50,6 +52,10 @@ async def storage():  # type: ignore[no-untyped-def]
     await store.save_brain(brain)
     store.set_brain(brain.id)
     yield store
+    try:
+        await cleanup_live_brains(store, own_brain_id=brain.id)
+    except Exception:
+        pass
     try:
         await store.close()
     except Exception:

--- a/tests/unit/test_surrealdb_gql_path.py
+++ b/tests/unit/test_surrealdb_gql_path.py
@@ -13,7 +13,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-if "surrealdb" not in sys.modules:
+# Stub the optional surrealdb SDK ONLY when it is genuinely not installed: an
+# `if not in sys.modules` guard would shadow an installed SDK for the rest of
+# the pytest session and break the live (SURREALDB_URL) tests running later.
+try:
+    import surrealdb  # noqa: F401
+except ImportError:  # pragma: no cover - CI unit env has no surrealdb SDK
     sys.modules["surrealdb"] = MagicMock()
     sys.modules["surrealdb.errors"] = MagicMock()
 

--- a/tests/unit/test_surrealdb_migrations.py
+++ b/tests/unit/test_surrealdb_migrations.py
@@ -16,7 +16,12 @@ import pytest
 # Stub the optional surrealdb SDK so the lazy `from surrealdb import RecordID`
 # inside migrations.py resolves. RecordID becomes a MagicMock factory — fine, the
 # tests assert on query text/state transitions, not RecordID internals.
-if "surrealdb" not in sys.modules:
+# Stub ONLY when the SDK is genuinely not installed: an `if not in sys.modules`
+# guard would shadow an installed SDK for the rest of the pytest session and
+# break the live (SURREALDB_URL) tests that run after this module.
+try:
+    import surrealdb  # noqa: F401
+except ImportError:  # pragma: no cover - CI unit env has no surrealdb SDK
     sys.modules["surrealdb"] = MagicMock()
     sys.modules["surrealdb.errors"] = MagicMock()
 

--- a/tests/unit/test_surrealdb_recordid_fix_live.py
+++ b/tests/unit/test_surrealdb_recordid_fix_live.py
@@ -14,6 +14,7 @@ import pytest
 
 from surreal_memory.core.brain import Brain
 from surreal_memory.core.source import Source, SourceStatus
+from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
 
 SURREALDB_URL = os.getenv("SURREALDB_URL")
 
@@ -25,6 +26,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 async def storage():  # type: ignore[no-untyped-def]
+    ensure_real_surrealdb_sdk()
     from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
     store = SurrealDBStorage(url=SURREALDB_URL)
@@ -33,6 +35,10 @@ async def storage():  # type: ignore[no-untyped-def]
     await store.save_brain(brain)
     store.set_brain(brain.id)
     yield store
+    try:
+        await cleanup_live_brains(store, own_brain_id=brain.id)
+    except Exception:
+        pass
     try:
         await store.close()
     except Exception:

--- a/tests/unit/test_surrealdb_retrieval_trace_live.py
+++ b/tests/unit/test_surrealdb_retrieval_trace_live.py
@@ -17,6 +17,7 @@ from surreal_memory.core.memory_types import MemoryType, TypedMemory
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.retrieval_trace import RetrievalTrace
 from surreal_memory.utils.timeutils import utcnow
+from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
 
 SURREALDB_URL = os.getenv("SURREALDB_URL")
 
@@ -28,6 +29,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 async def storage():  # type: ignore[no-untyped-def]
+    ensure_real_surrealdb_sdk()
     from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
     store = SurrealDBStorage(url=SURREALDB_URL)
@@ -39,6 +41,10 @@ async def storage():  # type: ignore[no-untyped-def]
     # Best-effort cleanup of this throwaway brain's traces on the shared DB.
     try:
         await store.prune_retrieval_traces(max_traces=0)
+    except Exception:
+        pass
+    try:
+        await cleanup_live_brains(store, own_brain_id=brain.id)
     except Exception:
         pass
     try:

--- a/tests/unit/test_surrealdb_store.py
+++ b/tests/unit/test_surrealdb_store.py
@@ -9,10 +9,14 @@ import pytest
 
 # surrealdb is an optional dependency not installed in the base test environment.
 # Inject a stub so that the lazy `from surrealdb import AsyncSurreal` inside
-# store.py succeeds and the mock can override it.
-if "surrealdb" not in sys.modules:
-    _fake_surrealdb = MagicMock()
-    sys.modules["surrealdb"] = _fake_surrealdb
+# store.py succeeds and the mock can override it. Stub ONLY when the SDK is
+# genuinely not installed: an `if not in sys.modules` guard would shadow an
+# installed SDK for the rest of the pytest session and break the live
+# (SURREALDB_URL) tests that run after this module.
+try:
+    import surrealdb  # noqa: F401
+except ImportError:  # pragma: no cover - CI unit env has no surrealdb SDK
+    sys.modules["surrealdb"] = MagicMock()
     sys.modules["surrealdb.errors"] = MagicMock()
 
 

--- a/tests/unit/test_surrealdb_stub_hygiene.py
+++ b/tests/unit/test_surrealdb_stub_hygiene.py
@@ -1,0 +1,40 @@
+"""Regression guard: surrealdb SDK stubs must not shadow an installed SDK.
+
+Several unit-test modules stub ``sys.modules["surrealdb"]`` with a MagicMock
+so ``store.py`` imports without the optional SDK. Before the try-import guard
+(``except ImportError``) they keyed on ``"surrealdb" not in sys.modules``,
+which conflates *not yet imported* with *not installed*: in a full-suite run
+the stub was installed at collection time and every live (SURREALDB_URL) test
+ERRORed at fixture setup with ``TypeError: object MagicMock can't be used in
+'await' expression`` — while the same file passed solo.
+
+Pytest imports every test module during collection before any test runs, so
+by the time this test executes, each stub-installing module has already had
+its chance to pollute ``sys.modules``. If the SDK is installed, whatever sits
+there must be the real package (or nothing).
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import sys
+import types
+
+import pytest
+
+
+def test_stub_modules_do_not_shadow_installed_sdk() -> None:
+    try:
+        importlib.metadata.distribution("surrealdb")
+    except importlib.metadata.PackageNotFoundError:
+        pytest.skip("surrealdb SDK not installed — stubs are legitimate here")
+
+    mod = sys.modules.get("surrealdb")
+    if mod is None:
+        return  # nobody imported or stubbed it — fine
+    assert isinstance(mod, types.ModuleType) and mod.__spec__ is not None, (
+        "sys.modules['surrealdb'] is a test stub, but the real SDK is installed. "
+        "Some test module stubbed the SDK unconditionally (use the "
+        "try/except ImportError guard) — this breaks every live SURREALDB_URL "
+        "test that runs later in the session."
+    )

--- a/tests/unit/test_surrealdb_supersession_live.py
+++ b/tests/unit/test_surrealdb_supersession_live.py
@@ -23,6 +23,7 @@ from surreal_memory.engine.supersession import (
     resolve_fibers_for_neurons,
     supersede_typed_memory,
 )
+from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
 
 SURREALDB_URL = os.getenv("SURREALDB_URL")
 
@@ -34,6 +35,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 async def storage():  # type: ignore[no-untyped-def]
+    ensure_real_surrealdb_sdk()
     from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
     store = SurrealDBStorage(url=SURREALDB_URL)
@@ -42,6 +44,10 @@ async def storage():  # type: ignore[no-untyped-def]
     await store.save_brain(brain)
     store.set_brain(brain.id)
     yield store
+    try:
+        await cleanup_live_brains(store, own_brain_id=brain.id)
+    except Exception:
+        pass
     try:
         await store.close()
     except Exception:

--- a/tests/unit/test_surrealdb_synapse_queries.py
+++ b/tests/unit/test_surrealdb_synapse_queries.py
@@ -13,7 +13,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-if "surrealdb" not in sys.modules:
+# Stub the optional surrealdb SDK ONLY when it is genuinely not installed: an
+# `if not in sys.modules` guard would shadow an installed SDK for the rest of
+# the pytest session and break the live (SURREALDB_URL) tests running later.
+try:
+    import surrealdb  # noqa: F401
+except ImportError:  # pragma: no cover - CI unit env has no surrealdb SDK
     sys.modules["surrealdb"] = MagicMock()
     sys.modules["surrealdb.errors"] = MagicMock()
 

--- a/tests/unit/test_surrealdb_typed_memory_all_types.py
+++ b/tests/unit/test_surrealdb_typed_memory_all_types.py
@@ -26,6 +26,7 @@ from surreal_memory.core.memory_types import (
     TypedMemory,
 )
 from surreal_memory.core.neuron import Neuron, NeuronType
+from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
 
 SURREALDB_URL = os.getenv("SURREALDB_URL")
 
@@ -37,6 +38,7 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 async def surrealdb_storage():  # type: ignore[no-untyped-def]
+    ensure_real_surrealdb_sdk()
     from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
     storage = SurrealDBStorage(url=SURREALDB_URL)
@@ -45,6 +47,12 @@ async def surrealdb_storage():  # type: ignore[no-untyped-def]
     await storage.save_brain(brain)
     storage.set_brain(brain.id)
     yield storage
+    # Best-effort: drop this test's brain (and stale leftovers) from the
+    # shared DB so `smem brain list` doesn't accumulate test brains.
+    try:
+        await cleanup_live_brains(storage, own_brain_id=brain.id)
+    except Exception:
+        pass
     try:
         await storage.close()
     except Exception:


### PR DESCRIPTION
Full-suite runs with SURREALDB_URL set ERRORed 47 live tests at fixture
setup (TypeError: object MagicMock can't be used in 'await' expression)
while the same files passed solo. Root cause: six unit-test modules stub
sys.modules["surrealdb"] with a MagicMock behind an
`if "surrealdb" not in sys.modules` guard, which conflates "not yet
imported" with "not installed". Pytest imports every module at collection,
so the stub landed before any live test ran, and store.py's lazy
`from surrealdb import AsyncSurreal` then resolved to the mock for the
rest of the session.

- Stub files now guard with try/except ImportError: the mock is installed
  only when the SDK is genuinely absent (CI unit env), never over a real
  installation. Their execution-time patching already targets
  `patch("surrealdb.AsyncSurreal", ..., create=True)`, so they pass
  against either the stub or the real module.
- New tests/unit/_surrealdb_live.py shared helper:
  * ensure_real_surrealdb_sdk() — live fixtures self-heal sys.modules if
    a stub leaked in, and skip cleanly when the SDK is not installed
    (restoring the stubs for later stub-based tests).
  * cleanup_live_brains() — live fixtures now delete their throwaway
    brain by record id at teardown, plus stale (>1h) leftovers matching
    the known live-test brain names from earlier leaked runs. Deletion is
    id-based only, never touches `default`/`my-brain.v2`, and skips
    fresh rows so parallel workers can't race each other.
- All 7 live fixtures (all-types-roundtrip, u1-retrieval-trace-live,
  u3-supersession-live, ub2-fiber-id-norm-live, u8-geo-live,
  ub1-recordid-fix-live, parity-test-surreal) use both helpers.
- New test_surrealdb_stub_hygiene.py regression guard fails the suite if
  any module shadows an installed SDK with a stub again.

Verified: full tests/unit run is 6281 passed / 80 skipped without
SURREALDB_URL; with SURREALDB_URL set and no server the 47 live errors are
all ConnectionRefusedError (real SDK reaching the network) instead of
MagicMock TypeErrors, matching solo behavior. With the SDK uninstalled the
stub files still pass and live tests skip.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQ7weFhv9ezUTWadymo2GY