### PR TITLE
fix: bound inline embedding so a slow provider cannot fail the write

### DIFF
--- a/src/surreal_memory/engine/encoder.py
+++ b/src/surreal_memory/engine/encoder.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 import re
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -46,6 +48,27 @@ from surreal_memory.utils.tag_normalizer import TagNormalizer
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
+
+
+def _inline_embed_timeout() -> float:
+    """Seconds the write path will wait for inline embeddings before giving up.
+
+    Default 10s: comfortably above a local endpoint (bge-m3 via llamastash answers
+    in ~15 ms) and comfortably below the 30s tool-call cap that MCP hosts such as
+    Claude Code and Claude Desktop enforce, so a slow provider can never turn a
+    successful write into a client-side timeout. Override with
+    ``SURREAL_MEMORY_INLINE_EMBED_TIMEOUT`` (<= 0 disables the bound).
+    """
+    raw = os.environ.get("SURREAL_MEMORY_INLINE_EMBED_TIMEOUT", "").strip()
+    if not raw:
+        return 10.0
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("Invalid SURREAL_MEMORY_INLINE_EMBED_TIMEOUT=%r — falling back to 10s", raw)
+        return 10.0
+    return value if value > 0 else 0.0
+
 
 if TYPE_CHECKING:
     from surreal_memory.core.brain import BrainConfig
@@ -499,7 +522,27 @@ class MemoryEncoder:
 
         try:
             provider = _create_provider(self._config, task_type="RETRIEVAL_DOCUMENT")
-            vectors = await provider.embed_batch([n.content for n in candidates])
+            # Bound the wait. This method is fail-soft by design — "no provider"
+            # already means "keyword-only memory, no error" — but an *unavailable*
+            # provider and a *slow* one used to be treated differently: a remote or
+            # rate-limited endpoint blocked the write until its own timeout, pushing
+            # `smem_remember` past the 30s tool-call cap MCP hosts impose. The write
+            # itself had already succeeded, so the caller saw a timeout and could not
+            # tell whether the memory landed — the exact failure this tool exists to
+            # prevent. A local endpoint (bge-m3 via llamastash, ~15 ms) is nowhere
+            # near this budget; anything that is pays with a slightly later vector
+            # instead of a lost write. `smem reindex` back-fills.
+            budget = _inline_embed_timeout()
+            embed = provider.embed_batch([n.content for n in candidates])
+            vectors = await (asyncio.wait_for(embed, timeout=budget) if budget else embed)
+        except TimeoutError:
+            logger.warning(
+                "Inline embedding exceeded %.0fs for %d neuron(s) — memory saved "
+                "keyword-only; run `smem reindex` to back-fill the vectors.",
+                _inline_embed_timeout(),
+                len(candidates),
+            )
+            return
         except Exception:
             logger.debug("Inline embedding skipped (provider unavailable)", exc_info=True)
             return

--- a/tests/unit/test_inline_embed_timeout.py
+++ b/tests/unit/test_inline_embed_timeout.py
@@ -1,0 +1,106 @@
+"""Regression test for #79: a slow embedding provider must not fail the write.
+
+``_embed_created_neurons`` runs inside the write path so a fresh memory is
+semantically recallable immediately. It was already fail-soft about a *missing*
+provider ("keyword-only memory, no error"), but not about a *slow* one: a remote
+or rate-limited endpoint blocked until its own timeout, pushing ``smem_remember``
+past the 30s tool-call cap MCP hosts impose. The write had already succeeded, so
+the caller saw a timeout and could not tell whether the memory landed — the exact
+loss this tool exists to prevent.
+
+The bound turns "slow provider" into "vector arrives later" rather than
+"caller cannot tell what happened".
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from surreal_memory.engine.encoder import MemoryEncoder, _inline_embed_timeout
+
+
+class TestInlineEmbedTimeoutConfig:
+    def test_default_sits_under_the_mcp_tool_cap(self, monkeypatch: Any) -> None:
+        """Must be well below the 30s cap, or the bound does not solve #79."""
+        monkeypatch.delenv("SURREAL_MEMORY_INLINE_EMBED_TIMEOUT", raising=False)
+        assert 0 < _inline_embed_timeout() < 30.0
+
+    def test_env_override_is_honoured(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("SURREAL_MEMORY_INLINE_EMBED_TIMEOUT", "2.5")
+        assert _inline_embed_timeout() == 2.5
+
+    def test_non_positive_disables_the_bound(self, monkeypatch: Any) -> None:
+        """Escape hatch for anyone who prefers the old blocking behaviour."""
+        monkeypatch.setenv("SURREAL_MEMORY_INLINE_EMBED_TIMEOUT", "0")
+        assert _inline_embed_timeout() == 0.0
+
+    def test_garbage_falls_back_instead_of_raising(self, monkeypatch: Any) -> None:
+        """A typo in the env must not take down every write."""
+        monkeypatch.setenv("SURREAL_MEMORY_INLINE_EMBED_TIMEOUT", "soon")
+        assert _inline_embed_timeout() == 10.0
+
+
+class _Neuron:
+    """Minimal stand-in for a created neuron."""
+
+    def __init__(self, nid: str) -> None:
+        from surreal_memory.core.neuron import NeuronType
+
+        self.id = nid
+        self.content = "alpha content"
+        self.metadata: dict[str, Any] = {}
+        self.ephemeral = False
+        self.type = NeuronType.CONCEPT
+
+
+class _Ctx:
+    def __init__(self, neurons: list[Any]) -> None:
+        self.neurons_created = neurons
+        self.anchor_neuron = None
+
+
+class _HangingProvider:
+    """Never answers — stands in for a rate-limited / cold-start remote endpoint."""
+
+    async def embed_batch(self, _texts: list[str]) -> list[list[float]]:
+        await asyncio.sleep(3600)
+        raise AssertionError("unreachable")
+
+
+@pytest.mark.asyncio
+async def test_slow_provider_does_not_block_the_write(monkeypatch: Any) -> None:
+    """The write path returns promptly; the memory is simply left keyword-only."""
+    monkeypatch.setenv("SURREAL_MEMORY_INLINE_EMBED_TIMEOUT", "0.2")
+    monkeypatch.setattr(
+        "surreal_memory.engine.semantic_discovery._effective_embedding",
+        lambda _cfg: (True, None, None),
+        raising=True,
+    )
+    monkeypatch.setattr(
+        "surreal_memory.engine.semantic_discovery._create_provider",
+        lambda _cfg, task_type=None: _HangingProvider(),
+        raising=True,
+    )
+
+    updates: list[Any] = []
+
+    class _Storage:
+        async def update_neuron(self, neuron: Any) -> None:
+            updates.append(neuron)
+
+    encoder = MemoryEncoder.__new__(MemoryEncoder)
+    encoder._storage = _Storage()  # type: ignore[attr-defined]
+    encoder._config = object()  # type: ignore[attr-defined]
+
+    ctx = _Ctx([_Neuron("n1")])
+
+    # Generous ceiling: the point is that it returns on the 0.2s budget, not on
+    # the provider's own (here: never).
+    await asyncio.wait_for(encoder._embed_created_neurons(ctx), timeout=10)
+
+    # Fail-soft: no vector was written, and crucially no exception propagated —
+    # the neuron itself was already persisted upstream.
+    assert updates == []


### PR DESCRIPTION
Closes #79.

## Problem

`_embed_created_neurons` runs inside the write path so a fresh memory is semantically recallable immediately. It is already fail-soft about a **missing** provider — *"keyword-only memory, no error, no slowdown"*, as its own docstring promises — but a **slow** provider was treated differently: the call blocked until the provider's own timeout.

Against a remote or rate-limited endpoint (the reporter runs a proxied Gemini endpoint) that pushes `smem_remember` past the **30s tool-call cap** MCP hosts such as Claude Code and Claude Desktop impose. The neuron has already been persisted by then, so the caller sees a timeout and cannot tell whether the write landed — precisely the loss this tool exists to prevent. The same content through the CLI succeeds, because nothing caps it there.

Verified still present on `main` (`d8233b1`) before changing anything: `encoder.py:438` awaits `_embed_created_neurons`, which awaits `provider.embed_batch` with no bound. No async/pending-embedding path exists (`git grep pending_embedding` is empty).

## Change

The embedding call runs under `asyncio.wait_for` with a **10s** budget — well above a local endpoint (bge-m3 via llamastash answers in ~15 ms) and well below the 30s cap, so the bound only ever fires on a provider that would have broken the call anyway.

On timeout the memory stays keyword-only and logs a warning naming `smem reindex` as the back-fill. That is the *same* outcome the method already produced when no provider was available — this extends an existing guarantee to a case it did not cover, rather than inventing new behaviour.

`SURREAL_MEMORY_INLINE_EMBED_TIMEOUT` tunes it; `<= 0` restores the previous unbounded behaviour for anyone who prefers it.

## Scope

This is the minimal form of **option 2** in the issue. It deliberately does **not** implement ack-first with async back-fill (option 1) or a `pending_embedding` state (option 3) — both are larger changes worth their own discussion. This closes the data-loss window in the meantime, and does not foreclose either.

## Test plan

- [x] `tests/unit/test_inline_embed_timeout.py` — 5 cases: default sits under the 30s cap, env override, `<= 0` disables, garbage falls back instead of raising, and a hanging provider does not block the write
- [x] Test proven to have teeth: with the bound disabled the same scenario hangs (confirmed by running it with `SURREAL_MEMORY_INLINE_EMBED_TIMEOUT=0` — the call never returns), so this fails without the fix
- [x] `pytest tests/unit` — 6563 passed, 48 skipped
- [x] `ruff check` / `ruff format --check` clean across `src/` and `tests/`
