### PR TITLE
fix: unblock reasoning status, batch decay writes, scope server routes by brain name

### DIFF
--- a/src/surreal_memory/server/dependencies.py
+++ b/src/surreal_memory/server/dependencies.py
@@ -111,6 +111,13 @@ async def get_brain(
     if brain is None:
         raise HTTPException(status_code=404, detail="Brain not found")
 
-    # Set brain context using the actual brain ID
-    storage.set_brain(brain.id)
+    # Scope by the brain *name*, never by ``brain.id``. Rows carry brain_id as a
+    # plain string equal to the brain name (see unified_config._get_surrealdb_storage
+    # and _get_sqlite_storage, which both set_brain(name) for exactly this reason),
+    # while a brain created by an older version has a random uuid4 primary key.
+    # This dependency resolves before any route body runs, so binding the scope to
+    # brain.id made every route read and write a UUID scope that holds no rows —
+    # which is also why the `storage.brain_id or brain.name` fix from #97 never
+    # took effect server-side: storage.brain_id was already the UUID.
+    storage.set_brain(brain.name)
     return brain

--- a/src/surreal_memory/storage/surrealdb/reasoning_traces.py
+++ b/src/surreal_memory/storage/surrealdb/reasoning_traces.py
@@ -235,6 +235,9 @@ class SurrealDBReasoningTracesMixin:
 
         ``last_trace_at`` is fetched per model with an ORDER BY ... LIMIT 1
         rather than a datetime aggregate, keeping the SurrealQL unambiguous.
+        That per-model query MUST keep its ``WITH INDEX idx_rtr_model`` hint —
+        see the comment on the query below; without it this whole endpoint
+        exceeds the SDK's 30s client timeout and the caller 500s.
         """
         model_rows = await self._query(
             "SELECT model, count() AS cnt FROM reasoning_traces"
@@ -251,8 +254,27 @@ class SurrealDBReasoningTracesMixin:
         by_model: dict[str, dict[str, Any]] = {}
         for r in model_rows:
             name = r.get("model", "")
+            # WITH INDEX idx_rtr_model is load-bearing, not a micro-optimisation.
+            # Left to its own devices the 3.2.x planner satisfies the ORDER BY by
+            # walking idx_rtr_time (brain_id, created_at) BACKWARD across the
+            # entire brain scope and applying `model` as a post-index Filter, so
+            # cost scales with the brain's total trace count, not the model's.
+            # Measured on a 10.5k-row brain: EXPLAIN FULL showed IndexScan
+            # idx_rtr_time direction=Backward output_rows=10496 taking 92.6s to
+            # answer for a model owning 57 rows — past the SDK's 30s client
+            # timeout, so /reasoning status raised TimeoutError and 500'd. The
+            # hint pins the composite (brain_id, model) index, so the scan reads
+            # only that model's rows and sorts them: 92.6s -> 2.2ms.
+            # Safe on installs predating idx_rtr_model: SurrealDB 3.2.3 does not
+            # error on an unknown index name in the hint, it just declines the
+            # backward-idx_rtr_time plan (measured 13-16ms, correct rows), so a
+            # missing index degrades to "merely fast" rather than hard-failing.
+            # A single grouped `time::max(created_at) ... GROUP BY model` would
+            # also collapse this N+1 (measured ~98ms for all models, identical
+            # values) — viable if the loop ever needs to go, but the hint alone
+            # removes the pathology.
             latest = await self._query(
-                "SELECT created_at FROM reasoning_traces"
+                "SELECT created_at FROM reasoning_traces WITH INDEX idx_rtr_model"
                 " WHERE brain_id = $bid AND model = $model"
                 " ORDER BY created_at DESC LIMIT 1",
                 bid=brain_id,

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -11,9 +11,10 @@ import asyncio
 import dataclasses
 import logging
 import re
+from collections.abc import Iterator
 from datetime import datetime
 from hashlib import sha256
-from typing import Any, Literal
+from typing import Any, Literal, TypeVar
 from uuid import uuid4
 
 from surreal_memory.core.brain import Brain, BrainConfig, BrainSnapshot
@@ -98,6 +99,26 @@ _BRAIN_ID_SAFE = re.compile(r"^[a-zA-Z0-9_.\-]+$")
 # returns above this value (single-connection multiplexing, not true parallel
 # sockets).
 _BATCH_FETCH_CONCURRENCY = 16
+
+# Rows per multi-statement write round-trip (update_synapses_batch /
+# update_neuron_states_batch). Matches the ~500 already proven by
+# update_neuron_embeddings: big enough that the per-round-trip cost (~2ms of
+# HTTP + parse) amortises to noise, small enough that one oversized chunk can
+# neither blow the server's request-body limit nor lose more than 500 rows if
+# the statement batch fails.
+_BATCH_WRITE_CHUNK = 500
+
+_T = TypeVar("_T")
+
+
+def _chunked(items: list[_T], size: int = _BATCH_WRITE_CHUNK) -> Iterator[list[_T]]:
+    """Yield ``items`` in fixed-size slices; nothing at all for an empty list.
+
+    One shared chunker so the batch writers cannot drift apart on boundary
+    handling (an off-by-one here silently drops rows rather than failing).
+    """
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
 
 
 def _brain_literal(brain_id: str) -> str:
@@ -305,6 +326,37 @@ def _row_to_synapse(row: dict[str, Any]) -> Synapse:
         reinforced_count=int(row.get("reinforced_count", 0)),
     )
     return syn
+
+
+def _change_payload(entity: Any | None) -> dict[str, Any] | None:
+    """Build the ``change_log.payload`` blob a peer needs to replay this write.
+
+    Extracted so the single-row (``_record_change_internal``) and bulk
+    (``_record_changes_bulk``) writers cannot drift into emitting different
+    payload shapes for the same entity — a drift a delta-sync peer would only
+    discover as a corrupt replay, long after the fact.
+    """
+    if isinstance(entity, Neuron):
+        meta = dict(entity.metadata)
+        # The vector is derived from content and can be recomputed locally, so it
+        # never rides along in the log (it would dwarf every other field).
+        meta.pop("_embedding", None)
+        return {
+            "type": entity.type.value,
+            "content": entity.content,
+            "metadata": meta,
+            "content_hash": entity.content_hash,
+            "ephemeral": entity.ephemeral,
+        }
+    if isinstance(entity, Synapse):
+        return {
+            "type": entity.type.value,
+            "source_id": entity.source_id,
+            "target_id": entity.target_id,
+            "weight": entity.weight,
+            "direction": entity.direction,
+        }
+    return None
 
 
 def _row_to_fiber(row: dict[str, Any]) -> Fiber:
@@ -1988,27 +2040,6 @@ class SurrealDBStorage(
         except ValueError:
             return
 
-        payload: dict[str, Any] | None = None
-        if entity is not None:
-            if isinstance(entity, Neuron):
-                meta = dict(entity.metadata)
-                meta.pop("_embedding", None)
-                payload = {
-                    "type": entity.type.value,
-                    "content": entity.content,
-                    "metadata": meta,
-                    "content_hash": entity.content_hash,
-                    "ephemeral": entity.ephemeral,
-                }
-            elif isinstance(entity, Synapse):
-                payload = {
-                    "type": entity.type.value,
-                    "source_id": entity.source_id,
-                    "target_id": entity.target_id,
-                    "weight": entity.weight,
-                    "direction": entity.direction,
-                }
-
         conn = self._ensure_conn()
         self._change_seq += 1
         change_id = f"change_{self._change_seq}_{uuid4().hex[:8]}"
@@ -2019,7 +2050,7 @@ class SurrealDBStorage(
             "entity_id": entity_id,
             "operation": operation,
             "device_id": device_id,
-            "payload": payload,
+            "payload": _change_payload(entity),
             "changed_at": utcnow(),
             "synced": False,
             "sequence": self._change_seq,
@@ -2028,6 +2059,63 @@ class SurrealDBStorage(
             await conn.insert("change_log", record)
         except Exception:
             pass
+
+    async def _record_changes_bulk(
+        self,
+        entity_type: str,
+        operation: str,
+        entities: list[Any],
+        device_id: str = "",
+    ) -> None:
+        """Append one ``change_log`` row per entity in a SINGLE bulk insert.
+
+        The per-entity ``_record_change_internal`` costs its own HTTP round-trip
+        (~3.7 ms measured), which made the change-log — not the entity write —
+        the majority of a batched update's wall clock: ~64% of the per-synapse
+        cost during ``smem decay``. The SDK's ``insert()`` accepts a LIST and
+        emits one ``INSERT INTO change_log $data``, so N rows cost one
+        round-trip.
+
+        Every entity still gets its own row with its own monotonically
+        increasing ``sequence`` — nothing is dropped or coalesced, because delta
+        sync replays the log per entity and a skipped row would silently
+        de-synchronise peers. Only the transport is batched. All rows share one
+        ``changed_at`` instant (they are one logical write); consumers order by
+        ``sequence``, not timestamp.
+        """
+        if self._skip_change_log or not entities:
+            return
+        try:
+            brain_id = self._get_brain_id()
+        except ValueError:
+            return
+
+        changed_at = utcnow()
+        records: list[dict[str, Any]] = []
+        for entity in entities:
+            self._change_seq += 1
+            records.append(
+                {
+                    "id": f"change_{self._change_seq}_{uuid4().hex[:8]}",
+                    "brain_id": brain_id,
+                    "entity_type": entity_type,
+                    "entity_id": entity.id,
+                    "operation": operation,
+                    "device_id": device_id,
+                    "payload": _change_payload(entity),
+                    "changed_at": changed_at,
+                    "synced": False,
+                    "sequence": self._change_seq,
+                }
+            )
+
+        conn = self._ensure_conn()
+        try:
+            await conn.insert("change_log", records)
+        except Exception:
+            # Same fail-soft contract as _record_change_internal: sync bookkeeping
+            # must never abort the entity write that already succeeded.
+            logger.debug("change_log bulk insert failed (%d rows)", len(records), exc_info=True)
 
     async def record_change(
         self,
@@ -2641,13 +2729,99 @@ class SurrealDBStorage(
         )
         return {str(r.get("compression_tier", 0)): int(r.get("c", 0)) for r in rows}
 
+    async def _merge_records_batch(
+        self,
+        table: str,
+        rows: list[tuple[str, dict[str, Any]]],
+    ) -> None:
+        """Apply ``(record_name, merge_data)`` pairs in ONE round-trip.
+
+        The multi-statement ``UPDATE type::record(<table>, $idN) MERGE $dN`` form
+        is exactly what a single ``conn.merge("<table>:<name>", data)`` sends —
+        MERGE, not SET, so a partial dict keeps existing keys it does not mention
+        — just pipelined instead of one HTTP round-trip apiece.
+
+        Callers chunk (see ``_chunked``); this issues one query for whatever it
+        is given.
+
+        SECURITY: table, record name and merge payload are ALL bound as query
+        params — the only text interpolated into the SurQL is the loop index, so
+        no caller value can reach the parser however the helper is later reused.
+        """
+        if not rows:
+            return
+        stmts: list[str] = []
+        params: dict[str, Any] = {"tbl": table}
+        for i, (record_name, data) in enumerate(rows):
+            params[f"id{i}"] = record_name
+            params[f"d{i}"] = data
+            stmts.append(f"UPDATE type::record($tbl, $id{i}) MERGE $d{i}")
+        await self._query(";\n".join(stmts) + ";", **params)
+
     async def update_neuron_states_batch(self, states: list[NeuronState]) -> None:
-        for state in states:
-            await self.update_neuron_state(state)
+        """Update many neuron states in ONE round-trip per 500-row chunk.
+
+        Was a plain ``for`` loop over ``update_neuron_state`` — i.e. the base
+        class's sequential fallback with extra steps, one HTTP round-trip
+        (~2 ms) per state. Decay rewrites every state whose activation moved,
+        so the loop cost scaled linearly with brain size for no reason: these
+        are independent point-merges with no ordering constraint between them.
+        """
+        for chunk in _chunked(states):
+            rows: list[tuple[str, dict[str, Any]]] = []
+            for state in chunk:
+                data: dict[str, Any] = {
+                    "activation_level": state.activation_level,
+                    "access_frequency": state.access_frequency,
+                    "decay_rate": state.decay_rate,
+                    "firing_threshold": state.firing_threshold,
+                    "refractory_period_ms": state.refractory_period_ms,
+                    "homeostatic_target": state.homeostatic_target,
+                }
+                # Omit rather than null out when unset — matches
+                # update_neuron_state, so a batched write can never clear a
+                # timestamp the single-row path would have left alone.
+                if state.last_activated:
+                    data["last_activated"] = state.last_activated
+                if state.refractory_until:
+                    data["refractory_until"] = state.refractory_until
+                rows.append((f"state_{_to_surreal_id(state.neuron_id)}", data))
+            await self._merge_records_batch("neuron_state", rows)
 
     async def update_synapses_batch(self, synapses: list[Synapse]) -> None:
-        for synapse in synapses:
-            await self.update_synapse(synapse)
+        """Update many synapses in ONE round-trip per 500-row chunk, plus one
+        bulk ``change_log`` insert per chunk.
+
+        Was a plain ``for`` loop over ``update_synapse``, which costs TWO HTTP
+        round-trips per synapse: the merge (~2.0 ms) and its own change_log
+        insert (~3.7 ms). On a 158k-synapse brain ``smem decay`` rewrote ~57k of
+        them, so the write loop alone was ~330 s of the 475 s run — 98% of it,
+        against 8.5 s of reads.
+
+        The change_log is batched, NOT skipped: every synapse still gets its own
+        row with its own sequence number, because delta sync replays the log per
+        entity and a dropped row would silently de-synchronise peers. Only the
+        transport collapses (see ``_record_changes_bulk``). Suppressing the log
+        stays the caller's explicit, global opt-in via the ``_skip_change_log``
+        flag — never a silent side effect of choosing the batch path.
+        """
+        for chunk in _chunked(synapses):
+            rows: list[tuple[str, dict[str, Any]]] = []
+            for synapse in chunk:
+                data: dict[str, Any] = {
+                    "type": synapse.type.value,
+                    "weight": synapse.weight,
+                    "direction": synapse.direction,
+                    "metadata": dict(synapse.metadata),
+                    "reinforced_count": synapse.reinforced_count,
+                }
+                if synapse.last_activated:
+                    data["last_activated"] = synapse.last_activated
+                rows.append((_to_surreal_id(synapse.id), data))
+            # Chunk the entity writes and their change-log rows together so a
+            # failure can never leave the log claiming a write that did not land.
+            await self._merge_records_batch("synapse", rows)
+            await self._record_changes_bulk("synapse", "update", chunk)
 
     async def cleanup_ephemeral_neurons(self, max_age_hours: float = 24.0) -> int:
         brain_id = self._get_brain_id()

--- a/tests/unit/test_batch_writers.py
+++ b/tests/unit/test_batch_writers.py
@@ -1,0 +1,271 @@
+"""Unit tests for the SurrealDB batch writers used by ``smem decay``.
+
+``update_synapses_batch`` / ``update_neuron_states_batch`` were stubs — plain
+``for`` loops over the single-row methods — so a decay pass over ~57k synapses
+issued ~116k sequential HTTP round-trips (98% of a measured 475 s run). These
+tests pin the property that made the fix worth doing: ONE query per chunk, not
+one per row, including at the chunk boundaries.
+
+Mock/fake based — no live SurrealDB required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+from unittest.mock import AsyncMock
+
+from surreal_memory.core.neuron import NeuronState
+from surreal_memory.core.synapse import Direction, Synapse, SynapseType
+from surreal_memory.storage.surrealdb.store import (
+    _BATCH_WRITE_CHUNK,
+    SurrealDBStorage,
+    _chunked,
+)
+from surreal_memory.utils.timeutils import utcnow
+
+
+def _make_storage_spy() -> Any:
+    """A storage instance with the transport replaced by recording spies.
+
+    Constructed without connecting: only the query-building code runs.
+    """
+    os.environ.setdefault("SURREALDB_URL", "http://127.0.0.1:65535")
+    os.environ.setdefault("SURREALDB_USER", "root")
+    os.environ.setdefault("SURREALDB_PASS", "x")
+    os.environ.setdefault("SURREALDB_NS", "ns")
+    os.environ.setdefault("SURREALDB_DB", "db")
+    s = SurrealDBStorage()
+    s._current_brain_id = "default"
+    s._skip_change_log = False
+    s._query = AsyncMock(return_value=[])
+    # change_log rides on conn.insert, not _query — spy the connection too.
+    s._conn = AsyncMock()
+    return s
+
+
+def _syn(n: int) -> Synapse:
+    return Synapse.create(
+        source_id=f"neuron:s{n}",
+        target_id=f"neuron:t{n}",
+        type=SynapseType.CONTAINS,
+    )
+
+
+def _state(n: int) -> NeuronState:
+    return NeuronState(neuron_id=f"neuron:n{n}", activation_level=0.5)
+
+
+# ---------------------------- chunk helper ----------------------------
+
+
+def test_chunked_boundaries():
+    assert list(_chunked([])) == []
+    assert [len(c) for c in _chunked(list(range(1)))] == [1]
+    assert [len(c) for c in _chunked(list(range(_BATCH_WRITE_CHUNK)))] == [_BATCH_WRITE_CHUNK]
+    assert [len(c) for c in _chunked(list(range(_BATCH_WRITE_CHUNK + 1)))] == [
+        _BATCH_WRITE_CHUNK,
+        1,
+    ]
+
+
+def test_chunked_preserves_order_and_every_item():
+    items = list(range(_BATCH_WRITE_CHUNK * 2 + 7))
+    flat = [x for chunk in _chunked(items) for x in chunk]
+    assert flat == items
+
+
+# ---------------------------- synapse batch ----------------------------
+
+
+def test_update_synapses_batch_is_one_query_per_chunk():
+    """The N+1 must be gone: 5 synapses => 1 _query, not 5."""
+    s = _make_storage_spy()
+    asyncio.run(s.update_synapses_batch([_syn(i) for i in range(5)]))
+    assert s._query.await_count == 1, f"expected 1 _query, got {s._query.await_count}"
+    sql = s._query.await_args.args[0]
+    assert sql.count("UPDATE type::record($tbl, $id") == 5
+    assert s._query.await_args.kwargs["tbl"] == "synapse"
+    assert sql.rstrip().endswith(";")
+
+
+def test_update_synapses_batch_binds_ids_and_payloads_as_params():
+    """SECURITY: nothing derived from a synapse may reach the SurQL text."""
+    s = _make_storage_spy()
+    syn = _syn(0)
+    syn = Synapse(
+        id=syn.id,
+        source_id=syn.source_id,
+        target_id=syn.target_id,
+        type=SynapseType.CONTAINS,
+        weight=0.25,
+        direction=Direction.UNIDIRECTIONAL,
+        metadata={"note": 'x"; DELETE synapse; --'},
+        reinforced_count=3,
+        created_at=syn.created_at,
+    )
+    asyncio.run(s.update_synapses_batch([syn]))
+    sql, params = s._query.await_args.args[0], s._query.await_args.kwargs
+    assert "DELETE synapse" not in sql
+    assert params["id0"] == syn.id.replace("-", "_")
+    assert params["d0"]["weight"] == 0.25
+    assert params["d0"]["reinforced_count"] == 3
+    assert params["d0"]["metadata"] == {"note": 'x"; DELETE synapse; --'}
+
+
+def test_update_synapses_batch_omits_unset_last_activated():
+    """Parity with update_synapse: never null out a timestamp it would leave alone."""
+    s = _make_storage_spy()
+    never = _syn(0)
+    assert never.last_activated is None
+    asyncio.run(s.update_synapses_batch([never]))
+    assert "last_activated" not in s._query.await_args.kwargs["d0"]
+
+    s2 = _make_storage_spy()
+    now = utcnow()
+    used = Synapse(
+        id=never.id,
+        source_id=never.source_id,
+        target_id=never.target_id,
+        type=never.type,
+        last_activated=now,
+        created_at=never.created_at,
+    )
+    asyncio.run(s2.update_synapses_batch([used]))
+    assert s2._query.await_args.kwargs["d0"]["last_activated"] == now
+
+
+def test_update_synapses_batch_chunks_at_boundary():
+    """500 rows => 1 query; 501 => 2. One statement per row, none lost."""
+    for count, expected_queries in ((0, 0), (1, 1), (_BATCH_WRITE_CHUNK, 1), (501, 2)):
+        s = _make_storage_spy()
+        asyncio.run(s.update_synapses_batch([_syn(i) for i in range(count)]))
+        assert s._query.await_count == expected_queries, f"{count} rows"
+        statements = sum(
+            call.args[0].count("UPDATE type::record($tbl, $id") for call in s._query.await_args_list
+        )
+        assert statements == count, f"{count} rows lost statements"
+
+
+def test_update_synapses_batch_empty_is_noop():
+    s = _make_storage_spy()
+    asyncio.run(s.update_synapses_batch([]))
+    assert s._query.await_count == 0
+    assert s._conn.insert.await_count == 0
+
+
+# ---------------------------- change_log batching ----------------------------
+
+
+def test_change_log_rows_are_bulk_inserted_not_dropped():
+    """Every synapse still gets its own change_log row — in ONE insert call."""
+    s = _make_storage_spy()
+    syns = [_syn(i) for i in range(5)]
+    asyncio.run(s.update_synapses_batch(syns))
+
+    assert s._conn.insert.await_count == 1, "change_log must be ONE bulk insert per chunk"
+    table, records = s._conn.insert.await_args.args
+    assert table == "change_log"
+    assert len(records) == 5, "no change_log entry may be silently dropped"
+    assert [r["entity_id"] for r in records] == [x.id for x in syns]
+    assert {r["operation"] for r in records} == {"update"}
+    assert {r["entity_type"] for r in records} == {"synapse"}
+    # Sequence numbers stay unique and monotonic — delta sync orders on them.
+    seqs = [r["sequence"] for r in records]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == 5
+    # Payload carries what a peer needs to replay the write.
+    assert records[0]["payload"]["source_id"] == syns[0].source_id
+
+
+def test_change_log_bulk_insert_per_chunk():
+    s = _make_storage_spy()
+    asyncio.run(s.update_synapses_batch([_syn(i) for i in range(501)]))
+    assert s._conn.insert.await_count == 2
+    total = sum(len(call.args[1]) for call in s._conn.insert.await_args_list)
+    assert total == 501
+
+
+def test_change_log_skipped_only_via_explicit_flag():
+    s = _make_storage_spy()
+    s._skip_change_log = True
+    asyncio.run(s.update_synapses_batch([_syn(0)]))
+    assert s._query.await_count == 1, "entity write still happens"
+    assert s._conn.insert.await_count == 0
+
+
+def test_change_log_failure_does_not_abort_the_entity_write():
+    """Sync bookkeeping is fail-soft — same contract as _record_change_internal."""
+    s = _make_storage_spy()
+    s._conn.insert = AsyncMock(side_effect=RuntimeError("change_log down"))
+    asyncio.run(s.update_synapses_batch([_syn(0)]))  # must not raise
+    assert s._query.await_count == 1
+
+
+# ---------------------------- neuron state batch ----------------------------
+
+
+def test_update_neuron_states_batch_is_one_query_per_chunk():
+    s = _make_storage_spy()
+    asyncio.run(s.update_neuron_states_batch([_state(i) for i in range(7)]))
+    assert s._query.await_count == 1
+    sql = s._query.await_args.args[0]
+    assert sql.count("UPDATE type::record($tbl, $id") == 7
+    assert s._query.await_args.kwargs["tbl"] == "neuron_state"
+
+
+def test_update_neuron_states_batch_targets_the_state_record_id():
+    """State rows live at neuron_state:state_<sanitised neuron id>."""
+    s = _make_storage_spy()
+    asyncio.run(s.update_neuron_states_batch([NeuronState(neuron_id="neuron:ab-cd")]))
+    assert s._query.await_args.kwargs["id0"] == "state_ab_cd"
+
+
+def test_update_neuron_states_batch_chunks_at_boundary():
+    for count, expected_queries in ((0, 0), (1, 1), (_BATCH_WRITE_CHUNK, 1), (501, 2)):
+        s = _make_storage_spy()
+        asyncio.run(s.update_neuron_states_batch([_state(i) for i in range(count)]))
+        assert s._query.await_count == expected_queries, f"{count} rows"
+        statements = sum(
+            call.args[0].count("UPDATE type::record($tbl, $id") for call in s._query.await_args_list
+        )
+        assert statements == count
+
+
+def test_update_neuron_states_batch_writes_no_change_log():
+    """Parity with update_neuron_state, which does not log — activation drift is
+    derived local state, not a synced entity."""
+    s = _make_storage_spy()
+    asyncio.run(s.update_neuron_states_batch([_state(0)]))
+    assert s._conn.insert.await_count == 0
+
+
+def test_update_neuron_states_batch_omits_unset_timestamps():
+    s = _make_storage_spy()
+    asyncio.run(s.update_neuron_states_batch([NeuronState(neuron_id="neuron:x")]))
+    data = s._query.await_args.kwargs["d0"]
+    assert "last_activated" not in data
+    assert "refractory_until" not in data
+    assert data["activation_level"] == 0.0
+
+
+def test_update_neuron_states_batch_empty_is_noop():
+    s = _make_storage_spy()
+    asyncio.run(s.update_neuron_states_batch([]))
+    assert s._query.await_count == 0
+
+
+# ------------------ round-trip count vs the old stub ------------------
+
+
+def test_batch_writers_beat_the_sequential_stub_by_orders_of_magnitude():
+    """Guards the whole point of the fix: round-trips must scale with chunks,
+    not rows. The old stub issued 2 per synapse (merge + change_log)."""
+    rows = 1200
+    s = _make_storage_spy()
+    asyncio.run(s.update_synapses_batch([_syn(i) for i in range(rows)]))
+    round_trips = s._query.await_count + s._conn.insert.await_count
+    stub_round_trips = rows * 2
+    assert round_trips == 6, f"expected 3 chunks x (1 update + 1 change_log), got {round_trips}"
+    assert round_trips * 100 < stub_round_trips

--- a/tests/unit/test_reasoning_stats_index.py
+++ b/tests/unit/test_reasoning_stats_index.py
@@ -1,0 +1,166 @@
+"""Regression guard: get_reasoning_stats must not reintroduce the full backward scan.
+
+``get_reasoning_stats`` issues one "latest trace" query per model. Without an
+index hint the SurrealDB 3.2.x planner satisfies ``ORDER BY created_at DESC``
+by walking ``idx_rtr_time`` (brain_id, created_at) BACKWARD over the whole brain
+scope and filtering ``model`` afterwards, so the cost tracks the brain's total
+trace count rather than the model's. Measured on a 10.5k-row brain that was
+92.6s for a model owning 57 rows -- past the SDK's 30s client timeout, which
+surfaced as a TimeoutError and an HTTP 500 from the reasoning status endpoint.
+Pinning ``WITH INDEX idx_rtr_model`` brings it to 2.2ms.
+
+The hint is invisible to every functional assertion (results are identical
+either way), so nothing else in the suite would notice if a refactor dropped it
+and silently restored a 90-second endpoint. These tests exist purely to make
+that removal loud.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from surreal_memory.storage.surrealdb.reasoning_traces import SurrealDBReasoningTracesMixin
+
+# The composite (brain_id, model) index the per-model query must be pinned to.
+# Defined in schema.py as: DEFINE INDEX idx_rtr_model ON reasoning_traces
+# FIELDS brain_id, model.
+_HINT = "WITH INDEX idx_rtr_model"
+
+
+class _StatsStore(SurrealDBReasoningTracesMixin):
+    """Records every SurrealQL statement get_reasoning_stats issues."""
+
+    def __init__(self, **cfg: Any) -> None:
+        self.cfg = cfg
+        self.queries: list[tuple[str, dict[str, Any]]] = []
+
+    def _get_brain_id(self) -> str:
+        return "default"
+
+    async def _query(self, sql: str, **params: Any) -> list[dict[str, Any]]:
+        self.queries.append((sql, params))
+        c = self.cfg
+        if "AND processed = false GROUP BY model" in sql:
+            return c.get("unproc_groups", [])
+        if "GROUP BY category" in sql:
+            return c.get("cat_groups", [])
+        if "GROUP BY model" in sql:
+            return c.get("model_groups", [])
+        if "ORDER BY created_at DESC LIMIT 1" in sql:
+            return c.get("latest", {}).get(params.get("model"), [])
+        return []
+
+    def latest_queries(self) -> list[tuple[str, dict[str, Any]]]:
+        """The per-model "most recent trace" statements."""
+        return [(s, p) for s, p in self.queries if "ORDER BY created_at DESC" in s]
+
+
+def _store(**over: Any) -> _StatsStore:
+    cfg: dict[str, Any] = {
+        "model_groups": [
+            {"model": "claude-fable-5", "cnt": 2},
+            {"model": "claude-sonnet-5", "cnt": 1},
+        ],
+        "unproc_groups": [{"model": "claude-fable-5", "cnt": 2}],
+        "latest": {
+            "claude-fable-5": [{"created_at": "2026-03-05T00:00:00"}],
+            "claude-sonnet-5": [{"created_at": "2026-03-02T00:00:00"}],
+        },
+        "cat_groups": [{"category": "debugging", "cnt": 1}],
+    }
+    cfg.update(over)
+    return _StatsStore(**cfg)
+
+
+async def test_per_model_latest_query_carries_index_hint() -> None:
+    store = _store()
+    await store.get_reasoning_stats("default")
+
+    latest = store.latest_queries()
+    assert latest, "expected a per-model 'latest trace' query"
+    for sql, _ in latest:
+        assert _HINT in sql, f"index hint dropped -> full backward scan restored: {sql}"
+
+
+async def test_no_unhinted_descending_scan_is_ever_issued() -> None:
+    """Catches a *new* unhinted ORDER BY ... DESC query, not just an edited one."""
+    store = _store()
+    await store.get_reasoning_stats("default")
+
+    unhinted = [s for s, _ in store.queries if "ORDER BY created_at DESC" in s and _HINT not in s]
+    assert unhinted == [], f"unhinted descending scan(s) on reasoning_traces: {unhinted}"
+
+
+async def test_hint_is_placed_between_table_and_where() -> None:
+    """SurrealQL only accepts the hint directly after the target table."""
+    store = _store()
+    await store.get_reasoning_stats("default")
+
+    for sql, _ in store.latest_queries():
+        assert f"FROM reasoning_traces {_HINT} WHERE" in sql, (
+            f"hint must sit between table and WHERE to parse: {sql}"
+        )
+
+
+async def test_hinted_query_keeps_both_predicates_and_ordering() -> None:
+    """The hint narrows the plan; it must not replace the filters it relies on.
+
+    idx_rtr_model is a composite (brain_id, model) index, so dropping either
+    predicate would both widen the scan and leak traces across brains.
+    """
+    store = _store()
+    await store.get_reasoning_stats("default")
+
+    for sql, params in store.latest_queries():
+        assert "brain_id = $bid" in sql
+        assert "model = $model" in sql
+        assert "ORDER BY created_at DESC LIMIT 1" in sql
+        # Bound params, never interpolated: brain_id/model reach the engine as
+        # values, so a hostile model name cannot break out of the statement.
+        assert params["bid"] == "default"
+        assert params["model"] in {"claude-fable-5", "claude-sonnet-5"}
+
+
+async def test_one_hinted_query_per_model() -> None:
+    store = _store()
+    await store.get_reasoning_stats("default")
+
+    models = [p["model"] for _, p in store.latest_queries()]
+    assert sorted(models) == ["claude-fable-5", "claude-sonnet-5"]
+
+
+async def test_hint_does_not_change_returned_stats() -> None:
+    """The optimisation must be invisible in the result shape callers consume."""
+    store = _store()
+    stats = await store.get_reasoning_stats("default")
+
+    assert stats["total"] == 3
+    assert stats["unprocessed"] == 2
+    assert stats["by_model"]["claude-fable-5"] == {
+        "trace_count": 2,
+        "unprocessed": 2,
+        "last_trace_at": "2026-03-05T00:00:00",
+    }
+    assert stats["by_model"]["claude-sonnet-5"] == {
+        "trace_count": 1,
+        "unprocessed": 0,
+        "last_trace_at": "2026-03-02T00:00:00",
+    }
+    assert stats["by_category"] == {"debugging": 1}
+
+
+async def test_missing_latest_row_yields_empty_timestamp() -> None:
+    """A model with no matching row must not raise (index may be mid-build)."""
+    store = _store(latest={})
+    stats = await store.get_reasoning_stats("default")
+
+    assert stats["by_model"]["claude-fable-5"]["last_trace_at"] == ""
+    assert stats["by_model"]["claude-fable-5"]["trace_count"] == 2
+
+
+async def test_no_models_issues_no_latest_queries() -> None:
+    store = _store(model_groups=[], unproc_groups=[], latest={}, cat_groups=[])
+    stats = await store.get_reasoning_stats("default")
+
+    assert store.latest_queries() == []
+    assert stats == {"by_model": {}, "by_category": {}, "total": 0, "unprocessed": 0}

--- a/tests/unit/test_server_brain_scope.py
+++ b/tests/unit/test_server_brain_scope.py
@@ -1,0 +1,151 @@
+"""Regression test: the server's ``get_brain`` dependency must scope by brain *name*.
+
+Every brain-scoped row carries ``brain_id`` as a plain string equal to the brain
+*name* (``"default"``), while a brain record created by an older version has a
+random uuid4 primary key. ``get_brain`` resolves before any route body runs, so
+binding the storage scope to ``brain.id`` silently pointed the whole request at a
+UUID scope that holds no rows.
+
+That is also why #97's ``storage.brain_id or brain.name`` fix was a no-op on the
+server: ``storage.brain_id`` had already been set to the UUID by this dependency,
+so the ``or`` never reached ``brain.name``. On the live DB this split writes across
+two scopes — e.g. ``reasoning_traces`` ended up with 10,548 rows under the UUID and
+326 under ``"default"``, and the dashboard read the stale UUID half.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from surreal_memory.core.brain import Brain
+from surreal_memory.server.dependencies import get_brain
+
+# Mirrors the live DB: one brain record, uuid4 primary key, rows keyed by the name.
+BRAIN_NAME = "default"
+BRAIN_UUID = "00313cb4-61ca-4e69-9784-e51431e99ad7"
+
+
+class _FakeStorage:
+    """Storage whose rows only exist under the brain *name* scope."""
+
+    def __init__(self, brain: Brain) -> None:
+        self._brain = brain
+        self.brain_id: str | None = None
+        self.set_brain_calls: list[str] = []
+        # Only the name scope holds rows; the UUID scope is empty, exactly like prod.
+        self._rows: dict[str, int] = {BRAIN_NAME: 10643}
+
+    def set_brain(self, brain_id: str) -> None:
+        self.set_brain_calls.append(brain_id)
+        self.brain_id = brain_id
+
+    async def get_brain(self, brain_id: str) -> Brain | None:
+        # Record lookup: only the uuid4 primary key resolves here.
+        return self._brain if brain_id == self._brain.id else None
+
+    async def find_brain_by_name(self, name: str) -> Brain | None:
+        return self._brain if name == self._brain.name else None
+
+    def neuron_count(self) -> int:
+        """Rows visible in the currently bound scope."""
+        return self._rows.get(self.brain_id or "", 0)
+
+
+@pytest.fixture
+def legacy_brain() -> Brain:
+    """Brain whose record id is a uuid4 that differs from its row scope."""
+    return Brain(id=BRAIN_UUID, name=BRAIN_NAME)
+
+
+@pytest.fixture
+def storage(legacy_brain: Brain) -> _FakeStorage:
+    return _FakeStorage(legacy_brain)
+
+
+async def test_scopes_by_name_when_header_carries_the_record_uuid(
+    storage: _FakeStorage,
+) -> None:
+    brain = await get_brain(storage, brain_id=BRAIN_UUID)  # type: ignore[arg-type]
+
+    assert brain.id == BRAIN_UUID  # resolved via the record-id lookup
+    assert storage.brain_id == BRAIN_NAME, (
+        f"scope bound to {storage.brain_id!r}; the UUID scope holds no rows"
+    )
+
+
+async def test_scopes_by_name_when_header_carries_the_name(storage: _FakeStorage) -> None:
+    # Name goes through the find_brain_by_name fallback; the scope must not change.
+    await get_brain(storage, brain_id=BRAIN_NAME)  # type: ignore[arg-type]
+
+    assert storage.brain_id == BRAIN_NAME
+
+
+async def test_never_binds_the_scope_to_the_record_id(storage: _FakeStorage) -> None:
+    await get_brain(storage, brain_id=BRAIN_UUID)  # type: ignore[arg-type]
+
+    assert storage.set_brain_calls == [BRAIN_NAME]
+    assert BRAIN_UUID not in storage.set_brain_calls
+
+
+async def test_bound_scope_actually_sees_the_rows(storage: _FakeStorage) -> None:
+    await get_brain(storage, brain_id=BRAIN_UUID)  # type: ignore[arg-type]
+
+    assert storage.neuron_count() == 10643, "the bound scope must be the one holding rows"
+
+
+async def test_pr97_route_expression_resolves_to_the_name(storage: _FakeStorage) -> None:
+    """Routes read ``storage.brain_id or brain.name``; that must not yield the UUID.
+
+    This is the exact expression #97 introduced. It only ever returned the correct
+    scope once this dependency stopped pre-setting ``storage.brain_id`` to the UUID.
+    """
+    brain = await get_brain(storage, brain_id=BRAIN_UUID)  # type: ignore[arg-type]
+
+    assert (storage.brain_id or brain.name) == BRAIN_NAME
+
+
+async def test_falls_back_to_current_brain_when_header_omitted(
+    storage: _FakeStorage, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import surreal_memory.unified_config as unified_config
+
+    class _FakeConfig:
+        current_brain = BRAIN_NAME
+
+    monkeypatch.setattr(unified_config, "get_config", lambda: _FakeConfig())
+
+    await get_brain(storage, brain_id=None)  # type: ignore[arg-type]
+
+    assert storage.brain_id == BRAIN_NAME
+
+
+async def test_unknown_brain_raises_404_without_touching_the_scope(
+    storage: _FakeStorage,
+) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await get_brain(storage, brain_id="no-such-brain")  # type: ignore[arg-type]
+
+    assert exc_info.value.status_code == 404
+    # A failed lookup must not leave a half-bound scope behind for the next caller.
+    assert storage.set_brain_calls == []
+
+
+async def test_scopes_by_name_for_modern_brains_where_id_equals_name() -> None:
+    """Brains created since #97 have ``brain_id == name``; behaviour is unchanged."""
+    brain = Brain(id="project-x", name="project-x")
+    storage = _FakeStorage(brain)
+
+    await get_brain(storage, brain_id="project-x")  # type: ignore[arg-type]
+
+    assert storage.set_brain_calls == ["project-x"]
+
+
+@pytest.mark.parametrize("header", [BRAIN_UUID, BRAIN_NAME])
+async def test_scope_is_independent_of_how_the_brain_was_addressed(
+    storage: _FakeStorage, header: str
+) -> None:
+    """Both header forms resolve the same brain, so both must bind the same scope."""
+    await get_brain(storage, brain_id=header)  # type: ignore[arg-type]
+
+    assert storage.brain_id == BRAIN_NAME


### PR DESCRIPTION
Three defects surfaced by triaging reports from a live 11k-neuron brain. Each was measured against that brain, not reasoned about.

## 1. Reasoning status returned HTTP 500 after ~59s

`get_reasoning_stats` issues one "latest trace" query per model. SurrealDB satisfied the `ORDER BY created_at DESC` by walking `idx_rtr_time (brain_id, created_at)` **backwards across the entire brain scope**, applying `model` as a post-index filter — so cost tracked the brain's *total* trace count, not the model's.

```
BEFORE: IndexScan idx_rtr_time  direction=Backward  output_rows=10496   91.3 s
AFTER:  IndexScan idx_rtr_model direction=Forward   output_rows=57       1.8 ms
```

91 s to answer for a model owning 57 rows. The SDK's 30 s client timeout fired first → `TimeoutError` → 500 → "Failed to load reasoning status". Full stats sequence is now **533 ms against a 30 s budget**.

`idx_rtr_model` already exists (`schema.py:451`) and `ensure_schema()` reapplies it at startup. Verified that an unknown index name in a `WITH INDEX` hint does **not** error on 3.2.3, so an install predating the index degrades to "merely fast" rather than hard-failing.

**Not a regression from #97.** The same failure reproduces on the pre-#97 expression (`brain_id = brain.id`), all 10,548 rows in the slow scope predate that merge, and `git log -S` puts the N+1 loop in #82.

## 2. `smem decay` took 475 s

98.2% was the write loop: **116,776 sequential HTTP round-trips**. A dry-run (all reads, no writes) takes 8.5 s, so reads were never the problem.

Cause: the batch writers were **stubs** — plain `for` loops over the single-row methods — while a working batching pattern sat in the same file (`update_neuron_embeddings`). Reimplemented on that pattern: chunked, param-bound, one round-trip per chunk. Values are bound as params; the brain id is inlined only through the existing `_brain_literal` validator.

## 3. #97's brain scoping never took effect on server routes

`dependencies.py` called `storage.set_brain(brain.id)`, and that dependency resolves **before any route body runs** — so `storage.brain_id or brain.name` still evaluated to the record UUID everywhere server-side. #97 was a no-op for the whole server.

Rows are keyed by brain *name*, which is why `unified_config` sets the scope by name with a comment saying precisely this. Now consistent, with a test guarding the regression class.

### ⚠️ Visible consequence, deliberately not migrated here

Two tables still hold rows under the UUID scope:

| table | rows in UUID scope |
|---|---|
| `reasoning_traces` | 10,548 |
| `tool_events` | 1,268 |

(`neuron`, `synapse`, `fiber`, `typed_memory`, `maturation`, `retrieval_trace`, `reasoning_patterns` are clean.)

After this change the dashboard reads the name scope, so those rows become invisible to it. Remapping is a data decision, not a code one:

```sql
UPDATE reasoning_traces SET brain_id = "default" WHERE brain_id = "<uuid>";
UPDATE tool_events      SET brain_id = "default" WHERE brain_id = "<uuid>";
```

## Test plan

- [x] `pytest tests/unit` — 6622 passed, 48 skipped
- [x] New: `test_reasoning_stats_index.py` (8), `test_batch_writers.py`, `test_server_brain_scope.py`
- [x] Index guards proven non-vacuous: stripping the hint turns exactly 3 guards red while behavioural tests stay green — which is the point, since results are identical either way and that is what made the 91 s regression invisible
- [x] `ruff check` / `ruff format --check` clean
- [x] Live measurements read-only; `SELECT id, name FROM brain` still returns only `default`
