### PR TITLE
feat(write-gate): reject machine output and session-notification noise (Gate 1b)

### DIFF
--- a/src/surreal_memory/engine/quality_scorer.py
+++ b/src/surreal_memory/engine/quality_scorer.py
@@ -67,6 +67,36 @@ _GENERIC_FILLER = frozenset(
     }
 )
 
+# Machine-output / notification noise — never valuable knowledge. Empirical denylist
+# from gate_decision false-accepts (2026-07-23): 180x "Session activity:", 30x <summary>,
+# 20x "Background command", 19x <status>, 12x task-notification, tool-use-id, *-caveat>, etc.
+_NOISE_TAG_RE = re.compile(
+    r"</?summary>|</?status>|</?task-notification>|<system-reminder"
+    r"|[a-z][a-z_-]*-caveat>|<tool_use_id>|tool-use-id>|<function_calls>"
+    r'|\bMonitor event\b|Background command "',
+    re.IGNORECASE,
+)
+_NOISE_PREFIXES = (
+    "session activity:",
+    "<task-notification",
+    "ps -o ",
+    "echo ",
+    "curl -",
+)
+
+
+def _is_machine_noise(content: str) -> bool:
+    """True if content is machine output / session-notification noise, not knowledge.
+
+    Two signals: (a) starts with a known auto-capture/shell noise prefix, or
+    (b) contains a structural notification/tool tag that never appears in a real memory.
+    """
+    stripped = content.strip()
+    if stripped.lower().startswith(_NOISE_PREFIXES):
+        return True
+    return bool(_NOISE_TAG_RE.search(stripped))
+
+
 # -- Quality thresholds -----------------------------------------------------
 
 _MIN_CONTENT_LENGTH = 10
@@ -235,6 +265,16 @@ def check_write_gate(
             hints=("Provide substantive content instead of generic filler",),
             rejected=True,
             rejection_reason=f"Generic filler rejected: '{stripped[:50]}'",
+        )
+
+    # Gate 1b: Machine-output / session-notification noise (empirical denylist)
+    if _is_machine_noise(stripped):
+        return QualityResult(
+            score=0,
+            quality="low",
+            hints=("Machine output / session-notification noise is not a memory",),
+            rejected=True,
+            rejection_reason=f"Machine-noise rejected: '{stripped[:50]}'",
         )
 
     # Gate 2: Minimum length


### PR DESCRIPTION
### Problem

Passive auto-capture stores a lot of harness output as if it were knowledge. Measured over one day of
`gate_decision` false-accepts on a live brain: **180×** `"Session activity:"`, **30×** `<summary>`,
**20×** `"Background command"`, **19×** `<status>`, **12×** `task-notification`, plus `tool-use-id`,
`*-caveat>` and raw shell lines (`ps -o …`, `echo …`, `curl -…`). None of it is a memory. All of it
passes the length and quality-score gates because it is long, structured, and full of distinct tokens.

### Change

A new `Gate 1b` in `score_memory`, running before the scoring heuristics:

```python
def _is_machine_noise(content: str) -> bool:
    """Two signals: (a) a known auto-capture/shell noise prefix, or
    (b) a structural notification/tool tag that never appears in a real memory."""
```

A match returns `QualityResult(score=0, quality="low", rejected=True,
rejection_reason="Machine-noise rejected: …")` — same shape as the existing rejection gates.

### Why upstream benefits

The denylist is derived from measured false-accepts, not guesswork, and it targets exactly the content
this project's own hooks generate. Every entry is a structural marker (a tag or a fixed prefix), so the
false-positive surface on genuine prose is small.

## Evidence

| Check | Result |
|---|---|
| cherry-pick onto `origin/main` | clean |
| `import surreal_memory` | OK |
| `ruff check` | All checks passed! |
| `ruff format --check` | 701 files already formatted |
| `mypy src/ --ignore-missing-imports` | Success: no issues found in 369 source files |
| `pytest -m "not stress" -n auto` | 6535 passed, 84 skipped, 1 xfailed — identical to baseline |

## Risks / notes for the reviewer

- **No new tests** (suite unchanged at 6535). This is the weakest of the eight on that axis: it is a
  rejection gate with no test asserting either that the noise is rejected or that ordinary prose is not.
  Recommend requiring a test before merge — happy to add one.
- **Hardcoded list.** The markers are Claude-Code-harness-specific (`<system-reminder>`,
  `task-notification`, `tool-use-id`). Reasonable for this project, but a reviewer may prefer it
  config-driven (`write_gate.noise_patterns`) so other harnesses can extend it without a code change.
- A memory that legitimately *quotes* one of these tags (e.g. a note about debugging the hooks) would be
  rejected. Rare, and the rejection is explicit with the reason in the message, not silent.
- The commit was reformatted with `ruff format` while preparing this branch (quote-style normalisation in
  `_NOISE_TAG_RE`); author preserved.
