### PR TITLE
fix(ci): sync npm package versions to release tag + unmask publish failures (2.12.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,10 +188,19 @@ jobs:
             echo "::notice::NPM_TOKEN not set — skipping npm publish."
             exit 0
           fi
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Idempotent re-run guard: skip ONLY if this exact version is already live.
+          if [ "$(npm view "surrealmemory@$VERSION" version 2>/dev/null)" = "$VERSION" ]; then
+            echo "::notice::surrealmemory@$VERSION already on npm — nothing to do."
+            exit 0
+          fi
           npm ci || npm install
+          # Sync the package version to the release tag (package.json drift was the
+          # root cause of releases 2.11.0/2.12.0 silently re-publishing 2.10.5).
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
           npm run build
-          npm publish --access public \
-            || echo "::warning::npm publish failed (already published or name/permissions) — skipping"
+          # No fallback mask: a real publish failure must fail the job loudly.
+          npm publish --access public
 
   # ── Publish TypeScript SDK ─────────────────────────────────────
   publish-sdk:
@@ -216,11 +225,19 @@ jobs:
             echo "::notice::NPM_TOKEN not set — skipping SDK publish."
             exit 0
           fi
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Idempotent re-run guard: skip ONLY if this exact version is already live.
+          if [ "$(npm view "@acidkill/surreal-memory-client@$VERSION" version 2>/dev/null)" = "$VERSION" ]; then
+            echo "::notice::@acidkill/surreal-memory-client@$VERSION already on npm — nothing to do."
+            exit 0
+          fi
           npm ci || npm install
+          # Sync the package version to the release tag (same drift class as publish-npm).
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
           npm run typecheck
           npm run build
-          npm publish --access public \
-            || echo "::warning::SDK publish failed (already published or name/permissions) — skipping"
+          # No fallback mask: a real publish failure must fail the job loudly.
+          npm publish --access public
 
   # ── Publish to ClawHub ─────────────────────────────────────────
   publish-clawhub:
@@ -267,20 +284,22 @@ jobs:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
           npm ci || npm install
+          # Sync the extension version to the release tag (same drift class as publish-npm).
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
           npm run compile 2>/dev/null || npm run build 2>/dev/null || true
 
-          # VS Code Marketplace
+          # VS Code Marketplace — no fallback mask: with a PAT set, a publish
+          # failure must fail the job loudly instead of reporting green.
           if [ -n "$VSCE_PAT" ]; then
-            npx @vscode/vsce publish --pat "$VSCE_PAT" \
-              || echo "::warning::VS Code Marketplace publish failed"
+            npx @vscode/vsce publish --pat "$VSCE_PAT"
           else
             echo "::warning::VSCE_PAT not set — skipping VS Code Marketplace"
           fi
 
           # Open VSX Registry
           if [ -n "$OVSX_PAT" ]; then
-            npx ovsx publish --pat "$OVSX_PAT" \
-              || echo "::warning::Open VSX publish failed"
+            npx ovsx publish --pat "$OVSX_PAT"
           else
             echo "::warning::OVSX_PAT not set — skipping Open VSX"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.1] — Release pipeline: npm packages actually ship again
+
+Patch release. No runtime changes — it exists to fix the release pipeline and
+re-align every published package on one version. npm packages had been silently
+stuck at 2.10.5: versions 2.11.0 and 2.12.0 were never published to npm (the
+registry rejected the re-upload of 2.10.5 with E403 and the workflow masked the
+failure as a warning). Those npm versions are intentionally skipped — npm jumps
+2.10.5 → 2.12.1.
+
+### Fixed
+
+- **Release workflow syncs npm package versions to the tag** — `publish-npm`
+  (`surrealmemory`), `publish-sdk` (`@acidkill/surreal-memory-client`) and
+  `publish-vscode` now run `npm version <tag> --no-git-tag-version` before
+  building, so a release can never re-publish a stale `package.json` version
+  again (the root cause: the pipeline bumped `pyproject.toml`/`__init__.py`
+  but never the npm manifests).
+- **Publish failures are no longer masked** — the `|| echo "::warning::…"`
+  fallbacks are gone; with a token set, a failed `npm publish`/`vsce publish`
+  now fails the job loudly. A graceful skip remains only for a missing token
+  and for an idempotent re-run (this exact version already live).
+
+### Changed
+
+- `integrations/surrealmemory`, `integrations/surreal-memory-client` and
+  `vscode-extension` manifests bumped to 2.12.1 so the repo matches the
+  published artifacts.
+
 ## [2.12.0] — Reasoning training: learn how models think
 
 An opt-in pipeline that mines a model's `thinking` blocks from `~/.claude`

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.10.0",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "2.10.0",
+      "version": "2.12.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.10.5",
+  "version": "2.12.1",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "2.10.0",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "2.10.0",
+      "version": "2.12.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.10.5",
+  "version": "2.12.1",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.12.0"
+version = "2.12.1"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.12.0"
+__version__ = "2.12.1"
 
 __all__ = [
     "__version__",

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.12.0"
+        assert surreal_memory.__version__ == "2.12.1"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "2.10.0",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "2.10.0",
+      "version": "2.12.1",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.10.5",
+  "version": "2.12.1",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Problem

npm packages have been silently stuck at **2.10.5** — releases 2.11.0 and 2.12.0 never shipped to npm.

Root cause (from the v2.12.0 release run logs):
```
npm notice version: 2.10.5
npm error 403 Forbidden - PUT https://registry.npmjs.org/surrealmemory
  - You cannot publish over the previously published versions: 2.10.5.
```
The release pipeline bumps `pyproject.toml` + `__init__.py` but never the npm manifests, so every publish re-tried the stale `package.json` version — and the `|| echo "::warning::…"` fallback masked the E403 as a green job.

## Fix

- **`publish-npm` / `publish-sdk` / `publish-vscode`**: run `npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version` (after install, before build) so the published version always equals the tag — the drift class is eliminated structurally.
- **No more masking**: publish failures now fail the job loudly. Graceful skip remains only for a missing token, plus an idempotent re-run guard (skip iff this exact version is already live in the registry).
- **Version bump 2.12.1** across `pyproject.toml`, `__init__.py`, the version test, and all three npm manifests (+lockfiles). npm intentionally skips 2.11.0/2.12.0 and jumps 2.10.5 → 2.12.1.
- CHANGELOG entry for 2.12.1. README verified — no hardcoded versions, nothing stale.

## Test plan

- `uv run make verify` green locally (CI-equivalent): 6543 passed, 84 skipped, coverage 69.77%, lint/type/security clean.
- `release.yml` parses as valid YAML; `$GITHUB_REF_NAME` used as a runner env var (no `${{ }}` script interpolation).
- After merge: tag `v2.12.1` → release run must show real publish results (green = actually published); registries verified post-release (PyPI + npm × 2 + marketplace).