### PR TITLE
fix(surrealdb): cascade synapses brain-agnostically on every neuron-delete path

### DIFF
--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -2618,13 +2618,14 @@ class SurrealDBStorage(
         )
         count = 0
         for r in rows:
-            # Re-sanitise the id read back from the DB rather than trusting the
-            # write-path invariant (defence in depth): _to_surreal_id strips the
-            # table prefix and folds, so ``neuron:{nid}`` stays a safe literal.
-            nid = _to_surreal_id(str(r.get("id", "")))
+            # Route through delete_neuron() (audit DB-01) instead of a raw
+            # conn.delete(): that raw call skipped the synapse cascade AND the
+            # neuron_state cleanup, leaving both as orphans once the ephemeral
+            # neuron aged out — the same bug already fixed for delete_neuron's
+            # other callers, just missed here.
             try:
-                await self._conn.delete(f"neuron:{nid}")
-                count += 1
+                if await self.delete_neuron(str(r.get("id", ""))):
+                    count += 1
             except Exception:
                 pass
         return count

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -907,22 +907,21 @@ class SurrealDBStorage(
 
     async def delete_neuron(self, neuron_id: str) -> bool:
         conn = self._ensure_conn()
-        brain_id = self._get_brain_id()
-        safe_brain = _safe_brain_id(brain_id)
         sid = _to_surreal_id(neuron_id)
 
-        # Delete connected synapses first (belt-and-braces: SurrealDB also auto-cleans
-        # edges when the neuron record is deleted). Endpoints are native in/out now.
-        #
-        # Measured live: a single "brain_id = $brain_id AND (in = ... OR out = ...)"
-        # query cost ~1.2s/call regardless of whether brain_id/the record id are
-        # inlined or param-bound — SurrealDB 3.2.0's planner doesn't use either
-        # `idx_synapse_in`/`idx_synapse_out` index across an OR of two different
-        # fields, so it falls back to a full scan. Splitting into two single-field
-        # DELETEs (each hits its own index) measured ~5ms total for both — this was
-        # the dominant cost behind prune's non-dry-run timeout on a large brain.
-        await self._query(f"DELETE synapse WHERE brain_id = '{safe_brain}' AND in = neuron:{sid}")
-        await self._query(f"DELETE synapse WHERE brain_id = '{safe_brain}' AND out = neuron:{sid}")
+        # Delete connected synapses first. This is brain-agnostic ON PURPOSE (audit
+        # DB-01): a synapse whose in/out points at this neuron becomes a dangling
+        # orphan once the neuron is gone, regardless of the synapse's own brain_id.
+        # Some write paths create synapses with a NULL brain_id, which the previous
+        # `brain_id = '<brain>' AND ...` filter silently skipped — leaving orphans that
+        # the schema's cascade_delete_synapses event did NOT catch either (that event
+        # does not fire on the SDK conn.delete() call below). Matching the neuron
+        # endpoint alone is correct AND index-friendly: two single-field DELETEs each
+        # hit their own `idx_synapse_in`/`idx_synapse_out` index (~5ms total); a
+        # combined OR across the two fields falls back to a full scan in SurrealDB
+        # 3.2.0's planner (~1.2s), which was the dominant cost behind prune timeouts.
+        await self._query(f"DELETE synapse WHERE in = neuron:{sid}")
+        await self._query(f"DELETE synapse WHERE out = neuron:{sid}")
         # Delete state (record id is state_<sid>, matching the writer in add_neuron)
         await self._query(f"DELETE neuron_state:state_{sid}")
 

--- a/tests/unit/test_cleanup_ephemeral_neurons_cascade.py
+++ b/tests/unit/test_cleanup_ephemeral_neurons_cascade.py
@@ -1,0 +1,75 @@
+"""Regression guard for audit finding DB-01 (re-accrual, 2026-07-26): the
+2026-07-19 fix (144c39d) made delete_neuron() cascade synapse deletes
+brain-agnostically, but cleanup_ephemeral_neurons() used its own raw
+conn.delete() with no cascade at all — orphaning both synapses and
+neuron_state rows every time smem_auto's session-end ephemeral sweep ran.
+This test asserts cleanup_ephemeral_neurons() now routes through
+delete_neuron() so the cascade applies here too.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+
+class _FakeConn:
+    """Captures SDK conn.delete() record ids."""
+
+    def __init__(self) -> None:
+        self.deletes: list[str] = []
+
+    async def delete(self, record_id: str) -> None:
+        self.deletes.append(record_id)
+
+
+class _FakeStore:
+    """Fake `self` exposing only what cleanup_ephemeral_neurons + delete_neuron touch."""
+
+    def __init__(self, ephemeral_rows: list[dict[str, Any]]) -> None:
+        self._conn = _FakeConn()
+        self.queries: list[str] = []
+        self._ephemeral_rows = ephemeral_rows
+
+    def _ensure_conn(self) -> Any:
+        return self._conn
+
+    def _get_brain_id(self) -> str:
+        return "uruboros"
+
+    async def _query(self, sql: str, **params: Any) -> list[dict[str, Any]]:
+        self.queries.append(sql)
+        if "FROM neuron WHERE" in sql and "ephemeral" in sql:
+            return self._ephemeral_rows
+        return []
+
+    async def _record_change_internal(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def delete_neuron(self, neuron_id: str) -> bool:
+        return await SurrealDBStorage.delete_neuron(self, neuron_id)
+
+
+async def test_cleanup_ephemeral_neurons_cascades_synapses_and_state() -> None:
+    store = _FakeStore(ephemeral_rows=[{"id": "neuron:00012d0f_c36e_4cd5_b2b4_7538fa683a17"}])
+
+    deleted = await SurrealDBStorage.cleanup_ephemeral_neurons(store, max_age_hours=24.0)
+
+    assert deleted == 1
+    synapse_deletes = [q for q in store.queries if "DELETE synapse" in q]
+    state_deletes = [q for q in store.queries if "DELETE neuron_state" in q]
+
+    assert any("in = neuron:" in q for q in synapse_deletes)
+    assert any("out = neuron:" in q for q in synapse_deletes)
+    assert len(state_deletes) == 1
+    assert store._conn.deletes == ["neuron:00012d0f_c36e_4cd5_b2b4_7538fa683a17"]
+
+
+async def test_cleanup_ephemeral_neurons_skips_when_none_expired() -> None:
+    store = _FakeStore(ephemeral_rows=[])
+
+    deleted = await SurrealDBStorage.cleanup_ephemeral_neurons(store, max_age_hours=24.0)
+
+    assert deleted == 0
+    assert store._conn.deletes == []

--- a/tests/unit/test_delete_neuron_cascade.py
+++ b/tests/unit/test_delete_neuron_cascade.py
@@ -1,0 +1,81 @@
+"""Regression guard for audit finding DB-01: delete_neuron must remove ALL synapses
+whose in/out points at the deleted neuron, regardless of the synapse's own brain_id.
+
+Some write paths create synapses with a NULL brain_id. The previous implementation
+deleted synapses with a `brain_id = '<brain>' AND in/out = neuron` filter, which
+silently skipped NULL-brain synapses — orphaning them when the neuron was pruned
+(the schema's cascade_delete_synapses event does not fire on the SDK conn.delete()).
+This test asserts the synapse-delete predicate is brain-agnostic (endpoint only).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+
+class _FakeConn:
+    """Captures SDK conn.delete() record ids."""
+
+    def __init__(self) -> None:
+        self.deletes: list[str] = []
+
+    async def delete(self, record_id: str) -> None:
+        self.deletes.append(record_id)
+
+
+class _FakeStore:
+    """Fake `self` exposing only what delete_neuron touches (no live DB, no full init)."""
+
+    def __init__(self) -> None:
+        self._conn = _FakeConn()
+        self.queries: list[str] = []
+
+    def _ensure_conn(self) -> Any:
+        return self._conn
+
+    def _get_brain_id(self) -> str:
+        return "uruboros"
+
+    async def _query(self, sql: str, **params: Any) -> list[dict[str, Any]]:
+        self.queries.append(sql)
+        return []
+
+    async def _record_change_internal(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+async def test_delete_neuron_deletes_synapses_brain_agnostically() -> None:
+    store = _FakeStore()
+
+    ok = await SurrealDBStorage.delete_neuron(store, "00012d0f-c36e-4cd5-b2b4-7538fa683a17")
+
+    assert ok is True
+    synapse_deletes = [q for q in store.queries if "DELETE synapse" in q]
+
+    # Both endpoints are swept (in AND out), each as its own index-friendly single-field DELETE.
+    assert any("in = neuron:" in q for q in synapse_deletes)
+    assert any("out = neuron:" in q for q in synapse_deletes)
+
+    # DB-01 regression guard: NO brain_id predicate — that filter skipped NULL-brain
+    # synapses and left dangling orphans.
+    assert all("brain_id" not in q for q in synapse_deletes), synapse_deletes
+
+    # The neuron record itself is deleted via the SDK (underscore-normalised id).
+    sid = "00012d0f_c36e_4cd5_b2b4_7538fa683a17"
+    assert f"neuron:{sid}" in store._conn.deletes
+
+
+async def test_delete_neuron_returns_false_when_delete_raises() -> None:
+    """Error path: a failing conn.delete() is swallowed and reported as False."""
+
+    class _BoomConn(_FakeConn):
+        async def delete(self, record_id: str) -> None:
+            raise RuntimeError("delete boom")
+
+    store = _FakeStore()
+    store._conn = _BoomConn()
+
+    ok = await SurrealDBStorage.delete_neuron(store, "abc-def")
+    assert ok is False

--- a/tests/unit/test_surrealdb_synapse_queries.py
+++ b/tests/unit/test_surrealdb_synapse_queries.py
@@ -150,19 +150,30 @@ class TestQueryShapes:
 
     @pytest.mark.asyncio
     async def test_delete_neuron_cascade_uses_in_out(self):
-        """Two single-field DELETEs, not one OR query.
+        """Two single-field DELETEs, not one OR query — and brain-agnostic.
 
         A single "brain_id = ... AND (in = X OR out = X)" query measured
         ~1.2s/call live on SurrealDB 3.2.0 — the planner doesn't use either
         idx_synapse_in/idx_synapse_out across an OR of two different fields.
         Splitting into two single-field DELETEs (each hits its own index)
         measured ~5ms total.
+
+        The DELETEs match the neuron endpoint ALONE, with no ``brain_id``
+        filter (audit DB-01): a synapse pointing at the deleted neuron becomes
+        a dangling orphan regardless of its own brain_id, and some write paths
+        create synapses with a NULL brain_id that a ``brain_id = '<brain>' AND``
+        filter silently skipped. Matching the endpoint alone is both correct and
+        index-friendly.
         """
         st, conn = _store_with_mock_conn()
         await st.delete_neuron("a")
-        in_query = _find_query(conn, "AND in = neuron:")
-        out_query = _find_query(conn, "AND out = neuron:")
+        in_query = _find_query(conn, "WHERE in = neuron:")
+        out_query = _find_query(conn, "WHERE out = neuron:")
         assert in_query is not None
         assert out_query is not None
         assert " OR " not in in_query[0]
         assert " OR " not in out_query[0]
+        # brain-agnostic on purpose (audit DB-01): no brain_id filter, or the
+        # NULL-brain_id orphan synapses this fix targets would be skipped again.
+        assert "brain_id" not in in_query[0]
+        assert "brain_id" not in out_query[0]


### PR DESCRIPTION
### Problem

`delete_neuron` deletes the neuron's synapses with a `brain_id`-filtered predicate:

```python
await self._query(f"DELETE synapse WHERE brain_id = '{safe_brain}' AND in  = neuron:{sid}")
await self._query(f"DELETE synapse WHERE brain_id = '{safe_brain}' AND out = neuron:{sid}")
```

Some write paths create synapses with a **NULL `brain_id`**. Those rows do not match the filter, so
they survive the neuron they point at and become dangling orphans. The schema's
`cascade_delete_synapses` event does not save us either — it does not fire on the SDK `conn.delete()`
call used for the neuron record itself.

### Change

Drop the `brain_id` term from the cascade. Matching the **neuron endpoint alone** is the correct
predicate: a synapse whose `in`/`out` points at a deleted neuron is dangling regardless of its own
`brain_id`.

```python
await self._query(f"DELETE synapse WHERE in  = neuron:{sid}")
await self._query(f"DELETE synapse WHERE out = neuron:{sid}")
```

### Second delete path with the same leak

`cleanup_ephemeral_neurons()` — the session-end ephemeral sweep behind `smem_auto` — did **not** go
through `delete_neuron()` at all. It had its own raw `conn.delete(f"neuron:{nid}")`, so it skipped both
the synapse cascade **and** the `neuron_state` cleanup, orphaning rows on every run. Fixing
`delete_neuron` alone would have left this path leaking, so the third commit routes it through
`delete_neuron()` instead of duplicating the delete logic:

```python
-                await self._conn.delete(f"neuron:{nid}")
-                count += 1
+                if await self.delete_neuron(str(r.get("id", ""))):
+                    count += 1
```

### Why upstream benefits

Fixes a real orphan leak with no downside: the predicate is *narrower* in what it can wrongly keep and
identical in what it deletes for correctly-tagged rows. It also preserves the performance property that
made the two-statement form necessary in the first place — each single-field `DELETE` hits its own
`idx_synapse_in` / `idx_synapse_out` index (~5 ms total), whereas a combined `OR` across the two fields
falls back to a full scan in SurrealDB 3.2.0's planner (~1.2 s), which was the dominant cost behind
prune timeouts on large brains. That measurement comment is retained in the code.

## Evidence

| Check | Result |
|---|---|
| cherry-pick onto `origin/main` | clean |
| `import surreal_memory` | OK |
| `ruff check` | All checks passed! |
| `ruff format --check` | 703 files already formatted |
| `mypy src/ --ignore-missing-imports` | Success: no issues found in 369 source files |
| `pytest -m "not stress" -n auto` | **6539 passed**, 84 skipped, 1 xfailed (baseline 6535 → **+4**) |

New files: `tests/unit/test_delete_neuron_cascade.py` (+81) and
`tests/unit/test_cleanup_ephemeral_neurons_cascade.py` (+75);
`tests/unit/test_surrealdb_synapse_queries.py` updated to the brain-agnostic query shape.

## Risks / notes for the reviewer

- **Intentional widening.** If a synapse in brain A legitimately points at a neuron in brain B, this now
  deletes it. That situation is already inconsistent data — a cross-brain edge — but a reviewer who knows
  of a valid use for it should say so.
- Second commit only realigns an existing test's expected query string; no behaviour change.
- `cleanup_ephemeral_neurons` now performs a full `delete_neuron` per row instead of a raw delete. That is
  strictly more work per ephemeral neuron — correct, but a reviewer running very large ephemeral sweeps
  may want to confirm the cost is acceptable.
- Backend-agnostic: SQLite storage untouched.
