### PR TITLE
fix(docker): mount ~/.claude/projects so dashboard reasoning mining works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Docker: reasoning mining found zero traces.** `docker-compose.surrealdb.yml`
+  now mounts the host's `~/.claude/projects` read-only into the dashboard
+  container at `/home/appuser/.claude/projects`. Without it the in-container miner
+  scanned an empty `~/.claude` and every dashboard "Mine" finished instantly with
+  0 traces (no error) — looking like nothing happened. Projects-only, read-only
+  mount (not the whole `~/.claude`); override via `HOST_CLAUDE_PROJECTS` in `.env`.
+
 ## [2.12.1] — Release pipeline: npm packages actually ship again
 
 Patch release. No runtime changes — it exists to fix the release pipeline and

--- a/docker-compose.surrealdb.yml
+++ b/docker-compose.surrealdb.yml
@@ -101,6 +101,13 @@ services:
         condition: service_healthy
     volumes:
       - nm_data:/data
+      # Reasoning-training mining reads the host's Claude transcripts from
+      # ~/.claude/projects/*/*.jsonl. Mounted READ-ONLY and projects-only (not the
+      # whole ~/.claude, which also holds settings/credentials). Without this the
+      # dashboard "Mine" runs in-container against an empty ~/.claude and silently
+      # finds zero traces. Container user is appuser (uid 1000); override the host
+      # path via HOST_CLAUDE_PROJECTS in .env if your home differs.
+      - ${HOST_CLAUDE_PROJECTS:-${HOME}/.claude/projects}:/home/appuser/.claude/projects:ro
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Problem

Enabling mining in the reasoning-training dashboard reported "mining enabled", but every **Mine** finished instantly (~0.6s) with `traces_ingested: 0`, `error: null` — no progress, no log, no patterns. Looked broken.

**Root cause:** the dashboard runs in the `docker-compose.surrealdb.yml` container (`HOME=/home/appuser`), but the miner scans `Path.home()/.claude/projects`. That path was empty in the container — the host's 3200+ transcripts in `~/.claude/projects` were never mounted. The mine correctly found nothing and returned quietly.

## Fix

Read-only, **projects-only** bind mount (not the whole `~/.claude`, which also holds settings/credentials):

```yaml
- ${HOST_CLAUDE_PROJECTS:-${HOME}/.claude/projects}:/home/appuser/.claude/projects:ro
```

Container user is `appuser` uid 1000 (matches host), so the mount is readable. Overridable via `HOST_CLAUDE_PROJECTS` in `.env`.

## Verification

After recreating the container:
- container sees **3289** transcripts (55 projects)
- `POST /api/dashboard/reasoning/mine {backfill:true}` → **502 traces ingested, 9 patterns learned**, no error
- detected model `claude-haiku-4-5`; sample patterns: `data-analysis` (conf 0.75), `research` (0.63), `verification` (0.56)

Docs-/infra-only (compose + CHANGELOG); no package/version change.