### PR TITLE
feat(reranker): support Bearer auth and the `score` response field in HttpReranker

### DIFF
--- a/src/surreal_memory/engine/reranker.py
+++ b/src/surreal_memory/engine/reranker.py
@@ -182,26 +182,42 @@ class HttpReranker:
         blend_weight: float = 0.7,
         max_candidates: int = 30,
         timeout: float = 15.0,
+        api_key: str = "",
     ) -> None:
         self._endpoint = endpoint.rstrip("/")
         self._model = model_name
         self._blend_weight = min(max(blend_weight, 0.0), 1.0)
         self._max_candidates = min(max_candidates, 100)
         self._timeout = timeout
+        # Bearer auth for endpoints that require it (e.g. the self-hosted BGE-M3
+        # /rerank service). llamastash/llama.cpp need none — an empty key sends no header.
+        self._api_key = (
+            api_key
+            or os.environ.get("SURREAL_MEMORY_RERANKER_API_KEY", "")
+            or os.environ.get("BGE_M3_API_KEY", "")
+        ).strip()
 
     def _raw_scores(self, query: str, documents: list[str]) -> list[float]:
         payload = json.dumps({"model": self._model, "query": query, "documents": documents}).encode(
             "utf-8"
         )
-        req = urllib.request.Request(  # noqa: S310 - fixed local llamastash endpoint
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        req = urllib.request.Request(  # noqa: S310 - fixed local rerank endpoint
             f"{self._endpoint}/rerank",
             data=payload,
-            headers={"Content-Type": "application/json"},
+            headers=headers,
             method="POST",
         )
         with urllib.request.urlopen(req, timeout=self._timeout) as resp:  # noqa: S310
             data = json.loads(resp.read().decode("utf-8"))
-        by_index = {int(r["index"]): float(r["relevance_score"]) for r in data.get("results", [])}
+        # Accept both the OpenAI-compatible field (`relevance_score`, llamastash) and
+        # the BGE-M3 service field (`score`).
+        by_index = {
+            int(r["index"]): float(r.get("relevance_score", r.get("score", 0.0)))
+            for r in data.get("results", [])
+        }
         return [by_index.get(i, float("-inf")) for i in range(len(documents))]
 
     def rerank(


### PR DESCRIPTION
### Problem

`HttpReranker` sends `Content-Type` only, and parses the response with
`float(r["relevance_score"])`. Two consequences:

1. Any rerank endpoint behind a token (most self-hosted deployments that are not on `localhost`)
   cannot be used at all.
2. Endpoints that return the field as `score` — including BGE-M3's `/rerank` — raise `KeyError`
   instead of reranking.

### Change

- Optional `api_key` constructor argument, falling back to `SURREAL_MEMORY_RERANKER_API_KEY` then
  `BGE_M3_API_KEY`. An empty key sends **no** `Authorization` header, so llamastash / llama.cpp
  deployments that need none are unaffected.
- Response parsing accepts both field names:
  `float(r.get("relevance_score", r.get("score", 0.0)))` — OpenAI-compatible field first, `score` as fallback.

### Why upstream benefits

Two small compatibility gaps that each make a whole class of rerank endpoints unusable. The change is
strictly additive: existing unauthenticated, `relevance_score`-returning endpoints behave exactly as before.

## Evidence

| Check | Result |
|---|---|
| cherry-pick onto `origin/main` | clean |
| `import surreal_memory` | OK |
| `ruff check` | All checks passed! |
| `ruff format --check` | 701 files already formatted |
| `mypy src/ --ignore-missing-imports` | Success: no issues found in 369 source files |
| `pytest -m "not stress" -n auto` | 6535 passed, 84 skipped, 1 xfailed — identical to baseline |

## Risks / notes for the reviewer

- **No new tests** (suite unchanged at 6535). Happy to add a mocked-`urlopen` test covering
  "no key → no header", "key → header", and both response field names if upstream wants it before merge.
- `r.get("score", 0.0)` defaults a missing score to `0.0` rather than raising. That is deliberately
  lenient — a malformed row sorts last instead of killing the whole rerank — but it is a judgement call
  worth a reviewer's opinion.
- The `# noqa: S310` comment was retightened from "fixed local llamastash endpoint" to
  "fixed local rerank endpoint" since the endpoint is no longer llamastash-specific.
