### PR TITLE
perf(doc-trainer): skip cross-linking/emotion + inline type in train mode (−42%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.0] — Fast bulk doc-training
+
+`smem train` on large documents is dramatically faster on big brains, and the
+encoder now batches its writes instead of issuing one round-trip per neuron /
+synapse. Three layers of work.
+
+### Added
+
+- `SurrealDBStorage.add_synapses_batch` (multi-statement `INSERT RELATION`)
+  plus a base `add_synapses_batch` default with a per-synapse fallback, so
+  non-SurrealDB backends stay correct.
+- `SurrealDBStorage.find_neurons_exact_batch` override — one `content IN $contents`
+  round-trip for N exact-content lookups (the base default was an N+1 sequential
+  loop). `brain_id` is inlined as a literal here too.
+- `tqdm` progress bar in `smem train` (optional import — tqdm is a transitive
+  dependency, not declared — with a `logger.info` fallback every 50 chunks so a
+  clean install without tqdm still reports progress).
+
+### Changed
+
+- **`increment_keyword_df`**: per-keyword SELECT-then-merge/insert N+1 → a single
+  multi-statement UPSERT (`fiber_count = (fiber_count ?? 0) + 1`). This was the
+  #1 per-chunk op count during doc-training (~93 keyword-DF SELECTs/chunk on a
+  6651-chunk doc); it is now 1 query/chunk.
+- **`CreateSynapsesStep` + `CoOccurrenceStep`** persist their synapses through a
+  new `_persist_synapses` helper that uses `add_synapses_batch` (an `asyncio.gather`
+  of N `add_synapse` collapses into one round-trip).
+- **`find_neurons`**: `brain_id` is now an inline, charset-validated literal
+  instead of a parameterized `$brain_id`. SurrealDB 3.2.0's planner only uses the
+  `brain_id` index for an inline literal; a parameterized value full-scans the
+  neuron table — the root cause of per-chunk doc-train cost scaling with brain
+  size. EXPLAIN confirms the plan changes from `TableScan` to
+  `IndexScan [idx_neuron_brain]`.
+
+### Performance
+
+- Isolated in-memory SDB 3.2.0, N=100 chunks: batch writes took per-chunk encode
+  from **1.446 s → 0.847 s (-41%, under the 1 s target)**.
+- DB-op count per chunk is ~10× lower (**581 → 58**) on a full 6651-chunk run.
+- `find_neurons` is now index-driven on large brains — the dominant lever on
+  disk-backed brains (a manual `smem train` on a 68k-neuron default brain
+  previously ran at **7–15 s/chunk** for this reason; the index vs full-scan gap
+  is the single biggest per-chunk cost on disk).
+
+### Notes
+
+- The doc-trainer now batches create/insert round-trips and uses the brain_id
+  index, but per-chunk reads and Python-side extraction remain the next
+  bottleneck on very large (>50k-neuron) brains — material for a follow-up.
+
 ## [2.10.5] — Consolidation scales, prune stops eating memories
 
 Full `smem consolidate` now finishes without per-strategy timeouts on large

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Sync uses **Merkle delta** — only diffs travel, not the full brain.
 #### Knowledge Ingestion
 - **Train from documents** — PDF, DOCX, PPTX, HTML, JSON, XLSX, CSV ingested into permanent brain knowledge
 - **Train from database schemas** — extract table structures and FK relationships
+- **Fast bulk training** — `smem train` batches DB writes (one round-trip per N synapses via `add_synapses_batch`) and the `find_neurons` brain_id index is now used, so large docs stay cheap per chunk even on big brains (previously 7–15 s/chunk on a 68k-neuron brain; ~10× fewer DB ops/chunk). Shows live `tqdm` progress.
 - **Import adapters** — migrate from ChromaDB, Mem0, Cognee, Graphiti, LlamaIndex
 
 #### Lifecycle & Storage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.10.5"
+version = "2.11.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.10.5"
+__version__ = "2.11.0"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/pipeline_steps.py
+++ b/src/surreal_memory/engine/pipeline_steps.py
@@ -1126,6 +1126,10 @@ class EmotionStep:
         config: BrainConfig,
     ) -> PipelineContext:
         assert ctx.anchor_neuron is not None
+        # Bulk doc-training: skip emotion extraction (find_neurons type=STATE
+        # scans type partition; doc knowledge has no emotional valence).
+        if ctx.skip_conflicts:
+            return ctx
         result = self.sentiment_extractor.extract(ctx.content, language=ctx.language)
 
         if result.valence == Valence.NEUTRAL or not result.emotion_tags:
@@ -1436,6 +1440,14 @@ class SemanticLinkingStep:
         config: BrainConfig,
     ) -> PipelineContext:
         # Collect entity and concept neurons from this encode
+        # Bulk doc-training: skip cross-linking to existing neurons. Each
+        # find_neurons(type, content_exact) call scans the full type partition
+        # (40k+ rows on a large brain) because SDB 3.2.0's planner picks
+        # idx_neuron_type and filters content post-index — ~1 s/call, 3+/chunk.
+        # ENRICH consolidation (post-train) adds cross-links anyway.
+        if ctx.skip_conflicts:
+            return ctx
+
         linkable = [
             n
             for n in ctx.entity_neurons
@@ -1531,6 +1543,9 @@ class CrossMemoryLinkStep:
         config: BrainConfig,
     ) -> PipelineContext:
         if ctx.anchor_neuron is None or not ctx.entity_neurons:
+            return ctx
+        # Bulk doc-training: skip (same rationale as SemanticLinkingStep).
+        if ctx.skip_conflicts:
             return ctx
 
         anchor_id = ctx.anchor_neuron.id

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -695,8 +695,14 @@ class SurrealDBStorage(
         params: dict[str, Any] = {}
 
         if type is not None:
-            conditions.append("type = $ntype")
-            params["ntype"] = type.value
+            # Inline type as a literal too — same planner gotcha as brain_id: a
+            # parameterized ``$ntype`` makes the planner pick idx_neuron_brain
+            # (single-col) and filter type over all brain rows, instead of the
+            # composite idx_neuron_type (brain_id, type). Measured 1147 ms/q vs
+            # single-digit ms/q with the literal on a 92k-neuron brain. type.value
+            # comes from the NeuronType enum (uppercase identifier), so inlining
+            # is injection-safe.
+            conditions.append(f"type = '{type.value}'")
 
         if content_exact is not None:
             conditions.append("content = $content_exact")
@@ -740,10 +746,10 @@ class SurrealDBStorage(
     ) -> dict[str, Neuron]:
         """Batched exact-content lookup — one round-trip for N contents.
 
-        Overrides the base N+1 default (sequential ``find_neurons`` per content).
-        Uses ``content IN $contents`` with the brain_id inlined as a literal so
-        the planner uses the brain_id/content indexes (a parameterized brain_id
-        full-scans). Returns the first match per content string.
+        Uses ``content IN $contents`` with brain_id inlined. On a 92k-neuron
+        brain this is ~1.3 s/call but still 4-5x faster than the base N+1
+        default (each individual find_neurons with type scans the type
+        partition at ~750 ms; for N=8 candidates that's 6 s vs 1.3 s).
         """
         if not contents:
             return {}
@@ -751,14 +757,11 @@ class SurrealDBStorage(
         conds = [f"brain_id = {_brain_literal(brain_id)}", "content IN $contents"]
         params: dict[str, Any] = {"contents": list(dict.fromkeys(contents))}
         if type is not None:
-            conds.append("type = $ntype")
-            params["ntype"] = type.value
+            conds.append(f"type = '{type.value}'")
         if ephemeral is not None:
             conds.append("ephemeral = $ephemeral")
             params["ephemeral"] = ephemeral
         where = " AND ".join(conds)
-        # OMIT embedding_vec — callers only need identity/type/content, and the
-        # 1024-3072-float vector is ~4-8 KB/row across a result set of N matches.
         rows = await self._query(f"SELECT * OMIT embedding_vec FROM neuron WHERE {where}", **params)
         out: dict[str, Neuron] = {}
         for r in rows:

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.10.5"
+        assert surreal_memory.__version__ == "2.11.0"
 
 
 class TestPackageIntegrity:


### PR DESCRIPTION
Data-driven fix from cProfile + per-query wall profiling on a 92k-neuron default brain (N=20 chunks). find_neurons at 1.1-1.4 s/q dominated (96% DB I/O).

## Root cause
SDB 3.2.0 planner picks `idx_neuron_type` and filters content post-index — scanning 40k+ type-partition rows per call. Even with `type` as literal (IndexScan), the content `WHERE` is applied as a post-index filter.

## Changes (all gated on `ctx.skip_conflicts` = train mode)
- **SemanticLinkingStep + CrossMemoryLinkStep**: skip (ENRICH consolidation adds cross-links post-train). Removes ~90 find_neurons calls/20 chunks.
- **EmotionStep**: skip (doc knowledge has no emotional valence).
- **find_neurons**: inline `type` as literal (enum-safe) so planner uses `idx_neuron_type` composite (IndexScan vs scan+filter).
- **find_neurons_exact_batch**: keep `content IN` override but inline type literal. N+1 base default was 4-5× slower (each type+content call ≈ 750ms vs one IN-query ≈ 1.3s for N=8 candidates).

## Measurement
On Toni's 92k-neuron default brain, N=20 chunks: **6.7 → 3.85 s/chunk (−42%)**.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] profiled N=20 on live default brain (data-driven, not bench)
- [ ] CI (ruff/mypy/pytest)

## Verified by
@acidkill