### PR TITLE
build(mypy): ignore missing stubs for sentence_transformers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,6 +258,7 @@ module = [
     "openpyxl.*",
     "google.genai.*",
     "watchdog.*",
+    "sentence_transformers.*",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
### Problem

`sentence_transformers` ships no type stubs. It is absent from the existing
`[[tool.mypy.overrides]]` block that already lists `networkx.*`, `chromadb.*`, `openpyxl.*`,
`google.genai.*` and `watchdog.*` — so in any environment where the package **is** installed, `mypy`
reports import errors for it while every comparable dependency is exempt.

### Change

One line in `pyproject.toml`:

```toml
[[tool.mypy.overrides]]
module = [
    ...
    "watchdog.*",
+   "sentence_transformers.*",
]
ignore_missing_imports = true
```

### Why upstream benefits

Consistency with every other stub-less optional dependency already handled the same way, and a clean
`mypy` run for contributors who have the package installed.

## Evidence

| Check | Result |
|---|---|
| cherry-pick onto `origin/main` | clean |
| `import surreal_memory` | OK |
| `ruff check` | All checks passed! |
| `ruff format --check` | 701 files already formatted |
| `mypy src/ --ignore-missing-imports` | Success: no issues found in 369 source files |
| `pytest -m "not stress" -n auto` | 6535 passed, 84 skipped, 1 xfailed — identical to baseline |

## Risks / notes for the reviewer

- Effectively none. The gate passes with and without it in an environment where the package is not
  installed; the change only matters where it is.
- Worth merging first — it is a one-liner and it is a prerequisite for a clean `mypy` on any branch that
  imports `sentence_transformers`.
