### PR TITLE
fix: brain scoping by name, loud rerank degradation, consolidation on large brains

### DIFF
--- a/src/surreal_memory/cli/commands/brain.py
+++ b/src/surreal_memory/cli/commands/brain.py
@@ -516,8 +516,10 @@ def brain_transplant(
             result = await transplant(
                 source_storage=source_storage,
                 target_storage=target_storage,
-                source_brain_id=source_brain.id,
-                target_brain_id=target_brain.id,
+                # Scope is the brain *name*; brain.id is a UUID for brains created
+                # by older versions and would transplant from/into an empty scope.
+                source_brain_id=source_brain.name,
+                target_brain_id=target_brain.name,
                 filt=filt,
                 strategy=merge_strategy,
             )

--- a/src/surreal_memory/cli/commands/info.py
+++ b/src/surreal_memory/cli/commands/info.py
@@ -32,7 +32,9 @@ def stats(
         if not brain:
             return {"error": "No brain configured"}
 
-        enhanced = await storage.get_enhanced_stats(brain.id)
+        # Rows are scoped by the brain *name* (storage.brain_id), not by the brain
+        # record's UUID primary key — brain.id would query an empty scope.
+        enhanced = await storage.get_enhanced_stats(storage.brain_id or brain.name)
 
         # Get fibers for freshness analysis
         fibers = await storage.get_fibers(limit=1000)
@@ -232,7 +234,7 @@ def status(
                 "error": "No brain configured. Run: smem brain create default && smem brain use default"
             }
 
-        stats_data = await storage.get_stats(brain.id)
+        stats_data = await storage.get_stats(storage.brain_id or brain.name)
 
         # Last memory timestamp
         fibers = await storage.get_fibers(limit=1)
@@ -362,7 +364,7 @@ def health(
         from surreal_memory.engine.diagnostics import DiagnosticsEngine
 
         engine = DiagnosticsEngine(storage)
-        report = await engine.analyze(brain.id)
+        report = await engine.analyze(storage.brain_id or brain.name)
 
         return {
             "brain": brain.name,

--- a/src/surreal_memory/cli/commands/memory.py
+++ b/src/surreal_memory/cli/commands/memory.py
@@ -491,6 +491,14 @@ def recall(
         if freshness_warnings:
             response["freshness_warnings"] = list(dict.fromkeys(freshness_warnings))[:3]
 
+        # Never let reranking fail silently: raw SA ordering is indistinguishable
+        # from reranked output, so say it out loud when the reranker did not run.
+        rerank_degraded = (result.metadata or {}).get("rerank_degraded")
+        if rerank_degraded:
+            response["rerank_degraded_warning"] = (
+                f"[!] Results NOT reranked (reranker enabled but unavailable): {rerank_degraded}"
+            )
+
         return response
 
     result = run_async(_recall())

--- a/src/surreal_memory/cli/commands/version.py
+++ b/src/surreal_memory/cli/commands/version.py
@@ -61,7 +61,7 @@ def version_create(
 
             engine = VersioningEngine(storage)
             try:
-                version = await engine.create_version(brain.id, name, description)
+                version = await engine.create_version(storage.brain_id or brain.name, name, description)
             except ValueError as e:
                 logger.error("Version create failed: %s", e)
                 return {"error": "Failed to create version: invalid parameters"}
@@ -122,7 +122,7 @@ def version_list(
             from surreal_memory.engine.brain_versioning import VersioningEngine
 
             engine = VersioningEngine(storage)
-            versions = await engine.list_versions(brain.id, limit=limit)
+            versions = await engine.list_versions(storage.brain_id or brain.name, limit=limit)
 
             return {
                 "versions": [
@@ -191,7 +191,7 @@ def version_rollback(
 
             engine = VersioningEngine(storage)
             try:
-                rollback_v = await engine.rollback(brain.id, version_id)
+                rollback_v = await engine.rollback(storage.brain_id or brain.name, version_id)
             except ValueError as e:
                 logger.error("Version rollback failed: %s", e)
                 return {"error": "Rollback failed: version not found or invalid"}
@@ -245,7 +245,7 @@ def version_diff(
 
             engine = VersioningEngine(storage)
             try:
-                diff = await engine.diff(brain.id, from_version, to_version)
+                diff = await engine.diff(storage.brain_id or brain.name, from_version, to_version)
             except ValueError as e:
                 logger.error("Version diff failed: %s", e)
                 return {"error": "Diff failed: one or both versions not found"}

--- a/src/surreal_memory/cli/commands/version.py
+++ b/src/surreal_memory/cli/commands/version.py
@@ -61,7 +61,9 @@ def version_create(
 
             engine = VersioningEngine(storage)
             try:
-                version = await engine.create_version(storage.brain_id or brain.name, name, description)
+                version = await engine.create_version(
+                    storage.brain_id or brain.name, name, description
+                )
             except ValueError as e:
                 logger.error("Version create failed: %s", e)
                 return {"error": "Failed to create version: invalid parameters"}

--- a/src/surreal_memory/cli/tui.py
+++ b/src/surreal_memory/cli/tui.py
@@ -66,7 +66,8 @@ async def render_dashboard(storage: PersistentStorage) -> None:
         return
 
     # Gather data
-    stats = await storage.get_stats(brain.id)
+    # Rows are scoped by the brain *name* (storage.brain_id), not the record UUID.
+    stats = await storage.get_stats(storage.brain_id or brain.name)
     fibers = await storage.get_fibers(limit=100)
     typed_memories = await storage.find_typed_memories(limit=1000)
     expired_memories = await storage.get_expired_memories()
@@ -449,7 +450,8 @@ async def render_quick_stats(storage: PersistentStorage) -> str:
     if not brain:
         return "No brain configured"
 
-    stats = await storage.get_stats(brain.id)
+    # Rows are scoped by the brain *name* (storage.brain_id), not the record UUID.
+    stats = await storage.get_stats(storage.brain_id or brain.name)
     typed_memories = await storage.find_typed_memories(limit=1000)
 
     # Count by type

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -72,8 +72,13 @@ class ConsolidationConfig:
     infer_co_activation_threshold: int = 3
     infer_window_days: int = 7
     infer_max_per_run: int = 50
-    strategy_timeout_seconds: float = 120.0
-    total_timeout_seconds: float = 600.0
+    # 600s per strategy, not 120s: on large brains (10k+ neurons) the heavy passes
+    # — compress, lifecycle, essence backfill — legitimately need minutes, and a
+    # 120s cap aborted them mid-run so consolidation never converged.
+    strategy_timeout_seconds: float = 600.0
+    # The total must stay well above the per-strategy cap, otherwise a single slow
+    # strategy consumes the whole budget and every later strategy times out.
+    total_timeout_seconds: float = 3600.0
 
 
 @dataclass(frozen=True)
@@ -320,8 +325,8 @@ class ConsolidationEngine:
         within each tier. Tiers execute sequentially so that later
         strategies can depend on results from earlier ones.
 
-        Each strategy has a per-strategy timeout (default 120s) and the
-        entire consolidation has a total timeout (default 600s) to prevent
+        Each strategy has a per-strategy timeout (default 600s) and the
+        entire consolidation has a total timeout (default 3600s) to prevent
         runaway execution.
 
         Args:
@@ -1600,8 +1605,10 @@ class ConsolidationEngine:
         offset = 0
         anchors: list[Neuron] = []
         while True:
+            # Anchors are selected on metadata alone, so skip the embedding vector
+            # — it is ~4-8 KB/row and only inflates the response.
             batch = await self._storage.find_neurons(
-                limit=batch_size, offset=offset, ephemeral=False
+                limit=batch_size, offset=offset, ephemeral=False, include_embedding=False
             )
             if not batch:
                 break
@@ -1767,9 +1774,29 @@ class ConsolidationEngine:
             _logger.debug("LIFECYCLE skipped: no brain context")
             return
 
-        # Fetch neurons in batches via find_neurons (full scan)
+        # Page through the neurons instead of pulling 10k rows in one response, and
+        # drop the embedding vector: this pass only reads neuron.metadata
+        # (last_accessed_at / access_frequency / priority). A single
+        # `limit=10000` with embeddings meant a multi-hundred-MB HTTP body that
+        # SurrealDB dropped mid-transfer — "[Errno 104] Connection reset by peer",
+        # which aborted the whole LIFECYCLE pass.
+        neurons: list[Neuron] = []
+        batch_size = 500
+        offset = 0
         try:
-            neurons = await self._storage.find_neurons(limit=10000, ephemeral=False)
+            while len(neurons) < 10000:
+                batch = await self._storage.find_neurons(
+                    limit=batch_size,
+                    offset=offset,
+                    ephemeral=False,
+                    include_embedding=False,
+                )
+                if not batch:
+                    break
+                neurons.extend(batch)
+                offset += len(batch)
+                if len(batch) < batch_size:
+                    break
         except Exception:
             _logger.error("LIFECYCLE failed to fetch neurons", exc_info=True)
             return

--- a/src/surreal_memory/engine/cross_brain.py
+++ b/src/surreal_memory/engine/cross_brain.py
@@ -74,7 +74,9 @@ async def _query_single_brain(
         if not brain:
             return brain_name, [], 0, ""
 
-        storage.set_brain(brain.id)
+        # Rows are scoped by the brain *name*; brain.id is a UUID for brains
+        # created by older versions and would select an empty scope.
+        storage.set_brain(brain.name)
 
         from surreal_memory.engine.retrieval import ReflexPipeline
 

--- a/src/surreal_memory/engine/reranker.py
+++ b/src/surreal_memory/engine/reranker.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import urllib.request
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -255,6 +257,27 @@ def _normalize_scores(scores: list[float]) -> list[float]:
     return [_sigmoid(s) for s in scores]
 
 
+_URL_RE = re.compile(r"https?://\S+")
+
+
+def _degradation_reason(exc: Exception | None) -> str:
+    """Describe a rerank failure without echoing anything sensitive.
+
+    The reason travels all the way into the recall response (MCP
+    ``rerank_degraded_reason`` / the CLI warning), so it must stay a diagnostic
+    label rather than a raw exception dump: today the endpoint is a local
+    llamastash with no credentials, but a future remote endpoint could carry a
+    token in its URL and this channel would happily publish it. Strip URLs and
+    cap the length.
+    """
+    if exc is None:
+        return "unknown reranker failure"
+    detail = _URL_RE.sub("<endpoint>", str(exc)).strip()
+    if len(detail) > 160:
+        detail = detail[:157] + "..."
+    return f"{type(exc).__name__}: {detail}" if detail else type(exc).__name__
+
+
 def rerank_activations(
     query: str,
     activations: dict[str, ActivationResult],
@@ -266,6 +289,7 @@ def rerank_activations(
     max_candidates: int = 30,
     limit: int = 50,
     endpoint: str | None = None,
+    on_degraded: Callable[[str], None] | None = None,
 ) -> dict[str, ActivationResult]:
     """Convenience function: rerank activations and return updated dict.
 
@@ -280,6 +304,8 @@ def rerank_activations(
     resolved_endpoint = (endpoint or "").strip() or _rerank_endpoint()
     if not resolved_endpoint and not _check_cross_encoder():
         logger.debug("Reranker not available, returning activations unchanged")
+        if on_degraded is not None:
+            on_degraded("no reranker configured (no endpoint and no local CrossEncoder)")
         return activations
 
     reranker: Any
@@ -311,11 +337,26 @@ def rerank_activations(
     # Sort by activation level descending (over-fetch from top)
     candidates.sort(key=lambda c: c[2], reverse=True)
 
-    try:
-        reranked = reranker.rerank(query, candidates, limit)
-    except Exception:
-        # Reranking must never break recall — fall back to the SA ordering.
-        logger.warning("Reranking failed; returning activations unchanged", exc_info=True)
+    # Reranking must never break recall, but a *silent* fall-back to the raw SA
+    # ordering is worse than no reranking: the caller cannot tell the results were
+    # never reranked. Retry once (the endpoint is local, so the common failure is a
+    # model that has not finished loading yet), then report the degradation through
+    # ``on_degraded`` so recall can surface it instead of hiding it in a log line.
+    reranked = None
+    last_error: Exception | None = None
+    for attempt in (1, 2):
+        try:
+            reranked = reranker.rerank(query, candidates, limit)
+            break
+        except Exception as exc:  # reported via on_degraded, not swallowed
+            last_error = exc
+            logger.warning(
+                "Reranking attempt %d/2 failed: %s", attempt, exc, exc_info=(attempt == 2)
+            )
+
+    if reranked is None:
+        if on_degraded is not None:
+            on_degraded(_degradation_reason(last_error))
         return activations
 
     # Build new activations dict with blended scores

--- a/src/surreal_memory/engine/retrieval.py
+++ b/src/surreal_memory/engine/retrieval.py
@@ -534,6 +534,15 @@ class ReflexPipeline:
         # for compatibility but are no longer the source of truth here.
         from surreal_memory.unified_config import get_config as _get_app_config
 
+        # Reranking degradation is reported, never silent: when the reranker is
+        # enabled but does not actually run, recall must say so instead of
+        # returning raw SA ordering that looks identical to a reranked result.
+        _rerank_degraded: str | None = None
+
+        def _mark_rerank_degraded(reason: str) -> None:
+            nonlocal _rerank_degraded
+            _rerank_degraded = reason
+
         _rr = _get_app_config().reranker
         if _rr.enabled and len(activations) > 1:
             try:
@@ -571,16 +580,26 @@ class ReflexPipeline:
                             max_candidates=_rr.max_candidates,
                             limit=50,
                             endpoint=_rr.endpoint,
+                            on_degraded=_mark_rerank_degraded,
                         )
                         logger.debug(
                             "Reranked %d → %d activations",
                             len(neuron_contents),
                             len(activations),
                         )
-            except ImportError:
+                    else:
+                        _mark_rerank_degraded("no candidate contents available to rerank")
+                else:
+                    _mark_rerank_degraded(
+                        "reranker enabled but neither an endpoint nor a local "
+                        "CrossEncoder is available"
+                    )
+            except ImportError as exc:
                 logger.debug("Reranker not available (sentence-transformers not installed)")
-            except Exception:
-                logger.debug("Reranking failed (non-critical)", exc_info=True)
+                _mark_rerank_degraded(f"reranker import failed: {exc}")
+            except Exception as exc:  # reported in result metadata
+                logger.warning("Reranking failed (non-critical): %s", exc, exc_info=True)
+                _mark_rerank_degraded(f"{type(exc).__name__}: {exc}")
 
         # 5. Find matching fibers
         query_tokens = set(query.lower().split())
@@ -677,6 +696,9 @@ class ReflexPipeline:
                 "disputed_ids": disputed_ids,
                 "sufficiency_gate": _sufficiency.gate,
                 "sufficiency_confidence": _sufficiency.confidence,
+                # None when reranking ran (or was disabled); a reason string when
+                # the reranker was enabled but did not actually rerank.
+                "rerank_degraded": _rerank_degraded,
                 "activation_levels": {
                     nid: round(ar.activation_level, 4) for nid, ar in activations.items()
                 },

--- a/src/surreal_memory/integrations/nanobot/tools.py
+++ b/src/surreal_memory/integrations/nanobot/tools.py
@@ -353,7 +353,8 @@ class NMHealthTool(BaseNMTool):
         from surreal_memory.engine.diagnostics import DiagnosticsEngine
 
         engine = DiagnosticsEngine(self._ctx.storage)
-        report = await engine.analyze(self._ctx.brain.id)
+        # Scope is the brain *name* (storage.brain_id), not the record UUID.
+        report = await engine.analyze(self._ctx.storage.brain_id or self._ctx.brain.name)
 
         return self._json(
             {

--- a/src/surreal_memory/mcp/evolution_handler.py
+++ b/src/surreal_memory/mcp/evolution_handler.py
@@ -38,7 +38,8 @@ class EvolutionHandler:
 
         try:
             engine = EvolutionEngine(storage)
-            evo = await engine.analyze(brain.id)
+            # Scope is the brain *name* (storage.brain_id), not the record UUID.
+            evo = await engine.analyze(storage.brain_id or brain.name)
         except Exception:
             logger.error("Evolution analysis failed", exc_info=True)
             return {"error": "Evolution analysis failed"}

--- a/src/surreal_memory/mcp/reasoning_handler.py
+++ b/src/surreal_memory/mcp/reasoning_handler.py
@@ -42,7 +42,9 @@ class ReasoningHandler:
         brain, err = await _get_brain_or_error(storage)
         if err:
             return err
-        brain_id = brain.id
+        # Scope is the brain *name*, never the record's UUID primary key — a UUID
+        # here binds the whole mining job to a brain recall never reads.
+        brain_id = storage.brain_id or brain.name
 
         if action == "status":
             return await self._reasoning_status(storage, brain_id)

--- a/src/surreal_memory/mcp/recall_handler.py
+++ b/src/surreal_memory/mcp/recall_handler.py
@@ -744,6 +744,18 @@ class RecallHandler:
                 "recency_factor": round(result.score_breakdown.recency_factor, 4),
             }
 
+        # Surface reranking degradation: when the reranker is enabled but did not
+        # actually run, the results are raw spreading-activation ordering and look
+        # exactly like reranked ones. Reporting it prevents silent quality loss.
+        rerank_degraded = (result.metadata or {}).get("rerank_degraded")
+        if rerank_degraded:
+            response["rerank_degraded"] = True
+            response["rerank_degraded_reason"] = str(rerank_degraded)
+            response["warning"] = (
+                "Results were NOT reranked (reranker enabled but unavailable): "
+                f"{rerank_degraded}"
+            )
+
         # Surface conflict info from retrieval
         disputed_ids: list[str] = (result.metadata or {}).get("disputed_ids", [])
         if disputed_ids:

--- a/src/surreal_memory/mcp/recall_handler.py
+++ b/src/surreal_memory/mcp/recall_handler.py
@@ -752,8 +752,7 @@ class RecallHandler:
             response["rerank_degraded"] = True
             response["rerank_degraded_reason"] = str(rerank_degraded)
             response["warning"] = (
-                "Results were NOT reranked (reranker enabled but unavailable): "
-                f"{rerank_degraded}"
+                f"Results were NOT reranked (reranker enabled but unavailable): {rerank_degraded}"
             )
 
         # Surface conflict info from retrieval

--- a/src/surreal_memory/mcp/remember_handler.py
+++ b/src/surreal_memory/mcp/remember_handler.py
@@ -521,7 +521,10 @@ class RememberHandler:
                 from surreal_memory.engine.spaced_repetition import SpacedRepetitionEngine
 
                 sr_engine = SpacedRepetitionEngine(storage, brain.config)
-                await sr_engine.auto_schedule_fiber(result.fiber.id, brain.id)
+                # Review rows are scoped by the brain *name*, not the record UUID.
+                await sr_engine.auto_schedule_fiber(
+                    result.fiber.id, storage.brain_id or brain.name
+                )
             except Exception:
                 logger.debug("Auto-schedule for review failed (non-critical)", exc_info=True)
 

--- a/src/surreal_memory/mcp/remember_handler.py
+++ b/src/surreal_memory/mcp/remember_handler.py
@@ -522,9 +522,7 @@ class RememberHandler:
 
                 sr_engine = SpacedRepetitionEngine(storage, brain.config)
                 # Review rows are scoped by the brain *name*, not the record UUID.
-                await sr_engine.auto_schedule_fiber(
-                    result.fiber.id, storage.brain_id or brain.name
-                )
+                await sr_engine.auto_schedule_fiber(result.fiber.id, storage.brain_id or brain.name)
             except Exception:
                 logger.debug("Auto-schedule for review failed (non-critical)", exc_info=True)
 

--- a/src/surreal_memory/mcp/stats_handler.py
+++ b/src/surreal_memory/mcp/stats_handler.py
@@ -227,7 +227,9 @@ class StatsHandler:
         from surreal_memory.engine.diagnostics import DiagnosticsEngine
 
         engine = DiagnosticsEngine(storage)
-        report = await engine.analyze(brain.id)
+        # Rows are scoped by the brain *name* (storage.brain_id), not by the brain
+        # record's UUID primary key — brain.id would analyse an empty scope.
+        report = await engine.analyze(storage.brain_id or brain.name)
 
         result: dict[str, Any] = {
             "brain": brain.name,

--- a/src/surreal_memory/mcp/version_check_handler.py
+++ b/src/surreal_memory/mcp/version_check_handler.py
@@ -211,7 +211,7 @@ async def _fetch_latest_version() -> str | None:
         try:
             if not _PYPI_URL.startswith("https://"):
                 return None
-            req = urllib.request.Request(  # noqa: S310
+            req = urllib.request.Request(
                 _PYPI_URL,
                 headers={"Accept": "application/json"},
             )

--- a/src/surreal_memory/server/routes/reasoning_training.py
+++ b/src/surreal_memory/server/routes/reasoning_training.py
@@ -265,7 +265,11 @@ async def get_status(
 
     config = get_config()
     rt = config.reasoning_training
-    brain_id = brain.id
+    # Rows are scoped by the brain *name*, never by the brain record's UUID
+    # primary key: passing brain.id into create_isolated_storage() bound the whole
+    # mining job to a UUID scope, so every mined neuron/fiber landed in a brain
+    # that recall never reads.
+    brain_id = storage.brain_id or brain.name
 
     stats = await storage.get_reasoning_stats(brain_id)
     by_model_traces: dict[str, Any] = stats.get("by_model", {})

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -547,14 +547,38 @@ class SurrealDBStorage(
         that surfaces as a connection error, not a 401, so without this the dead
         cached connection fails every query until the process restarts (S-01).
         """
+        from surreal_memory.storage.surrealdb.connection import StorageAuthError
+
         try:
             result = await self._ensure_conn().query(sql, params)
         except Exception as exc:
             if not (_is_auth_error(exc) or _is_connection_error(exc)):
                 raise
-            async with self._reauth_lock:
-                await self._reconnect()
-            result = await self._ensure_conn().query(sql, params)
+            # A dropped transport often needs a moment before it accepts a new
+            # connection: reconnecting in the same instant tends to hit the very
+            # same reset ("[Errno 104] Connection reset by peer" during signin),
+            # which aborted the caller — e.g. an entire consolidation pass — on a
+            # single transient blip. Retry the reconnect with a short backoff.
+            last_exc: Exception = exc
+            result = None
+            for attempt, delay in enumerate((0.0, 1.0, 3.0), start=1):
+                if delay:
+                    await asyncio.sleep(delay)
+                try:
+                    async with self._reauth_lock:
+                        await self._reconnect()
+                    result = await self._ensure_conn().query(sql, params)
+                    break
+                except StorageAuthError:
+                    # Bad credentials never fix themselves — fail fast.
+                    raise
+                except Exception as retry_exc:  # re-raised below
+                    last_exc = retry_exc
+                    logger.warning(
+                        "SurrealDB reconnect attempt %d/3 failed: %s", attempt, retry_exc
+                    )
+            else:
+                raise last_exc
         if result and isinstance(result, list) and len(result) > 0:
             return result[0] if isinstance(result[0], list) else result
         return []

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -2507,7 +2507,10 @@ async def _get_sqlite_storage(
         else:
             await _migrate_brain_runtime_config(storage, brain, config)
 
-        storage.set_brain(brain.id)
+        # Match the cache-hit path above (which uses `name`): brain.id is a UUID
+        # for brains created by older versions, and binding the scope to it would
+        # split writes into a brain that lookups by name never see.
+        storage.set_brain(name)
         _storage_cache[cache_key] = storage
         return storage
 

--- a/tests/unit/test_brain_scope_uses_brain_name.py
+++ b/tests/unit/test_brain_scope_uses_brain_name.py
@@ -1,0 +1,146 @@
+"""Regression test: brain-scoped queries must use the brain *name*, not ``brain.id``.
+
+On the SurrealDB backend every row is scoped by ``brain_id = <brain name>``
+(``storage.brain_id``, e.g. ``"default"``), while the ``brain`` record carries a
+separate UUID primary key. Callers that passed ``brain.id`` into
+``get_stats``/``get_enhanced_stats``/``DiagnosticsEngine.analyze`` therefore
+queried a brain scope that holds no rows, so ``smem stats`` and ``smem_health``
+reported an empty brain (grade F, EMPTY_BRAIN) on a brain with >10k neurons.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any
+
+BRAIN_NAME = "default"
+BRAIN_UUID = "00313cb4-61ca-4e69-9784-e51431e99ad7"
+
+
+class _FakeBrain:
+    """Brain record: UUID primary key, name used as the row scope."""
+
+    def __init__(self) -> None:
+        self.id = BRAIN_UUID
+        self.name = BRAIN_NAME
+        self.created_at = datetime(2026, 6, 22)
+
+
+class _FakeStorage:
+    """Storage that only holds rows under the brain *name* scope."""
+
+    def __init__(self) -> None:
+        self.brain_id = BRAIN_NAME
+        self.scopes_queried: list[str] = []
+
+    def _counts(self, brain_id: str) -> dict[str, int]:
+        self.scopes_queried.append(brain_id)
+        if brain_id != BRAIN_NAME:
+            return {"neuron_count": 0, "synapse_count": 0, "fiber_count": 0}
+        return {"neuron_count": 10643, "synapse_count": 126086, "fiber_count": 2226}
+
+    async def get_brain(self, _brain_id: str) -> _FakeBrain:
+        return _FakeBrain()
+
+    async def get_stats(self, brain_id: str) -> dict[str, int]:
+        return self._counts(brain_id)
+
+    async def get_enhanced_stats(
+        self, brain_id: str, include_neuron_types: bool = True
+    ) -> dict[str, Any]:
+        return dict(self._counts(brain_id))
+
+    async def get_fibers(self, limit: int = 100) -> list[Any]:
+        return []
+
+    async def find_typed_memories(self, **_kwargs: Any) -> list[Any]:
+        return []
+
+    async def get_expired_memories(self) -> list[Any]:
+        return []
+
+
+def test_cli_stats_queries_the_brain_name_scope(monkeypatch: Any) -> None:
+    from surreal_memory.cli.commands import info
+
+    storage = _FakeStorage()
+
+    async def fake_get_storage(_config: Any) -> _FakeStorage:
+        return storage
+
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(info, "get_config", lambda: object())
+    monkeypatch.setattr(info, "get_storage", fake_get_storage)
+    monkeypatch.setattr(info, "output_result", lambda result, _json: captured.update(result))
+
+    info.stats(json_output=True)
+
+    assert storage.scopes_queried == [BRAIN_NAME], (
+        f"stats queried scope {storage.scopes_queried!r}; the UUID scope holds no rows"
+    )
+    assert captured["neuron_count"] == 10643
+
+
+def test_cli_status_queries_the_brain_name_scope(monkeypatch: Any) -> None:
+    from surreal_memory.cli.commands import info
+
+    storage = _FakeStorage()
+
+    async def fake_get_storage(_config: Any) -> _FakeStorage:
+        return storage
+
+    captured: dict[str, Any] = {}
+
+    monkeypatch.setattr(info, "get_config", lambda: object())
+    monkeypatch.setattr(info, "get_storage", fake_get_storage)
+    monkeypatch.setattr(info, "output_result", lambda result, _json: captured.update(result))
+
+    info.status(json_output=True)
+
+    assert storage.scopes_queried == [BRAIN_NAME]
+
+
+def test_mcp_health_analyzes_the_brain_name_scope(monkeypatch: Any) -> None:
+    from surreal_memory.engine import diagnostics as diagnostics_mod
+    from surreal_memory.mcp.stats_handler import StatsHandler
+
+    storage = _FakeStorage()
+    analyzed: list[str] = []
+
+    class _FakeReport:
+        grade = "A"
+        purity_score = 1.0
+        neuron_count = 10643
+        synapse_count = 126086
+        fiber_count = 2226
+        contradiction_count = 0
+        warnings: list[Any] = []
+        recommendations: list[Any] = []
+        top_penalties: list[Any] = []
+
+        def __getattr__(self, _name: str) -> Any:
+            return 0.0
+
+    class _FakeEngine:
+        def __init__(self, _storage: Any) -> None: ...
+
+        async def analyze(self, brain_id: str) -> _FakeReport:
+            analyzed.append(brain_id)
+            return _FakeReport()
+
+    monkeypatch.setattr(diagnostics_mod, "DiagnosticsEngine", _FakeEngine)
+
+    handler = StatsHandler.__new__(StatsHandler)
+
+    async def fake_get_storage() -> _FakeStorage:
+        return storage
+
+    handler.get_storage = fake_get_storage  # type: ignore[method-assign]
+
+    asyncio.run(handler._health({}))
+
+    assert analyzed == [BRAIN_NAME], (
+        f"health analyzed scope {analyzed!r}; the UUID scope reports EMPTY_BRAIN"
+    )

--- a/tests/unit/test_consolidation_timeouts_and_reconnect.py
+++ b/tests/unit/test_consolidation_timeouts_and_reconnect.py
@@ -1,0 +1,137 @@
+"""Regressions behind the 2026-07-28 `smem consolidate` failure.
+
+Two independent defects made a full consolidation unusable on a ~11k-neuron brain:
+
+1. The per-strategy timeout had regressed to 120s. The heavy passes (compress,
+   lifecycle, essence backfill) legitimately need minutes on a large brain, so
+   they were aborted mid-run and consolidation never converged. The project
+   decision is 600s per strategy — and the total budget must exceed it, or one
+   slow strategy starves every later one.
+
+2. ``_lifecycle`` fetched ``find_neurons(limit=10000)`` with embeddings included,
+   i.e. 10k rows x a 1024-float vector in a single HTTP response. SurrealDB
+   dropped the transfer ("[Errno 104] Connection reset by peer") and the reconnect
+   was attempted exactly once, in the same instant, so it hit the same reset and
+   the whole pass died.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from surreal_memory.engine.consolidation import ConsolidationConfig
+
+
+class TestStrategyTimeouts:
+    def test_per_strategy_timeout_is_ten_minutes(self) -> None:
+        """120s aborted the heavy passes on large brains; the decision is 600s."""
+        assert ConsolidationConfig().strategy_timeout_seconds == 600.0
+
+    def test_total_budget_exceeds_a_single_strategy(self) -> None:
+        """Otherwise one slow strategy consumes everything and the rest time out."""
+        cfg = ConsolidationConfig()
+        assert cfg.total_timeout_seconds > cfg.strategy_timeout_seconds
+
+
+class _FakeNeuron:
+    def __init__(self, nid: str) -> None:
+        self.id = nid
+        self.metadata: dict[str, Any] = {"access_frequency": 1, "priority": 5}
+
+
+class _RecordingStorage:
+    """Records how find_neurons is called; returns two short pages."""
+
+    def __init__(self) -> None:
+        self.current_brain_id = "default"
+        self.brain_id = "default"
+        self.calls: list[dict[str, Any]] = []
+
+    async def find_neurons(self, **kwargs: Any) -> list[_FakeNeuron]:
+        self.calls.append(kwargs)
+        offset = int(kwargs.get("offset", 0))
+        limit = int(kwargs.get("limit", 100))
+        if offset >= 10:
+            return []
+        return [_FakeNeuron(f"n{offset + i}") for i in range(min(10 - offset, limit))]
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_never_fetches_embeddings() -> None:
+    """The lifecycle pass reads metadata only — pulling vectors killed the transfer."""
+    from surreal_memory.engine.consolidation import ConsolidationEngine
+
+    storage = _RecordingStorage()
+    engine = ConsolidationEngine.__new__(ConsolidationEngine)
+    engine._storage = storage  # type: ignore[attr-defined]
+    engine._config = ConsolidationConfig()  # type: ignore[attr-defined]
+
+    report = type("R", (), {"extra": {}})()
+    try:
+        await engine._lifecycle(report, None, True)  # type: ignore[attr-defined]
+    except Exception:
+        # Later stages of the pass need more of the engine than this stub provides;
+        # the fetch behaviour is what this test pins down.
+        pass
+
+    assert storage.calls, "_lifecycle did not fetch neurons at all"
+    for call in storage.calls:
+        assert call.get("include_embedding") is False, (
+            f"lifecycle fetched embeddings ({call}) — that is the huge response "
+            "SurrealDB resets mid-transfer"
+        )
+        assert int(call.get("limit", 0)) <= 1000, (
+            f"lifecycle fetched {call.get('limit')} rows in one response; page it instead"
+        )
+
+
+class _FlakyConn:
+    """Fails `attempts_before_success` times with a connection reset, then works."""
+
+    def __init__(self, attempts_before_success: int) -> None:
+        self.remaining = attempts_before_success
+        self.query_calls = 0
+
+    async def query(self, _sql: str, _params: Any) -> list[Any]:
+        self.query_calls += 1
+        if self.remaining > 0:
+            self.remaining -= 1
+            raise ConnectionResetError(104, "Connection reset by peer")
+        return [[{"ok": True}]]
+
+
+@pytest.mark.asyncio
+async def test_query_retries_reconnect_after_connection_reset(monkeypatch: Any) -> None:
+    """One transient reset must not abort the caller (it killed consolidation)."""
+    from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+    store = SurrealDBStorage.__new__(SurrealDBStorage)
+    store._reauth_lock = asyncio.Lock()  # type: ignore[attr-defined]
+    conn = _FlakyConn(attempts_before_success=2)
+    store._conn = conn  # type: ignore[attr-defined]
+
+    reconnects = {"n": 0}
+
+    async def fake_reconnect() -> None:
+        reconnects["n"] += 1
+
+    store._reconnect = fake_reconnect  # type: ignore[assignment,method-assign]
+    store._ensure_conn = lambda: conn  # type: ignore[assignment,method-assign]
+
+    # Keep the test fast: the production backoff sleeps between attempts.
+    async def _no_sleep(_d: float) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "surreal_memory.storage.surrealdb.store.asyncio.sleep", _no_sleep, raising=True
+    )
+
+    rows = await store._query("SELECT 1")
+
+    assert rows == [{"ok": True}]
+    assert reconnects["n"] >= 2, (
+        f"only {reconnects['n']} reconnect attempt(s) — a single retry hits the same reset"
+    )

--- a/tests/unit/test_rerank_degradation_is_loud.py
+++ b/tests/unit/test_rerank_degradation_is_loud.py
@@ -1,0 +1,130 @@
+"""Regression test: a failing reranker must never degrade recall *silently*.
+
+When the reranker is enabled but unavailable (e.g. llamastash restarted and the
+rerank model has not been re-loaded, which answers HTTP 501), recall used to fall
+back to the raw spreading-activation ordering and only log a warning. The caller
+saw results that looked exactly like reranked ones. Recall now retries once and
+reports the degradation via ``on_degraded`` so it can reach the user.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from surreal_memory.engine.reranker import rerank_activations
+
+ENDPOINT = "http://127.0.0.1:11435/v1"
+
+
+@dataclass
+class _Act:
+    """Stand-in for ActivationResult (dataclasses.replace() is used on it)."""
+
+    activation_level: float
+
+
+def _activations() -> dict[str, Any]:
+    return {"n1": _Act(0.8), "n2": _Act(0.5)}
+
+
+def _contents() -> dict[str, str]:
+    return {"n1": "alpha content", "n2": "beta content"}
+
+
+class _RerankedItem:
+    def __init__(self, neuron_id: str, blended_score: float) -> None:
+        self.neuron_id = neuron_id
+        self.blended_score = blended_score
+
+
+def test_failing_reranker_reports_degradation_and_retries(monkeypatch: Any) -> None:
+    """A reranker that always raises: recall keeps results, but reports it."""
+    attempts: list[int] = []
+
+    class _BrokenReranker:
+        def __init__(self, **_kwargs: Any) -> None: ...
+
+        def rerank(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+            attempts.append(1)
+            raise RuntimeError("HTTP Error 501: Not Implemented")
+
+    monkeypatch.setattr(
+        "surreal_memory.engine.reranker.HttpReranker", _BrokenReranker, raising=True
+    )
+
+    reasons: list[str] = []
+    activations = _activations()
+
+    result = rerank_activations(
+        "query",
+        activations,
+        _contents(),
+        endpoint=ENDPOINT,
+        on_degraded=reasons.append,
+    )
+
+    # Recall is never broken: the caller still gets its activations back.
+    assert result is activations
+    # ...but the degradation is reported, not swallowed.
+    assert reasons, "reranker failure was silent — the caller cannot tell"
+    assert "501" in reasons[0]
+    # ...and a transient failure gets a second chance before giving up.
+    assert len(attempts) == 2, f"expected one retry, got {len(attempts)} attempt(s)"
+
+
+def test_transient_failure_recovers_on_retry(monkeypatch: Any) -> None:
+    """A reranker that fails once then succeeds must NOT report degradation."""
+
+    class _FlakyReranker:
+        calls = 0
+
+        def __init__(self, **_kwargs: Any) -> None: ...
+
+        def rerank(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+            _FlakyReranker.calls += 1
+            if _FlakyReranker.calls == 1:
+                raise RuntimeError("model still loading")
+            return [_RerankedItem("n2", 0.95), _RerankedItem("n1", 0.4)]
+
+    monkeypatch.setattr(
+        "surreal_memory.engine.reranker.HttpReranker", _FlakyReranker, raising=True
+    )
+
+    reasons: list[str] = []
+
+    result = rerank_activations(
+        "query",
+        _activations(),
+        _contents(),
+        endpoint=ENDPOINT,
+        on_degraded=reasons.append,
+    )
+
+    assert not reasons, f"retry succeeded but degradation was reported: {reasons}"
+    # Reranked order won: n2 outranks n1 despite the lower initial activation.
+    assert result["n2"].activation_level == 0.95
+
+
+def test_no_reranker_configured_is_reported(monkeypatch: Any) -> None:
+    """No endpoint and no local CrossEncoder is itself a reportable degradation."""
+    monkeypatch.setattr(
+        "surreal_memory.engine.reranker._check_cross_encoder", lambda: False, raising=True
+    )
+    monkeypatch.setattr(
+        "surreal_memory.engine.reranker._rerank_endpoint", lambda: "", raising=True
+    )
+
+    reasons: list[str] = []
+    activations = _activations()
+
+    result = rerank_activations(
+        "query",
+        activations,
+        _contents(),
+        endpoint="",
+        on_degraded=reasons.append,
+    )
+
+    assert result is activations
+    assert reasons and "no reranker configured" in reasons[0]

--- a/tests/unit/test_rerank_degradation_is_loud.py
+++ b/tests/unit/test_rerank_degradation_is_loud.py
@@ -87,9 +87,7 @@ def test_transient_failure_recovers_on_retry(monkeypatch: Any) -> None:
                 raise RuntimeError("model still loading")
             return [_RerankedItem("n2", 0.95), _RerankedItem("n1", 0.4)]
 
-    monkeypatch.setattr(
-        "surreal_memory.engine.reranker.HttpReranker", _FlakyReranker, raising=True
-    )
+    monkeypatch.setattr("surreal_memory.engine.reranker.HttpReranker", _FlakyReranker, raising=True)
 
     reasons: list[str] = []
 
@@ -111,9 +109,7 @@ def test_no_reranker_configured_is_reported(monkeypatch: Any) -> None:
     monkeypatch.setattr(
         "surreal_memory.engine.reranker._check_cross_encoder", lambda: False, raising=True
     )
-    monkeypatch.setattr(
-        "surreal_memory.engine.reranker._rerank_endpoint", lambda: "", raising=True
-    )
+    monkeypatch.setattr("surreal_memory.engine.reranker._rerank_endpoint", lambda: "", raising=True)
 
     reasons: list[str] = []
     activations = _activations()

--- a/tests/unit/test_reranker.py
+++ b/tests/unit/test_reranker.py
@@ -206,8 +206,15 @@ class TestRerankerAvailable:
 
 
 class TestRerankActivations:
-    @patch("surreal_memory.engine.reranker.reranker_available", return_value=False)
-    def test_graceful_skip_when_unavailable(self, mock_available: MagicMock) -> None:
+    # rerank_activations() gates on _rerank_endpoint()/_check_cross_encoder(), NOT on
+    # reranker_available() — patching the latter left the real availability check in
+    # place, so this test reranked for real (and downloaded the HF model) on any
+    # machine with sentence-transformers installed or a rerank endpoint configured.
+    @patch("surreal_memory.engine.reranker._check_cross_encoder", return_value=False)
+    @patch("surreal_memory.engine.reranker._rerank_endpoint", return_value="")
+    def test_graceful_skip_when_unavailable(
+        self, mock_endpoint: MagicMock, mock_cross_encoder: MagicMock
+    ) -> None:
         """When reranker not installed, return activations unchanged."""
         activations = {
             "n1": FakeActivationResult(neuron_id="n1", activation_level=0.8),

--- a/tests/unit/test_version_check.py
+++ b/tests/unit/test_version_check.py
@@ -84,7 +84,7 @@ class TestGetUpdateHint:
 def _make_handler(
     *,
     update_available: bool = False,
-    version_info: VersionInfo | None | str = "auto",
+    version_info: VersionInfo | str | None = "auto",
 ) -> MagicMock:
     """Create a mock handler with VersionCheckHandler.get_update_hint."""
     from surreal_memory.mcp.version_check_handler import VersionCheckHandler


### PR DESCRIPTION
Three independent bugs found while recovering a local stack that would not come back after a manual shutdown. All three are reproducible outside that machine.

## 1. Brain-owned rows scoped by UUID instead of name

Rows in SurrealDB are scoped by the brain **name** (`brain_id = "default"`, i.e. `storage.brain_id`), while the `brain` record carries a separate UUID primary key. Ten call sites mixed the two and addressed an empty scope.

**Reads** were wrong but harmless: `smem stats`, `smem status` and MCP `smem_health` reported an empty brain (grade F, `EMPTY_BRAIN`) on a brain holding 10k+ neurons.

**Writes** were not harmless. `reasoning_training.py` and `reasoning_handler.py` passed `brain.id` into `create_isolated_storage()`, binding the whole mining job to a UUID scope, so every mined neuron/fiber/synapse landed in a brain that recall never reads. Observed live: **76 neurons / 150 fibers / 68 synapses** written into an invisible scope in two minutes.

This is **not** limited to brains created by older versions. `Brain.create()` defaults to `brain_id or str(uuid4())`, and `POST /brain` does not pass `brain_id=name` — so any brain created through the dashboard or API lands in exactly this configuration on a fresh install.

Same confusion also fixed in cross-brain recall, spaced-repetition scheduling, versioning, transplant, and the SQLite branch of `get_shared_storage` (whose cache-hit path already used the name).

Note: this PR fixes the consumers. The underlying divergence — `POST /brain` minting a UUID id while rows are keyed by name — is left alone deliberately, as changing id assignment touches existing data. Worth a follow-up.

## 2. Rerank degradation was silent

With the reranker enabled but unavailable, recall fell back to raw spreading-activation ordering and only logged a warning. Un-reranked results are indistinguishable from reranked ones, so the quality loss was invisible. A llamastash restart left `/v1/rerank` answering HTTP 501 for over an hour while every recall quietly lost reranking.

`rerank_activations()` now retries once (the endpoint is typically local, so the common failure is a model still loading) and reports degradation via an optional `on_degraded` callback, surfaced in `RetrievalResult.metadata["rerank_degraded"]`, the MCP recall response, and the CLI. Recall still returns its memories — it just stops pretending they were reranked. The reason string is sanitised (URLs stripped, length capped) since it travels into the response.

Also fixes `test_graceful_skip_when_unavailable`, which patched `reranker_available()` — a function `rerank_activations()` never calls. On any machine with sentence-transformers installed the test reranked for real and downloaded the model from the HF Hub.

## 3. Consolidation broken on large brains

- Per-strategy timeout had regressed to 120s; the heavy passes legitimately need minutes on a large brain and were aborted mid-run. Restored to 600s, and the total budget raised 600s → 3600s (leaving the total at 600s would make the per-strategy value meaningless — one slow strategy would starve the rest).
- `_lifecycle` fetched `find_neurons(limit=10000)` **with embeddings**: 10k rows × a 1024-float vector in one HTTP response. SurrealDB dropped the transfer (`[Errno 104] Connection reset by peer`) and the pass died. The pass only reads `neuron.metadata`, so it now pages with `include_embedding=False` — matching what the neighbouring dead-neuron scan already did. The anchor scan gets the same treatment.
- `_query` retried its reconnect exactly once, in the same instant as the failure, hitting the same reset. Now retries with a short backoff (0s/1s/3s), still failing fast on `StorageAuthError`.

## Test plan

- [x] `pytest tests/unit` — 6527 passed, 48 skipped
- [x] Three new regression files: `test_brain_scope_uses_brain_name.py`, `test_rerank_degradation_is_loud.py`, `test_consolidation_timeouts_and_reconnect.py` (verified RED before the fixes)
- [x] `ruff check` / `ruff format` clean for every touched file
- [x] Live: `smem stats` reports 10,987 neurons where it previously reported 0
- [x] Live: stopping the rerank model makes recall emit `rerank_degraded_warning: HTTPError: HTTP Error 501: Not Implemented`; restarting it clears the flag
- [x] Live: full `smem consolidate --dry-run` on the affected brain completes in 46.9s with no reset and no timed-out strategy
- [x] Security review: no CRITICAL/HIGH/MEDIUM findings; no secrets, no new injection vector (`_brain_literal` validates against `^[a-zA-Z0-9_.\-]+$` and fails closed), no cross-brain leakage
