### PR TITLE
fix: close PR-queue follow-ups and release 2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,114 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.0] — Brain scoping, honest degradation, and consolidation that finishes
+
+Correctness release. The theme is **silent failure**: three of these bugs made the
+system look like it was working while it quietly was not — an empty-looking brain
+that held 10k neurons, recall that skipped reranking without saying so, and writes
+that landed but reported a timeout.
+
+### ⚠️ Upgrade note
+
+**If a deployment accumulated rows under a UUID brain scope, they need remapping.**
+Rows are scoped by brain *name* (`brain_id = "default"`), but several call sites
+passed the brain record's UUID primary key. Reasoning mining was one such path, so
+its output landed in a scope recall never reads. Before this release a fetch by
+record id still returned those rows; #63 now brain-scopes every by-id fetch, so
+they become unreadable by *any* path until remapped:
+
+```sql
+UPDATE neuron  SET brain_id = "default" WHERE brain_id = "<uuid>";
+UPDATE fiber   SET brain_id = "default" WHERE brain_id = "<uuid>";
+UPDATE synapse SET brain_id = "default" WHERE brain_id = "<uuid>";
+```
+
+Check first with `SELECT brain_id, count() FROM neuron GROUP BY brain_id` — a
+healthy install shows one scope per brain name and no UUIDs.
+
+### Security
+
+- **Cross-brain read via record id (#63).** Every fetch-by-record-id did a bare
+  `select` with no `WHERE brain_id`, so a caller in brain A could read a record
+  owned by brain B just by knowing its id. All six getters (`get_neuron`,
+  `get_neuron_state`, `get_synapse`, `get_fiber`, `get_neurons_batch`,
+  `find_neurons_by_ids`) now scope to the brain, fail-closed. Fetches stay pinned
+  by id, so this is not a table scan — the dashboard-perf property is preserved.
+- **Id sanitisers consolidated (#63).** `migrations._sanitize_id` and an inline
+  fold in `tool_events` bypassed the single `_to_surreal_id` choke point.
+
+### Fixed
+
+- **Brain-owned rows scoped by UUID instead of name (#97, #98).** Ten call sites
+  passed `brain.id` where rows are keyed by brain name. Reads reported an empty
+  brain (grade F, `EMPTY_BRAIN`) on a brain holding 10k+ neurons; writes were
+  worse — reasoning mining bound its whole job to a UUID scope, so mined neurons
+  and fibers landed where recall never looks. `POST /brain` now also pins
+  `brain_id` to the name, closing the source rather than the symptoms: previously
+  any brain created through the dashboard or API was born with an id that did not
+  match its own row scope.
+- **Rerank degradation was silent (#97).** With the reranker enabled but
+  unreachable, recall fell back to raw spreading-activation order and only logged
+  a warning — results indistinguishable from reranked ones. Recall now retries
+  once and reports the degradation (`rerank_degraded` in the MCP response,
+  `rerank_degraded_warning` in the CLI). The reason string is sanitised, so a
+  remote endpoint cannot leak a token through it.
+- **Consolidation aborted on large brains (#97).** Per-strategy timeout had
+  regressed to 120s, cutting the heavy passes mid-run so consolidation never
+  converged; restored to 600s with the total budget raised to 3600s. `_lifecycle`
+  fetched 10k neurons *with* embeddings in one response, which SurrealDB dropped
+  mid-transfer (`[Errno 104] Connection reset by peer`); it reads only metadata,
+  so it now pages with `include_embedding=False`. `_query` retried its reconnect
+  once, in the same instant, hitting the same reset — now backs off (0s/1s/3s) and
+  still fails fast on auth errors.
+- **Writes reported a timeout after succeeding (#79, #99).** Inline embedding ran
+  unbounded inside the write path, so a slow or rate-limited provider pushed
+  `smem_remember` past the 30s tool-call cap MCP hosts impose — the memory landed
+  but the caller could not tell. Now bounded at 10s (tune with
+  `SURREAL_MEMORY_INLINE_EMBED_TIMEOUT`, `<= 0` restores the old behaviour); on
+  timeout the memory stays keyword-only and `smem reindex` back-fills.
+- **Dangling synapses survived neuron deletion (#89).** The cascade filtered on
+  `brain_id`, but some write paths create synapses with a NULL `brain_id`, so
+  those outlived the neuron they pointed at. A synapse whose endpoint is gone is
+  dangling regardless of which brain it claims.
+- **`SURREAL_MEMORY_BRAIN` ignored when `--brain` omitted (#90, #98).** Extracted
+  into a single `resolve_brain()` helper; the duplicated
+  `os.environ.get(X) or os.environ.get(X)` lookup is gone from both remaining
+  sites.
+- **En-dash was not a clause boundary (#65).** Editors and operating systems emit
+  U+2013 as readily as U+2014, so the same cross-clause junk bigram slipped
+  through. The ASCII hyphen stays a non-boundary, so `write-gate` still yields
+  the bigram `write gate`.
+
+### Added
+
+- **Write-gate shadow/enforce modes (#93).** `mode: off | shadow | enforce`
+  replaces the all-or-nothing boolean, with a per-intent `auto_capture_mode` so
+  the gate can be enforced on passive auto-captures while interactive writes stay
+  in shadow. `shadow` records decisions without rejecting anything, which is what
+  makes the thresholds tunable against a real corpus. Backward compatible:
+  defaults to `off` and falls back to the legacy `enabled` bool, so behaviour is
+  unchanged until opted into. Adds `gate_decision` telemetry.
+- **Machine-noise denylist (#94).** Empirically derived from real false-accepts
+  (180× `Session activity:`, 30× `<summary>`, …) — session notifications and shell
+  output are never knowledge.
+- **BGE-M3 embedding provider (#91).** HTTP provider for a self-hosted BGE-M3
+  service (1024D, L2-normalised), with a zero-vector guard: on failure it raises
+  rather than returning a fabricated `[0.0] * dim`, which would poison top-k KNN
+  silently. Reads `SURREAL_MEMORY_EMBEDDING_ENDPOINT` (with
+  `SURREAL_MEMORY_EMBEDDING_BASE_URL` kept as a fallback — #98).
+- **Reranker Bearer auth (#92).** `HttpReranker` sends `Authorization` when a key
+  is configured and accepts both `relevance_score` and `score` response fields.
+  An empty key sends no header, so llamastash and llama.cpp are unaffected.
+
+### Changed
+
+- **Lint is pinned (#96).** `ruff` was installed unpinned in CI, making Lint a
+  moving target: 0.16.0 started reporting `RUF100`/`RUF036` on untouched files and
+  turned `main` and every open PR red on the same day. Now `ruff==0.16.0` in both
+  jobs.
+- **mypy: ignore missing `sentence_transformers` stubs (#95).**
+
 ## [2.13.0] — Full-corpus reasoning mining: deep discovery, per-model targets, live progress
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -280,11 +280,16 @@ blend_weight = 0.7
 
 - **HTTP mode** (`endpoint` set) — runs on a shared inference server (e.g. llama.cpp /
   llamastash on GPU), no `torch` dependency needed locally. Falls back to the
-  `SURREAL_MEMORY_RERANKER_ENDPOINT` env var when `endpoint` is unset.
+  `SURREAL_MEMORY_RERANKER_ENDPOINT` env var when `endpoint` is unset. For endpoints
+  that require auth, set `SURREAL_MEMORY_RERANKER_API_KEY` and requests carry a
+  `Bearer` header (an empty key sends none, so llamastash needs no extra config).
 - **In-process mode** (no endpoint) — loads a local `sentence-transformers` `CrossEncoder`.
   Install with `pip install "surreal-memory[reranker]"`.
-- Reranking never breaks recall — any error falls back to the spreading-activation
-  ordering unchanged.
+- Reranking never breaks recall, but it never fails *quietly* either. A failed rerank
+  is retried once; if it still cannot run, recall returns the spreading-activation
+  ordering **and says so** — `rerank_degraded` in the MCP response,
+  `rerank_degraded_warning` in the CLI. Un-reranked results look exactly like
+  reranked ones, so a silent fallback would hide a real drop in precision.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.13.0"
+version = "2.14.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.13.0"
+__version__ = "2.14.0"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/cli/commands/brain.py
+++ b/src/surreal_memory/cli/commands/brain.py
@@ -85,7 +85,7 @@ def brain_use(
         raise typer.Exit(1)
 
     # Warn if env var is set — this CLI switch won't affect env-pinned processes
-    env_brain = os.environ.get("SURREAL_MEMORY_BRAIN") or os.environ.get("SURREAL_MEMORY_BRAIN")
+    env_brain = os.environ.get("SURREAL_MEMORY_BRAIN")
     if env_brain:
         typer.secho(
             f"Note: SURREAL_MEMORY_BRAIN env var is set to '{env_brain}'. "

--- a/src/surreal_memory/engine/embedding/bge_m3_embedding.py
+++ b/src/surreal_memory/engine/embedding/bge_m3_embedding.py
@@ -51,7 +51,21 @@ class BGEM3Embedding(EmbeddingProvider):
         api_key_env: str = "BGE_M3_API_KEY",
     ) -> None:
         self._model = model
-        self._base_url = (base_url or os.getenv(base_url_env) or _DEFAULT_BASE_URL).rstrip("/")
+        # Endpoint resolution order: explicit arg > SURREAL_MEMORY_EMBEDDING_ENDPOINT
+        # > SURREAL_MEMORY_EMBEDDING_BASE_URL > default.
+        #
+        # ENDPOINT is the name the rest of the codebase already uses (the
+        # OpenAI-compatible provider, the Stop hook, the reasoning distiller), so it
+        # wins here too: two similarly-named variables for "where the embedding
+        # service lives" is a setup where someone sets the wrong one and gets a
+        # silent fallback to the default URL instead of an error. BASE_URL stays
+        # supported so anyone who configured this provider earlier keeps working.
+        self._base_url = (
+            base_url
+            or os.getenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT")
+            or os.getenv(base_url_env)
+            or _DEFAULT_BASE_URL
+        ).rstrip("/")
         self._api_key = (
             api_key or os.getenv(api_key_env) or os.getenv("SURREAL_MEMORY_EMBEDDING_API_KEY")
         )

--- a/src/surreal_memory/server/routes/brain.py
+++ b/src/surreal_memory/server/routes/brain.py
@@ -49,11 +49,19 @@ async def create_brain(
             max_context_tokens=request.config.max_context_tokens,
         )
 
+    # brain_id == name, deliberately. Rows are scoped by the brain *name*
+    # (`brain_id = "default"`), but `Brain.create()` defaults to a random uuid4 — so
+    # a brain created through this endpoint used to be born with an id that did not
+    # match its own row scope. Every call site reaching for `brain.id` then
+    # addressed an empty scope: stats and health reported an empty brain, and
+    # reasoning mining wrote neurons into a brain that recall never reads (#97).
+    # Fixing those call sites treated the symptom; this closes the source.
     brain = Brain.create(
         name=request.name,
         config=config,
         owner_id=request.owner_id,
         is_public=request.is_public,
+        brain_id=request.name,
     )
 
     await storage.save_brain(brain)

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -2388,7 +2388,7 @@ async def get_shared_storage(brain_name: str | None = None) -> NeuralStorage:
     # env var. Mutating the shared config object would cause cross-brain
     # contamination if the config singleton is ever shared.
     if brain_name is None:
-        env_brain = os.environ.get("SURREAL_MEMORY_BRAIN") or os.environ.get("SURREAL_MEMORY_BRAIN")
+        env_brain = os.environ.get("SURREAL_MEMORY_BRAIN")
         if env_brain:
             name = env_brain
         else:

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.13.0"
+        assert surreal_memory.__version__ == "2.14.0"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_quality_scorer.py
+++ b/tests/unit/test_quality_scorer.py
@@ -4,7 +4,57 @@ from __future__ import annotations
 
 import pytest
 
-from surreal_memory.engine.quality_scorer import QualityResult, score_memory
+from surreal_memory.engine.quality_scorer import QualityResult, _is_machine_noise, score_memory
+
+
+class TestIsMachineNoise:
+    """Pins the machine-noise denylist added in #94.
+
+    A denylist rots silently: widening ``_NOISE_TAG_RE`` can start swallowing real
+    memories with nothing failing, and narrowing it lets the junk back in. Both
+    directions are pinned, per signal.
+    """
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "Session activity: Zrobione. Zweryfikowane...",  # 180 real false-accepts
+            "session activity: lowercased variant",  # prefix match is case-insensitive
+            "<task-notification>build finished</task-notification>",
+            "ps -o pid,cmd -p 1234",
+            "echo hello",
+            "curl -s http://127.0.0.1:8001/health",
+        ],
+    )
+    def test_rejects_machine_output(self, content: str) -> None:
+        assert _is_machine_noise(content) is True
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "<summary>tool output</summary>",
+            "<status>running</status>",
+            "<system-reminder>ambient context</system-reminder>",
+            'Background command "pytest" completed',
+        ],
+    )
+    def test_rejects_structural_tags(self, content: str) -> None:
+        assert _is_machine_noise(content) is True
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "Chose SurrealDB over Postgres because the graph traversal is native.",
+            "Root cause: the reranker was enabled but unreachable, so recall degraded.",
+            # Mentions a shell command mid-sentence — the prefix rule must not fire.
+            "We debugged it by running curl against the health endpoint.",
+            # Contains the word 'summary' but no structural tag.
+            "The summary of the incident is in the postmortem doc.",
+            "Toni prefers direct answers with no filler.",
+        ],
+    )
+    def test_keeps_real_knowledge(self, content: str) -> None:
+        assert _is_machine_noise(content) is False
 
 
 class TestScoreMemory:

--- a/tests/unit/test_queue_followups.py
+++ b/tests/unit/test_queue_followups.py
@@ -1,0 +1,113 @@
+"""Regressions for the follow-ups collected in #98 after the PR-queue cleanup."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+class TestBrainIdMatchesName:
+    """#98/4 — the source of the brain-scope bug, not just its symptoms.
+
+    Rows are scoped by the brain *name*, but ``Brain.create()`` defaults to a
+    random uuid4. ``POST /brain`` did not pass ``brain_id``, so a brain created
+    through the dashboard or API was born with an id that did not match its own
+    row scope — and the next call site reaching for ``brain.id`` would reintroduce
+    the bug #97 had just fixed at ~10 call sites.
+    """
+
+    def test_create_brain_endpoint_pins_id_to_name(self) -> None:
+        from surreal_memory.server.routes import brain as brain_route
+
+        source = inspect.getsource(brain_route.create_brain)
+        assert "brain_id=request.name" in source, (
+            "POST /brain must pin brain_id to the name; a uuid4 id does not match "
+            "the row scope and silently re-opens the #97 class of bug"
+        )
+
+    def test_brain_create_still_defaults_to_uuid(self) -> None:
+        """The default is fine — callers that own a scope must be explicit."""
+        from surreal_memory.core.brain import Brain
+
+        brain = Brain.create(name="scratch")
+        assert brain.id != "scratch"
+
+    def test_explicit_brain_id_wins(self) -> None:
+        from surreal_memory.core.brain import Brain
+
+        brain = Brain.create(name="scratch", brain_id="scratch")
+        assert brain.id == brain.name == "scratch"
+
+
+class TestSingleEnvLookup:
+    """#98/1 — ``os.environ.get(X) or os.environ.get(X)`` read the same key twice.
+
+    Functionally a no-op, so nothing was broken; it reads as if a second variable
+    name was intended and got lost, which is exactly the kind of line that
+    survives review indefinitely.
+    """
+
+    @pytest.mark.parametrize(
+        "module_path",
+        [
+            "surreal_memory/cli/commands/brain.py",
+            "surreal_memory/unified_config.py",
+        ],
+    )
+    def test_no_duplicated_env_lookup(self, module_path: str) -> None:
+        import surreal_memory
+
+        root = Path(surreal_memory.__file__).resolve().parent.parent
+        source = (root / module_path).read_text(encoding="utf-8")
+        duplicated = (
+            'os.environ.get("SURREAL_MEMORY_BRAIN") or os.environ.get("SURREAL_MEMORY_BRAIN")'
+        )
+        assert duplicated not in source, f"{module_path} still reads the same env key twice"
+
+
+class TestBgeM3EndpointResolution:
+    """#98/3 — two similarly-named env vars for "where the embedding service lives".
+
+    The rest of the codebase reads ``SURREAL_MEMORY_EMBEDDING_ENDPOINT``; the
+    BGE-M3 provider introduced ``SURREAL_MEMORY_EMBEDDING_BASE_URL``. Setting the
+    wrong one yielded a silent fallback to a default URL rather than an error.
+    """
+
+    @staticmethod
+    def _build(monkeypatch: Any, **env: str) -> Any:
+        from surreal_memory.engine.embedding.bge_m3_embedding import BGEM3Embedding
+
+        for key in (
+            "SURREAL_MEMORY_EMBEDDING_ENDPOINT",
+            "SURREAL_MEMORY_EMBEDDING_BASE_URL",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        return BGEM3Embedding(api_key="test-key")
+
+    def test_endpoint_is_honoured(self, monkeypatch: Any) -> None:
+        provider = self._build(
+            monkeypatch, SURREAL_MEMORY_EMBEDDING_ENDPOINT="http://127.0.0.1:9999"
+        )
+        assert provider._base_url == "http://127.0.0.1:9999"
+
+    def test_base_url_still_works(self, monkeypatch: Any) -> None:
+        """Anyone who configured this provider before the change keeps working."""
+        provider = self._build(
+            monkeypatch, SURREAL_MEMORY_EMBEDDING_BASE_URL="http://127.0.0.1:8888"
+        )
+        assert provider._base_url == "http://127.0.0.1:8888"
+
+    def test_endpoint_wins_over_base_url(self, monkeypatch: Any) -> None:
+        provider = self._build(
+            monkeypatch,
+            SURREAL_MEMORY_EMBEDDING_ENDPOINT="http://127.0.0.1:9999",
+            SURREAL_MEMORY_EMBEDDING_BASE_URL="http://127.0.0.1:8888",
+        )
+        assert provider._base_url == "http://127.0.0.1:9999", (
+            "ENDPOINT is the name the rest of the codebase uses and must take priority"
+        )

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
Closes #98.

Every merged PR in yesterday's queue cleanup was sound; these are the loose ends each one left. Plus the 2.14.0 release prep.

## 1. `brain_id == name` at the source (#98/4)

`Brain.create()` defaults to `brain_id or str(uuid4())`, and `POST /brain` did not pass `brain_id` — so a brain created through the dashboard or API was born with an id that does not match its own row scope (rows are keyed by brain *name*).

#97 fixed ~10 call sites that reached for `brain.id`. That treated the symptom: the next call site to reach for it reintroduces the bug. This pins the id at creation, so the divergence stops being possible for new brains.

Existing brains are untouched — changing their ids is a data migration, deliberately out of scope. The changelog carries the remapping note.

## 2. One env lookup, not two (#98/1)

```python
env_brain = os.environ.get("SURREAL_MEMORY_BRAIN") or os.environ.get("SURREAL_MEMORY_BRAIN")
```

Survived #90 in `cli/commands/brain.py` and `unified_config.py`. `X or X` is `X`, so nothing was broken — but it reads as if a second variable name was intended and lost, which is why it survived review this long. Pinned by a test so it cannot come back.

## 3. One env var for the embedding endpoint (#98/3)

#91 introduced `SURREAL_MEMORY_EMBEDDING_BASE_URL`; the OpenAI-compatible provider, the Stop hook and the reasoning distiller all read `SURREAL_MEMORY_EMBEDDING_ENDPOINT`. Setting the wrong one produced a silent fallback to a default URL instead of an error — a poor failure mode for "the service is not where you think it is".

ENDPOINT now takes priority; BASE_URL stays supported so anyone who already configured the provider keeps working.

## 4. The denylist is pinned (#98/2)

`_is_machine_noise` (#94) was pure regex with no test. A denylist rots in both directions — widening `_NOISE_TAG_RE` starts swallowing real memories with nothing failing; narrowing it lets the junk back in. 15 cases now pin both, per signal.

## 5. Release 2.14.0

Version bumped in all three places (`pyproject.toml`, `__init__.py`, `vscode-extension/package.json`). CHANGELOG gains a full 2.14.0 section covering the twelve PRs since v2.13.0, led by an **upgrade note**: once #63 brain-scopes every by-id fetch, rows sitting in a UUID scope become unreadable by *any* path, where previously a by-id fetch still returned them. That is a data step, not a code step.

README: the Reranking section claimed *"any error falls back to the spreading-activation ordering unchanged"*, which stopped being true with #97 — recall now reports the degradation. Bearer auth from #92 documented alongside it.

## Test plan

- [x] `pytest tests/unit` — 6586 passed, 48 skipped
- [x] New: `tests/unit/test_queue_followups.py` (9 cases) and `TestIsMachineNoise` in `test_quality_scorer.py` (15 cases)
- [x] `ruff check` / `ruff format --check` clean
- [x] `TestVersionBump` updated to 2.14.0 — it pins the version deliberately, so it fails on every bump until the release is intentional
