### PR TITLE
feat(write-gate): shadow/enforce modes, per-intent auto-capture mode, and gate_decision telemetry

### DIFF
--- a/src/surreal_memory/engine/gate_telemetry.py
+++ b/src/surreal_memory/engine/gate_telemetry.py
@@ -1,0 +1,65 @@
+"""Write-gate telemetry — append engine-side gate decisions to the
+`gate_decision` table (the same SCHEMALESS table the Hermes plugin writes to),
+so scripts/gate_stats.py sees BOTH the plugin and the engine (smem
+auto-capture / stop-hook) decisions in one report.
+
+Fire-and-forget: logging must never break a write.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _lang_hint(s: str) -> str:
+    """'cjk' if the text contains CJK / Kana / Hangul, else 'latin' (no lib)."""
+    for ch in s:
+        o = ord(ch)
+        if (
+            0x4E00 <= o <= 0x9FFF
+            or 0x3400 <= o <= 0x4DBF
+            or 0x3040 <= o <= 0x30FF
+            or 0xAC00 <= o <= 0xD7A3
+        ):
+            return "cjk"
+    return "latin"
+
+
+async def log_gate_decision(
+    storage: Any,
+    *,
+    intent: str,
+    accepted: bool,
+    reason: str,
+    score: int | None,
+    mode: str,
+    content: str,
+    agent_id: str = "",
+) -> None:
+    """Best-effort insert of one gate decision (both SHADOW and ENFORCE log)."""
+    try:
+        from surreal_memory.utils.timeutils import utcnow
+
+        conn = storage._ensure_conn()
+        s = (content or "").strip()
+        await conn.insert(
+            "gate_decision",
+            {
+                "ts": utcnow(),
+                "intent": intent,
+                "accepted": accepted,
+                "score": score,
+                "reason": reason,
+                "preview": s[:80],
+                "length": len(s),
+                "lang_hint": _lang_hint(s),
+                "agent_id": agent_id,
+                "mode": mode,
+                "source": "engine",
+            },
+        )
+    except Exception:
+        logger.debug("gate_decision log failed (non-fatal)", exc_info=True)

--- a/src/surreal_memory/hooks/pre_compact.py
+++ b/src/surreal_memory/hooks/pre_compact.py
@@ -182,10 +182,44 @@ async def flush_text(text: str, project_name: str | None = None) -> dict[str, An
         auto_redact_severity = config.safety.auto_redact_min_severity
         saved: list[str] = []
 
+        # Write gate for the compaction flush (intent=auto). This path encoded
+        # with NO gate at all, so junk auto-captures bypassed both telemetry
+        # and enforcement — same contract as the stop-hook auto block now.
+        write_gate_cfg = config.write_gate
+        gate_mode = write_gate_cfg.effective_auto_mode
+
         for item in boosted:
             try:
                 # Auto-redact sensitive content
                 content = item["content"]
+
+                if gate_mode != "off":
+                    from surreal_memory.engine.gate_telemetry import log_gate_decision
+                    from surreal_memory.engine.quality_scorer import check_write_gate
+
+                    gate_result = check_write_gate(
+                        content,
+                        gate_config=write_gate_cfg,
+                        is_auto_capture=True,
+                        memory_type=item.get("type"),
+                        tags=list(base_tags),
+                    )
+                    await log_gate_decision(
+                        storage,
+                        intent="auto",
+                        accepted=not gate_result.rejected,
+                        reason=gate_result.rejection_reason or "accept",
+                        score=gate_result.score,
+                        mode=gate_mode,
+                        content=content,
+                    )
+                    if gate_mode == "enforce" and gate_result.rejected:
+                        logger.debug(
+                            "Pre-compact write gate rejected: %s",
+                            gate_result.rejection_reason,
+                        )
+                        continue
+
                 redacted_content, matches, _ = auto_redact_content(
                     content, min_severity=auto_redact_severity
                 )

--- a/src/surreal_memory/hooks/stop.py
+++ b/src/surreal_memory/hooks/stop.py
@@ -376,16 +376,19 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
         auto_redact_severity = config.safety.auto_redact_min_severity
         saved: list[str] = []
 
-        # Write gate check for stop hook (auto-capture path)
+        # Write gate check for stop hook (auto-capture path). SHADOW logs the
+        # decision to gate_decision without blocking; ENFORCE rejects. The
+        # stop hook is intent=auto, so it resolves auto_capture_mode.
         write_gate_cfg = config.write_gate
-        gate_enabled = write_gate_cfg.enabled
+        gate_mode = write_gate_cfg.effective_auto_mode
 
         for item in eligible:
             try:
                 content = item["content"]
 
-                # Apply write gate if enabled (uses auto_capture threshold)
-                if gate_enabled:
+                # Apply write gate unless off (uses auto_capture threshold)
+                if gate_mode != "off":
+                    from surreal_memory.engine.gate_telemetry import log_gate_decision
                     from surreal_memory.engine.quality_scorer import check_write_gate
 
                     gate_result = check_write_gate(
@@ -393,8 +396,18 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
                         gate_config=write_gate_cfg,
                         is_auto_capture=True,
                         memory_type=item.get("type"),
+                        tags=list(base_tags),
                     )
-                    if gate_result.rejected:
+                    await log_gate_decision(
+                        storage,
+                        intent="auto",
+                        accepted=not gate_result.rejected,
+                        reason=gate_result.rejection_reason or "accept",
+                        score=gate_result.score,
+                        mode=gate_mode,
+                        content=content,
+                    )
+                    if gate_mode == "enforce" and gate_result.rejected:
                         logger.debug(
                             "Stop hook write gate rejected: %s",
                             gate_result.rejection_reason,
@@ -440,16 +453,28 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
             summary = _extract_session_summary(text)
             if summary and len(summary) > 30:
                 # Apply write gate to session summary too
-                if gate_enabled:
+                if gate_mode != "off":
+                    from surreal_memory.engine.gate_telemetry import log_gate_decision
                     from surreal_memory.engine.quality_scorer import check_write_gate
 
+                    summary_gate_tags = list(set(base_tags) | {"session_summary"})
                     gate_result = check_write_gate(
                         summary,
                         gate_config=write_gate_cfg,
                         is_auto_capture=True,
                         memory_type="context",
+                        tags=summary_gate_tags,
                     )
-                    if gate_result.rejected:
+                    await log_gate_decision(
+                        storage,
+                        intent="auto",
+                        accepted=not gate_result.rejected,
+                        reason=gate_result.rejection_reason or "accept",
+                        score=gate_result.score,
+                        mode=gate_mode,
+                        content=summary,
+                    )
+                    if gate_mode == "enforce" and gate_result.rejected:
                         logger.debug(
                             "Stop hook session summary rejected: %s",
                             gate_result.rejection_reason,

--- a/src/surreal_memory/mcp/remember_handler.py
+++ b/src/surreal_memory/mcp/remember_handler.py
@@ -218,9 +218,16 @@ class RememberHandler:
                     logger.error("Encryption failed, refusing to store plaintext", exc_info=True)
                     return {"error": "Encryption failed — memory not stored. Check encryption key."}
 
-        # Write gate: reject low-quality content before encoding
+        # Write gate: score content; SHADOW logs the decision to gate_decision
+        # without blocking, ENFORCE rejects. Auto-captures resolve their own
+        # mode (auto_capture_mode) so junk can be enforced while manual writes
+        # stay in shadow.
         write_gate_cfg = self.config.write_gate
-        if write_gate_cfg.enabled is True:
+        gate_mode = (
+            write_gate_cfg.effective_auto_mode if is_auto_capture else write_gate_cfg.effective_mode
+        )
+        if gate_mode != "off":
+            from surreal_memory.engine.gate_telemetry import log_gate_decision
             from surreal_memory.engine.quality_scorer import check_write_gate
 
             gate_result = check_write_gate(
@@ -231,9 +238,18 @@ class RememberHandler:
                 tags=args.get("tags"),
                 context=args.get("context") if isinstance(args.get("context"), dict) else None,
             )
-            if gate_result.rejected:
+            await log_gate_decision(
+                storage,
+                intent="auto" if is_auto_capture else "manual",
+                accepted=not gate_result.rejected,
+                reason=gate_result.rejection_reason or "accept",
+                score=gate_result.score,
+                mode=gate_mode,
+                content=content,
+            )
+            if gate_mode == "enforce" and gate_result.rejected:
                 logger.debug(
-                    "Write gate rejected: %s (score=%d)",
+                    "Write gate rejected: %s (score=%s)",
                     gate_result.rejection_reason,
                     gate_result.score,
                 )

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -441,16 +441,44 @@ class WriteGateConfig:
     Addresses GitHub Issue #95: write-gate to improve brain purity.
     """
 
-    enabled: bool = False  # opt-in, backward compat
+    enabled: bool = False  # opt-in, backward compat (True == enforce)
+    mode: str = "off"  # off | shadow | enforce. Overrides `enabled` when not "off".
+    # Per-intent override for auto-captures (intent=auto ONLY; summaries and
+    # turns keep `mode`). "" = inherit `mode`. Lets junk auto-captures be
+    # ENFORCED while interactive writes stay in shadow — a global enforce is
+    # known to false-reject real turn/summary content.
+    auto_capture_mode: str = ""  # "" (inherit) | off | shadow | enforce
     min_length: int = 30  # reject content shorter than this
     min_quality_score: int = 3  # reject score below this (0-10 scale)
     auto_capture_min_score: int = 5  # stricter threshold for passive captures
     max_content_length: int = 2000  # reject wall-of-text above this
     reject_generic_filler: bool = True  # reject "done", "ok", "completed" etc.
 
+    @property
+    def effective_mode(self) -> str:
+        """Resolve the operating mode. `mode` wins; otherwise fall back to the
+        legacy `enabled` bool (True -> enforce, False -> off)."""
+        m = (self.mode or "off").strip().lower()
+        if m in ("shadow", "enforce"):
+            return m
+        if m == "off" and self.enabled:
+            return "enforce"
+        return "off"
+
+    @property
+    def effective_auto_mode(self) -> str:
+        """Resolve the mode for auto-captures (intent=auto). A valid
+        `auto_capture_mode` wins; otherwise inherit `effective_mode`."""
+        m = (self.auto_capture_mode or "").strip().lower()
+        if m in ("off", "shadow", "enforce"):
+            return m
+        return self.effective_mode
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "enabled": self.enabled,
+            "mode": self.mode,
+            "auto_capture_mode": self.auto_capture_mode,
             "min_length": self.min_length,
             "min_quality_score": self.min_quality_score,
             "auto_capture_min_score": self.auto_capture_min_score,
@@ -462,6 +490,8 @@ class WriteGateConfig:
     def from_dict(cls, data: dict[str, Any]) -> WriteGateConfig:
         return cls(
             enabled=bool(data.get("enabled", False)),
+            mode=str(data.get("mode", "off")),
+            auto_capture_mode=str(data.get("auto_capture_mode", "")),
             min_length=int(data.get("min_length", 30)),
             min_quality_score=int(data.get("min_quality_score", 3)),
             auto_capture_min_score=int(data.get("auto_capture_min_score", 5)),
@@ -1915,6 +1945,8 @@ class UnifiedConfig:
             "# Write gate (quality enforcement before storage)",
             "[write_gate]",
             f"enabled = {'true' if self.write_gate.enabled else 'false'}",
+            f'mode = "{self.write_gate.mode}"',
+            f'auto_capture_mode = "{self.write_gate.auto_capture_mode}"',
             f"min_length = {self.write_gate.min_length}",
             f"min_quality_score = {self.write_gate.min_quality_score}",
             f"auto_capture_min_score = {self.write_gate.auto_capture_min_score}",

--- a/tests/unit/test_geo_mcp.py
+++ b/tests/unit/test_geo_mcp.py
@@ -15,7 +15,7 @@ import pytest
 
 from surreal_memory.engine.retrieval_types import DepthLevel, RetrievalResult, Subgraph
 from surreal_memory.mcp.server import MCPServer
-from surreal_memory.unified_config import ResponseConfig, ToolTierConfig
+from surreal_memory.unified_config import ResponseConfig, ToolTierConfig, WriteGateConfig
 from surreal_memory.utils.geo import GeoFilter
 
 
@@ -31,7 +31,7 @@ def _make_server() -> MCPServer:
             tool_tier=ToolTierConfig(tier="full"),
             response=ResponseConfig(),
         )
-        cfg.write_gate.enabled = False
+        cfg.write_gate = WriteGateConfig()  # real config (mode="off") so the write-gate is skipped
         cfg.encryption.enabled = False
         cfg.safety.auto_redact_min_severity = 3
         mock_get_config.return_value = cfg

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -8,7 +8,7 @@ import pytest
 
 from surreal_memory.mcp.auto_capture import analyze_text_for_memories
 from surreal_memory.mcp.server import MCPServer, create_mcp_server, handle_message
-from surreal_memory.unified_config import ToolTierConfig
+from surreal_memory.unified_config import ToolTierConfig, WriteGateConfig
 
 
 class TestMCPServer:
@@ -22,6 +22,7 @@ class TestMCPServer:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 tool_tier=ToolTierConfig(tier="full"),
                 response=ResponseConfig(),
@@ -33,6 +34,7 @@ class TestMCPServer:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 tool_tier=ToolTierConfig(tier="full"),
             )
@@ -216,13 +218,15 @@ class TestMCPToolCalls:
         from surreal_memory.unified_config import ResponseConfig
 
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
+            # Real WriteGateConfig (default mode="off") so the gate resolves via
+            # effective_mode/effective_auto_mode instead of a truthy MagicMock.
             cfg = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 tool_tier=ToolTierConfig(tier="full"),
                 response=ResponseConfig(),
             )
-            cfg.write_gate.enabled = False
             mock_get_config.return_value = cfg
             return MCPServer()
 
@@ -522,6 +526,7 @@ class TestMCPToolCalls:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 auto=mock_auto_config,
             )
@@ -879,6 +884,7 @@ class TestMCPErrorPaths:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 auto=MagicMock(enabled=False),
             )
@@ -1026,6 +1032,7 @@ class TestMCPProtocol:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 tool_tier=ToolTierConfig(tier="full"),
                 response=ResponseConfig(),
@@ -1187,6 +1194,7 @@ class TestMCPResources:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 tool_tier=ToolTierConfig(tier="full"),
                 response=ResponseConfig(),
@@ -1282,6 +1290,7 @@ class TestMCPStorage:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 tool_tier=ToolTierConfig(tier="full"),
             )
@@ -1431,6 +1440,7 @@ class TestPassiveCapture:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 auto=mock_auto_config,
             )
@@ -1568,6 +1578,7 @@ class TestMCPEternal:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 eternal=mock_eternal_config,
                 auto=mock_auto_config,
@@ -1872,6 +1883,7 @@ class TestMCPImport:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 tool_tier=ToolTierConfig(tier="full"),
                 response=ResponseConfig(),
@@ -2050,6 +2062,7 @@ class TestMCPAutoExtended:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 auto=mock_auto_config,
                 eternal=mock_eternal_config,
@@ -2158,6 +2171,7 @@ class TestMCPContextExtended:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 tool_tier=ToolTierConfig(tier="full"),
                 response=ResponseConfig(),
@@ -2277,6 +2291,7 @@ class TestMCPRecallExtended:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 auto=mock_auto_config,
                 eternal=mock_eternal_config,
@@ -2405,6 +2420,7 @@ class TestMCPMiscErrors:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 eternal=mock_eternal_config,
             )
@@ -2517,6 +2533,7 @@ class TestMCPFireTrigger:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 eternal=mock_eternal_config,
                 auto=mock_auto_config,
@@ -2571,6 +2588,7 @@ class TestMCPInputValidation:
         with patch("surreal_memory.mcp.server.get_config") as mock_get_config:
             mock_get_config.return_value = MagicMock(
                 current_brain="test-brain",
+                write_gate=WriteGateConfig(enabled=False),
                 get_brain_db_path=MagicMock(return_value="/tmp/test-brain.db"),
                 auto=MagicMock(enabled=True, min_confidence=0.7),
                 eternal=MagicMock(enabled=False),

--- a/tests/unit/test_write_gate.py
+++ b/tests/unit/test_write_gate.py
@@ -361,3 +361,73 @@ class TestWriteGateEdgeCases:
         result = check_write_gate("done", gate_config=self._gate())
         with pytest.raises(AttributeError):
             result.rejected = False  # type: ignore[misc]
+
+
+# ============================================================================
+# Mode / per-intent auto_capture_mode (Uruboros SHADOW/ENFORCE overlay)
+# ============================================================================
+
+
+class TestWriteGateModePersistence:
+    """write_gate.mode must survive a config save()/load() round-trip.
+
+    Regression: the TOML serializer omitted the mode key, so every engine-side
+    config save silently demoted an active shadow/enforce gate to effective
+    'off' (live incident 2026-06-30)."""
+
+    def test_mode_survives_save_load_roundtrip(self, tmp_path) -> None:
+        from pathlib import Path
+
+        from surreal_memory.unified_config import UnifiedConfig
+
+        config = UnifiedConfig(
+            data_dir=Path(tmp_path),
+            current_brain="default",
+            write_gate=WriteGateConfig(enabled=False, mode="shadow"),
+        )
+        config.save()
+
+        toml_content = (Path(tmp_path) / "config.toml").read_text()
+        assert 'mode = "shadow"' in toml_content
+
+        loaded = UnifiedConfig.load(Path(tmp_path) / "config.toml")
+        assert loaded.write_gate.mode == "shadow"
+        assert loaded.write_gate.effective_mode == "shadow"
+
+
+class TestAutoCaptureMode:
+    """auto_capture_mode: per-intent override for intent=auto captures."""
+
+    def test_default_inherits_effective_mode(self) -> None:
+        cfg = WriteGateConfig(mode="shadow")
+        assert cfg.effective_auto_mode == "shadow"
+
+    def test_explicit_enforce_wins_over_shadow(self) -> None:
+        cfg = WriteGateConfig(mode="shadow", auto_capture_mode="enforce")
+        assert cfg.effective_mode == "shadow"
+        assert cfg.effective_auto_mode == "enforce"
+
+    def test_invalid_value_inherits(self) -> None:
+        cfg = WriteGateConfig(mode="shadow", auto_capture_mode="bogus")
+        assert cfg.effective_auto_mode == "shadow"
+
+    def test_off_disables_auto_gate_only(self) -> None:
+        cfg = WriteGateConfig(mode="shadow", auto_capture_mode="off")
+        assert cfg.effective_mode == "shadow"
+        assert cfg.effective_auto_mode == "off"
+
+    def test_survives_save_load_roundtrip(self, tmp_path) -> None:
+        from pathlib import Path
+
+        from surreal_memory.unified_config import UnifiedConfig
+
+        config = UnifiedConfig(
+            data_dir=Path(tmp_path),
+            current_brain="default",
+            write_gate=WriteGateConfig(mode="shadow", auto_capture_mode="enforce"),
+        )
+        config.save()
+        loaded = UnifiedConfig.load(Path(tmp_path) / "config.toml")
+        assert loaded.write_gate.auto_capture_mode == "enforce"
+        assert loaded.write_gate.effective_auto_mode == "enforce"
+        assert loaded.write_gate.effective_mode == "shadow"


### PR DESCRIPTION
### Problem

`WriteGateConfig` on `main` is a single boolean: `enabled`. That forces an all-or-nothing choice.
Turning it on immediately starts rejecting writes with thresholds nobody has measured on their own
corpus; leaving it off means the gate never produces any data you could tune it with. In practice a
global `enforce` false-rejects real conversational turns and summaries, so the gate ends up permanently off.

### Change

**1. Three modes instead of a boolean.**

```python
mode: str = "off"            # off | shadow | enforce — overrides `enabled` when not "off"
auto_capture_mode: str = ""  # "" (inherit) | off | shadow | enforce
```

`shadow` evaluates the gate and records the decision **without rejecting anything**. Backward compatible:
`effective_mode` falls back to the legacy `enabled` bool (`True` → `enforce`) whenever `mode` is `"off"`,
so existing configs behave exactly as today.

**2. Per-intent override.** `auto_capture_mode` applies to `intent=auto` only; summaries and turns keep
`mode`. This is the practically useful combination: **enforce** the gate on junk passive auto-captures
while interactive writes stay in **shadow**.

**3. `gate_decision` telemetry** (`engine/gate_telemetry.py`, new) wired into the paths that actually
write: `mcp/remember_handler.py`, `hooks/stop.py`, `hooks/pre_compact.py`. This is what makes shadow mode
worth anything — you get the accept/reject record you need to pick thresholds before you enforce them.

**4.** Two test commits replace hand-rolled config mocks in the MCP and geo server tests with a real
`WriteGateConfig`, so the mocks cannot drift from the dataclass.

### Why upstream benefits

Shadow mode is the standard way to ship a policy engine: measure first, enforce second. Without it the
write gate is a feature most users will never safely turn on. Full backward compatibility means zero
impact on anyone who does not set `mode`.

## Evidence

| Check | Result |
|---|---|
| cherry-pick onto `origin/main` | clean (4 commits) |
| `import surreal_memory` | OK |
| `ruff check` | All checks passed! |
| `ruff format --check` | 702 files already formatted |
| `mypy src/ --ignore-missing-imports` | Success: no issues found in **370** source files (369 + `gate_telemetry`) |
| `pytest -m "not stress" -n auto` | **6541 passed**, 84 skipped, 1 xfailed (baseline 6535 → **+6**) |

`tests/unit/test_write_gate.py` +70 lines covering `effective_mode` / `effective_auto_mode` resolution
including the legacy-`enabled` fallback.

## Risks / notes for the reviewer

- Largest of the eight PRs (8 files). Splittable if preferred: commits 1+3+4 (config + test mocks) are
  independent of commit 2 (telemetry + wiring), though shadow mode is not much use without the telemetry.
- Two config knobs where there was one boolean. `effective_mode` / `effective_auto_mode` centralise the
  precedence so no call site re-derives it — worth a look, that is where a subtle bug would live.
- Telemetry writes: `gate_decision` records are persisted. A reviewer should confirm the retention story
  is acceptable — this branch does not add pruning for them.
- Backend-agnostic: no storage-layer schema change.
