### PR TITLE
fix: let memories mature again, and stop the health metrics flattering the graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,79 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.0] — Memories can finally mature, and the health metrics stop flattering the graph
+
+Correctness release, and the most consequential one so far for anyone with a brain more
+than a few weeks old. Two of these defects meant the system reported health it did not
+have while quietly failing to do its central job: consolidating memories.
+
+### ⚠️ Your purity score will drop on upgrade. That is the fix working.
+
+Connectivity previously counted `alias` edges — dedup pointers with weight 0.0 that
+carry no meaning. On a real brain they were **89.4% of all synapses** (137,871 of
+154,252), so the metric measured plumbing, not knowledge. Connectivity now counts
+semantic edges only.
+
+Measured on an 11.4k-neuron brain:
+
+| metric | before | after this release | after optional alias cleanup |
+|---|---|---|---|
+| connectivity | 1.0 (saturated) | **0.085** | 0.085 |
+| diversity | 0.256 | 0.256 | **0.948** |
+| purity | — | **−23 points** | **+14 points** |
+
+Nothing degraded. The old number was a saturated sigmoid reading a graph that was 89%
+bookkeeping. **Stored purity/grade values from before this release are not comparable
+with values after it** — treat the upgrade as a new baseline.
+
+### Fixed
+
+- **Memories never matured (EPISODIC → SEMANTIC promotion was dead).** `Fiber.create`
+  mints a dash-form uuid4, but the storage layer folds ids to underscore form. The
+  `maturation` table stored whichever form the caller happened to pass, so maturation
+  rows and fiber rows never joined. Measured on a live brain: of 1,920 maturation rows,
+  1,277 carried a dash-form id and **not one of them had ever been rehearsed or
+  promoted** — every rehearsed row (77) and every semantic row (9) was underscore-form.
+  `get_maturation` returned `None`, `rehearse()` never ran, and the spacing gate could
+  never be met. Pattern extraction was blind to the same 1,277 fibers. A blanket
+  `except Exception` had been swallowing the resulting write collisions as "Skipping
+  maturation save" for months.
+  Lookups now resolve through the record id — the one identifier that was canonical in
+  both eras — so legacy rows heal on their next write with no migration required.
+  Expect the first consolidation run after upgrading to do noticeably more work: those
+  1,277 fibers become promotable again.
+- **Decay recomputed from creation on every run.** Nothing marked a synapse as already
+  decayed, so each run re-measured from `created_at` and multiplied an already-decayed
+  weight again — quadratic in run count (ten daily runs applied ~55 days of decay, not
+  10). Decay now bills only the interval since the last decay, via the `_last_decayed`
+  bookmark. The exponents telescope, so total decay per day of wall-clock time matches
+  the documented Ebbinghaus curve. **Weights now fade slower than in previous builds** —
+  that is the bug being removed, not a behaviour change.
+  Rows with nothing to bill are skipped entirely, which removes the ~57k pointless
+  rewrites per run.
+- **Dedup re-inserted the same alias edge on every consolidation.** 2,375 distinct pairs
+  had produced 144,565 rows, growing ~40k/day. Alias edges now use a deterministic id
+  per pair, so re-running consolidation is idempotent.
+- **Knowledge surface reported "not generated" depending on your shell's directory.**
+  `$HOME` was being classified as a project root because it contains the global
+  `.surrealmemory/` config dir, so `smem surface generate` and `smem doctor` resolved
+  different paths. Project-level surfaces still work; the home directory no longer
+  masquerades as a project.
+- **Connectivity contradicted itself across the product.** `smem health`,
+  `smem_stats`, the maintenance handler and topology analysis each computed it
+  independently; after excluding structural edges in one place the others would have
+  printed 13.5 where health printed 1.4. All now share one definition.
+- **Warning texts collided units.** "connectivity 1.0 (target 3-8)" pairs a 0-1
+  normalised score with a raw synapses/neuron target, reading as "you are far below
+  target" when the raw ratio was 13.5 — far above. Texts now name their unit and state
+  where the score sits on its own scale.
+
+### Changed
+
+- `LOW_DIVERSITY` no longer fires on brains that use many synapse types. The live brain
+  uses **17** distinct types; the warning claiming "only 1 of 8 used" was reading an
+  empty scope, not the real graph.
+
 ## [2.14.0] — Brain scoping, honest degradation, and consolidation that finishes
 
 Correctness release. The theme is **silent failure**: three of these bugs made the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.14.0"
+version = "2.15.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.14.0"
+__version__ = "2.15.0"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/core/synapse.py
+++ b/src/surreal_memory/core/synapse.py
@@ -122,6 +122,11 @@ INVERSE_TYPES: dict[SynapseType, SynapseType] = {
     # SUPERSEDES and DERIVED_FROM are intentionally unidirectional with no inverse.
 }
 
+# Metadata key carrying the decay bookmark written by ``Synapse.decay`` — see that
+# method for why decay gets its own timestamp instead of reusing ``last_activated``,
+# and why the timestamp lives in ``metadata`` rather than in a dataclass field.
+LAST_DECAYED_KEY = "_last_decayed"
+
 
 @dataclass(frozen=True)
 class Synapse:
@@ -140,8 +145,12 @@ class Synapse:
         direction: Whether connection is uni or bidirectional
         metadata: Additional connection-specific data
         reinforced_count: How many times this connection was reinforced
-        last_activated: When this synapse was last used
+        last_activated: When this synapse was last used (fired/reinforced) —
+            never advanced by decay, see :meth:`decay`
         created_at: When this synapse was created
+
+    See also the ``last_decayed`` / ``decay_reference_time`` properties, which
+    expose when a decay pass last touched this synapse.
     """
 
     id: str
@@ -256,17 +265,40 @@ class Synapse:
             created_at=self.created_at,
         )
 
-    def decay(self, factor: float = 0.95) -> Synapse:
+    def decay(self, factor: float = 0.95, now: datetime | None = None) -> Synapse:
         """
-        Create a new Synapse with decayed weight.
+        Create a new Synapse with decayed weight, bookmarked with the decay time.
+
+        ``last_activated`` keeps its meaning — "when this synapse last fired" — and
+        is deliberately NOT advanced here. It is the field ``time_decay`` ages
+        against, the one consolidation reads as ``days_inactive`` for its prune gate,
+        and the one ``brain_evolution`` counts as recent activity; advancing it would
+        make a decay pass look like usage, freeze all further decay and block pruning
+        for good. So decay records its own bookmark, ``last_decayed``, instead.
+
+        Without that bookmark nothing marked a synapse as already processed, so every
+        run re-derived the elapsed time from ``last_activated`` and re-applied the
+        *whole* elapsed-time decay on top of an already-decayed weight — the same
+        tens of thousands of synapses rewritten each run, compounding
+        ``exp(-rate * total_elapsed)`` instead of ``exp(-rate * elapsed)``. Callers
+        should measure elapsed time from :attr:`decay_reference_time`.
+
+        The bookmark lives in ``metadata`` rather than in a new dataclass field
+        because the SurrealDB ``synapse`` table is SCHEMAFULL: an undeclared field is
+        dropped on write, so a real column needs a coordinated schema migration
+        across every backend before it would persist at all. ``metadata`` is a
+        FLEXIBLE object that already round-trips through all stores and already
+        carries internal ``_``-prefixed keys (``_dedup``, ``_intensity``, ``_dream``).
 
         Args:
             factor: Decay multiplier (0.0 - 1.0)
+            now: Decay timestamp to record (default: utcnow)
 
         Returns:
-            New Synapse with decreased weight
+            New Synapse with decreased weight and a refreshed ``last_decayed``
         """
         factor = max(0.0, min(1.0, factor))
+        now = now or utcnow()
         return Synapse(
             id=self.id,
             source_id=self.source_id,
@@ -274,7 +306,9 @@ class Synapse:
             type=self.type,
             weight=self.weight * factor,
             direction=self.direction,
-            metadata=self.metadata,
+            # New dict: the frozen dataclass must not share (and mutate) the caller's
+            # metadata. ISO string so the value survives JSON columns unchanged.
+            metadata={**self.metadata, LAST_DECAYED_KEY: now.isoformat()},
             reinforced_count=self.reinforced_count,
             last_activated=self.last_activated,
             created_at=self.created_at,
@@ -289,6 +323,10 @@ class Synapse:
         Unreinforced (count=0): ~0.98 at 1d, ~0.50 at 60d, floor 0.30
         Reinforced 5x: half-life 210d, floor 0.55
         Reinforced 10x: half-life 360d, floor 0.80
+
+        Unlike :meth:`decay` this writes no ``last_decayed`` bookmark: it is a
+        read-side staleness estimate (consolidation uses the result to decide what to
+        prune and discards it) rather than a decay pass that persists a new weight.
 
         Args:
             reference_time: Reference time for age calculation (default: now)
@@ -336,6 +374,44 @@ class Synapse:
             last_activated=self.last_activated,
             created_at=self.created_at,
         )
+
+    @property
+    def last_decayed(self) -> datetime | None:
+        """When a decay pass last reduced this weight, or None if never decayed.
+
+        Accepts both shapes the stores hand back: a real datetime (SurrealDB decodes
+        object fields into datetimes) and an ISO string (SQLite stores metadata as
+        JSON). A value that is neither reads as "never decayed" so a corrupt bookmark
+        degrades to the pre-bookmark behaviour instead of raising mid-decay.
+        """
+        raw = self.metadata.get(LAST_DECAYED_KEY)
+        if isinstance(raw, datetime):
+            return ensure_naive_utc(raw)
+        if isinstance(raw, str):
+            try:
+                return ensure_naive_utc(datetime.fromisoformat(raw))
+            except ValueError:
+                return None
+        return None
+
+    @property
+    def decay_reference_time(self) -> datetime:
+        """Time this synapse's decay clock was last reset.
+
+        The newest of creation, last firing and last decay — decay passes should
+        measure elapsed time from here. A synapse reinforced since its last decay
+        must not be charged for the interval it spent being used, and one already
+        decayed must not be charged twice for the same interval.
+
+        Falls back to now (i.e. "nothing to decay yet") for a record missing every
+        timestamp, rather than treating it as infinitely old.
+        """
+        stamps = [
+            ensure_naive_utc(stamp)
+            for stamp in (self.created_at, self.last_activated, self.last_decayed)
+            if stamp is not None
+        ]
+        return max(stamps) if stamps else utcnow()
 
     @property
     def is_bidirectional(self) -> bool:

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -1591,7 +1591,7 @@ class ConsolidationEngine:
         """
         import logging
 
-        from surreal_memory.core.synapse import SynapseType
+        from surreal_memory.engine.dedup.alias_edges import AliasEdgeLedger, ensure_alias_edge
         from surreal_memory.utils.simhash import is_near_duplicate
 
         logger = logging.getLogger(__name__)
@@ -1625,6 +1625,20 @@ class ConsolidationEngine:
         if len(anchors) > max_anchors:
             anchors = anchors[:max_anchors]
 
+        # This pass re-derives the *same* duplicate pairs on every run, so without
+        # a memory of what already exists it re-inserts its whole alias edge set
+        # each time. Preload the alias slice once rather than probing per pair —
+        # 2000 anchors would otherwise turn one write storm into a read storm.
+        ledger: AliasEdgeLedger | None = None
+        if not dry_run:
+            try:
+                ledger = await AliasEdgeLedger.load(self._storage)
+            except Exception:
+                # Per-pair checks are slower but still correct. Treating a failed
+                # preload as "nothing exists" is what re-opens the growth bug, so
+                # never substitute an empty ledger here.
+                logger.debug("Alias edge preload failed; falling back to per-pair checks")
+
         # Group duplicates by SimHash proximity
         seen: set[str] = set()
         for i, anchor_a in enumerate(anchors):
@@ -1649,18 +1663,15 @@ class ConsolidationEngine:
                     if dry_run:
                         continue
 
-                    # Create ALIAS synapse from newer to older (canonical)
-                    alias_synapse = Synapse.create(
-                        source_id=anchor_b.id,
-                        target_id=anchor_a.id,
-                        type=SynapseType.ALIAS,
-                        weight=0.9,
-                        metadata={"_dedup": True},
+                    # ALIAS synapse from newer to older (canonical). The edge id
+                    # is derived from the pair, so a second run re-writes the
+                    # same row instead of adding another one for the same fact.
+                    await ensure_alias_edge(
+                        self._storage,
+                        anchor_b.id,
+                        anchor_a.id,
+                        ledger=ledger,
                     )
-                    try:
-                        await self._storage.add_synapse(alias_synapse)
-                    except ValueError:
-                        logger.debug("ALIAS synapse already exists")
 
     async def _semantic_link(
         self,

--- a/src/surreal_memory/engine/dedup/__init__.py
+++ b/src/surreal_memory/engine/dedup/__init__.py
@@ -6,7 +6,21 @@ Each tier short-circuits on definitive answers.
 OFF by default -- enable via DedupConfig(enabled=True).
 """
 
+from surreal_memory.engine.dedup.alias_edges import (
+    ALIAS_EDGE_WEIGHT,
+    AliasEdgeLedger,
+    alias_edge_id,
+    ensure_alias_edge,
+)
 from surreal_memory.engine.dedup.config import DedupConfig
 from surreal_memory.engine.dedup.pipeline import DedupPipeline, DedupResult
 
-__all__ = ["DedupConfig", "DedupPipeline", "DedupResult"]
+__all__ = [
+    "ALIAS_EDGE_WEIGHT",
+    "AliasEdgeLedger",
+    "DedupConfig",
+    "DedupPipeline",
+    "DedupResult",
+    "alias_edge_id",
+    "ensure_alias_edge",
+]

--- a/src/surreal_memory/engine/dedup/alias_edges.py
+++ b/src/surreal_memory/engine/dedup/alias_edges.py
@@ -1,0 +1,241 @@
+"""Idempotent creation of dedup ALIAS synapses.
+
+An ALIAS edge means "this anchor is a duplicate of that canonical anchor".
+That is a *set membership* fact, so exactly one edge per (source, target)
+pair is meaningful — a second one carries no information.
+
+Both dedup call sites used to express that intent like this::
+
+    try:
+        await storage.add_synapse(alias_synapse)
+    except ValueError:
+        logger.debug("ALIAS synapse already exists")
+
+but the guard never fired. ``Synapse.create()`` mints a fresh UUID on every
+call, so the only uniqueness either backend enforces — the synapse primary
+key — could not collide: SQLite raises solely on PK/FK conflict, and the
+SurrealDB ``INSERT RELATION`` path does not check at all. Neither backend has
+a constraint on ``(source, target, type)``. The consolidation dedup pass
+therefore re-inserted its entire alias edge set on *every* run, unbounded.
+
+Measured on the live 11.5k-neuron brain: 144,565 alias rows backing only
+2,375 distinct pairs — a 61x amplification, still growing by ~40k rows/day,
+and 94% of the rows the prune pass has to load and walk.
+
+This module makes the guard real, in two layers:
+
+1. A pre-insert existence check — cheap and backend-agnostic.
+2. A deterministic edge id derived from the pair, so a concurrent writer that
+   slips past the check still collides on the primary key instead of
+   producing a twin row.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import TYPE_CHECKING
+
+from surreal_memory.core.synapse import Synapse, SynapseType
+
+if TYPE_CHECKING:
+    from surreal_memory.storage.base import NeuralStorage
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "AliasEdgeLedger",
+    "ALIAS_EDGE_WEIGHT",
+    "alias_edge_id",
+    "ensure_alias_edge",
+]
+
+# Both former call sites created ALIAS edges at 0.9; keep that so the change is
+# purely about *how many* rows exist, not how strongly they pull in traversal.
+ALIAS_EDGE_WEIGHT = 0.9
+
+# How many alias rows the ledger is willing to materialise in one response.
+#
+# The dedup pass compares at most 2000 anchors and a healthy brain's alias slice
+# is ~2.4k pairs, so this keeps the whole-slice fast path for every brain that is
+# not already amplified — while refusing to ask a brain that *is* (137,871 rows
+# live) for a response it cannot deliver. An unbounded `get_synapses` is only
+# capped on SQLite (implicit LIMIT 10000); on SurrealDB it streams the entire
+# slice in one HTTP body, which is how the LIFECYCLE pass earned its
+# "[Errno 104] Connection reset by peer" before PR #97 bounded it.
+_LEDGER_SCAN_LIMIT = 5000
+
+
+def alias_edge_id(source_id: str, target_id: str) -> str:
+    """Return the stable synapse id for the alias edge ``source -> target``.
+
+    Neuron ids are UUIDs, so the digest is unique across brains without
+    mixing brain_id in — which keeps the id stable if a neuron is ever
+    transplanted. Truncated to 32 hex chars to match the UUID-shaped ids the
+    rest of the synapse table uses.
+    """
+    digest = hashlib.sha256(f"alias:{source_id}:{target_id}".encode()).hexdigest()
+    return f"alias-{digest[:32]}"
+
+
+class AliasEdgeLedger:
+    """Which (source, target) alias pairs already exist, loaded once.
+
+    The consolidation dedup pass compares up to 2000 anchors pairwise, so a
+    per-pair existence query would trade one write storm for a read storm.
+    Loading the alias slice once and answering from memory keeps the pass at a
+    single extra query.
+
+    That cache is only worth having while the slice fits in one response, so
+    the load is capped. A capped load can prove *presence* (every pair it holds
+    really is in the brain) but not *absence*, hence ``is_complete``:
+    ``ensure_alias_edge`` re-checks unknown pairs one at a time when the ledger
+    is partial. Trusting a truncated ledger would mean re-creating every pair
+    past the cap — the amplification this module exists to stop.
+
+    Also records edges created through it, so repeated ``ensure`` calls for
+    the same pair *within* one run are idempotent too.
+    """
+
+    def __init__(
+        self,
+        pairs: set[tuple[str, str]] | None = None,
+        *,
+        complete: bool = True,
+    ) -> None:
+        self._pairs: set[tuple[str, str]] = set(pairs or ())
+        self._complete = complete
+
+    @classmethod
+    async def load(
+        cls,
+        storage: NeuralStorage,
+        *,
+        limit: int = _LEDGER_SCAN_LIMIT,
+    ) -> AliasEdgeLedger:
+        """Fetch this brain's ALIAS edges, up to ``limit`` rows."""
+        try:
+            existing = await storage.get_synapses(type=SynapseType.ALIAS, limit=limit)
+        except Exception:
+            # A ledger that cannot load must not silently degrade into
+            # "nothing exists" — that is exactly the bug this module fixes.
+            # Signal it so ensure_alias_edge falls back to per-pair queries.
+            logger.debug("AliasEdgeLedger.load failed; falling back to per-pair checks")
+            raise
+        # A full page means there is very likely more behind it; the rows we did
+        # get stay useful as positive hits, but absence is no longer provable.
+        truncated = len(existing) >= limit
+        if truncated:
+            logger.debug(
+                "alias slice exceeds %d rows; ledger is partial, falling back to "
+                "per-pair checks for unknown pairs",
+                limit,
+            )
+        return cls(
+            {(s.source_id, s.target_id) for s in existing},
+            complete=not truncated,
+        )
+
+    @property
+    def is_complete(self) -> bool:
+        """True when a miss in this ledger proves the pair does not exist."""
+        return self._complete
+
+    def __contains__(self, pair: tuple[str, str]) -> bool:
+        return pair in self._pairs
+
+    def __len__(self) -> int:
+        return len(self._pairs)
+
+    def has(self, source_id: str, target_id: str) -> bool:
+        return (source_id, target_id) in self._pairs
+
+    def record(self, source_id: str, target_id: str) -> None:
+        self._pairs.add((source_id, target_id))
+
+
+async def _pair_exists(storage: NeuralStorage, source_id: str, target_id: str) -> bool:
+    """Targeted existence check for a single pair.
+
+    Used by the encode path, which handles one duplicate at a time and would
+    be badly served by loading the whole alias slice, and by the dedup path
+    whenever its ledger came back partial. Matches on the pair rather than on
+    ``alias_edge_id`` because the rows already in the brain predate the
+    deterministic id and carry random UUIDs.
+    """
+    try:
+        hits = await storage.get_synapses(
+            source_id=source_id,
+            target_id=target_id,
+            type=SynapseType.ALIAS,
+            limit=1,
+        )
+    except Exception:
+        # Failing open would resurrect unbounded growth, so fail closed: skip
+        # the write. A missing alias edge is recoverable (the next dedup pass
+        # recreates it); a duplicate row is not — nothing ever removes it.
+        logger.debug("alias edge existence check failed for %s -> %s", source_id, target_id)
+        return True
+    return bool(hits)
+
+
+async def ensure_alias_edge(
+    storage: NeuralStorage,
+    source_id: str,
+    target_id: str,
+    *,
+    weight: float = ALIAS_EDGE_WEIGHT,
+    ledger: AliasEdgeLedger | None = None,
+) -> Synapse | None:
+    """Create the ``source -> target`` ALIAS edge unless it already exists.
+
+    Args:
+        storage: Brain-scoped storage.
+        source_id: Duplicate anchor.
+        target_id: Canonical anchor it aliases.
+        weight: Edge weight (defaults to the historical 0.9).
+        ledger: Preloaded pair set; pass one when calling in a loop. A partial
+            ledger still short-circuits its known pairs, the rest fall back to
+            the targeted per-pair check.
+
+    Returns:
+        The created Synapse, or None when the edge already existed, the pair
+        is degenerate (self-alias), or the write failed.
+    """
+    if not source_id or not target_id:
+        return None
+    if source_id == target_id:
+        # A self-alias is a no-op relationship that PPR would traverse as a
+        # weight-0.9 self-loop, quietly draining push mass from real edges.
+        return None
+
+    if ledger is not None:
+        if ledger.has(source_id, target_id):
+            return None
+        # A partial ledger only knows what it managed to load, so a miss is not
+        # evidence of absence — confirm with the targeted query before writing.
+        if not ledger.is_complete and await _pair_exists(storage, source_id, target_id):
+            return None
+    elif await _pair_exists(storage, source_id, target_id):
+        return None
+
+    synapse = Synapse.create(
+        source_id=source_id,
+        target_id=target_id,
+        type=SynapseType.ALIAS,
+        weight=weight,
+        metadata={"_dedup": True},
+        synapse_id=alias_edge_id(source_id, target_id),
+    )
+    try:
+        await storage.add_synapse(synapse)
+    except Exception:
+        # Deterministic id means a racing writer collides on the primary key
+        # here rather than creating a twin — losing the race is the correct
+        # outcome, not an error.
+        logger.debug("ALIAS synapse %s -> %s already exists", source_id, target_id)
+        return None
+
+    if ledger is not None:
+        ledger.record(source_id, target_id)
+    return synapse

--- a/src/surreal_memory/engine/diagnostics.py
+++ b/src/surreal_memory/engine/diagnostics.py
@@ -137,11 +137,17 @@ def _build_dynamic_action(
     types_used = metrics.get("types_used", 0)
 
     if component == "connectivity" and neuron_count > 0:
-        ratio = synapse_count / max(neuron_count, 1)
-        gap = max(0, int(3.0 * neuron_count) - synapse_count)
+        # Quote the SEMANTIC count: connectivity is scored on that graph only, so
+        # citing the total (alias/audit rows included) would advertise a ratio the
+        # score never saw. Naming both units keeps the 0-1 score from being read
+        # as if it were the synapses/neuron target.
+        semantic_count = int(metrics.get("semantic_synapse_count", synapse_count))
+        ratio = semantic_count / max(neuron_count, 1)
+        gap = max(0, int(3.0 * neuron_count) - semantic_count)
         return (
-            f"Store memories with context to build ~{gap} more connections "
-            f"(current: {ratio:.1f} synapses/neuron, target: 3.0+)."
+            f"Store memories with context to add ~{gap} semantic connections "
+            f"(now {ratio:.1f} semantic synapses/neuron; the 0-1 connectivity score "
+            "reaches 0.5 at 3/neuron and saturates near 1.0 at 8/neuron)."
         )
     elif component == "diversity":
         # Diversity is Shannon entropy over synapse types (distribution balance),
@@ -153,13 +159,15 @@ def _build_dynamic_action(
         if types_used < expected:
             return (
                 f"Use varied memory types — only {types_used} of {expected} common "
-                "synapse types used. Try: 'X caused Y', 'after A then B', "
-                "'X is related to Y'."
+                "synapse types used. The 0-1 diversity score measures how evenly "
+                "that mix is spread, not how many types exist. Try: 'X caused Y', "
+                "'after A then B', 'X is related to Y'."
             )
         return (
             f"Balance your synapse types — {types_used} types are in use but "
-            "unevenly distributed, so a few relations dominate. Vary phrasing: "
-            "'X caused Y', 'after A then B', 'X is related to Y'."
+            "unevenly distributed, so a few relations dominate and the 0-1 "
+            "diversity score stays low. Vary phrasing: 'X caused Y', "
+            "'after A then B', 'X is related to Y'."
         )
     elif component == "freshness":
         fresh_count = int(freshness * max(fiber_count, 1))
@@ -276,6 +284,11 @@ class BrainHealthReport:
     contradiction_count: int = 0
     conflict_rate: float = 0.0
 
+    # Synapses left after dropping structural/dedup buckets — this is the count
+    # `connectivity` is actually scored on, whereas `synapse_count` above is the
+    # raw table total. Kept separate so a dashboard can show both without guessing.
+    semantic_synapse_count: int = 0
+
 
 # ── Grade mapping ────────────────────────────────────────────────
 
@@ -305,6 +318,32 @@ class DiagnosticsEngine:
 
     # Number of defined synapse types (for diversity normalization)
     _TOTAL_SYNAPSE_TYPES = len(SynapseType)
+
+    # Synapse types that are graph plumbing rather than remembered meaning. They are
+    # subtracted before scoring connectivity, so the metric describes the semantic
+    # graph a recall actually traverses:
+    #   alias — dedup pointer (weight 0.0, metadata {"_dedup": true}) written once per
+    #     repeated mention, so it scales with write volume, not with what is known. On
+    #     a real brain 137871 of 154252 synapses were alias rows (89%): they pinned the
+    #     sigmoid at its 1.0 ceiling while the semantic graph held 1.4 edges/neuron —
+    #     the metric was hiding the very weakness it exists to expose.
+    #   stored_by / verified_at / approved_by / source_of — audit and provenance edges
+    #     pointing at an agent, user or source record, not at another memory.
+    # similar_to is deliberately NOT structural. It is embedding-derived rather than
+    # authored, but it joins two content neurons, carries a real weight and is walked
+    # during retrieval; dropping it would understate a graph that genuinely recalls.
+    # in_row / in_column stay for the same reason — table structure links content to
+    # content. The test is "does traversing this edge return meaning?", not "did a
+    # human type it?".
+    _STRUCTURAL_SYNAPSE_TYPES: frozenset[str] = frozenset(
+        {
+            SynapseType.ALIAS.value,
+            SynapseType.STORED_BY.value,
+            SynapseType.VERIFIED_AT.value,
+            SynapseType.APPROVED_BY.value,
+            SynapseType.SOURCE_OF.value,
+        }
+    )
 
     def __init__(self, storage: NeuralStorage) -> None:
         self._storage = storage
@@ -363,7 +402,9 @@ class DiagnosticsEngine:
             _connected_or_none(),
         )
 
-        connectivity = self._compute_connectivity(synapse_count, neuron_count)
+        # Score connectivity on the semantic graph only — see _STRUCTURAL_SYNAPSE_TYPES.
+        semantic_synapse_count = self._count_semantic_synapses(synapse_count, synapse_stats)
+        connectivity = self._compute_connectivity(semantic_synapse_count, neuron_count)
         diversity = self._compute_diversity(synapse_stats)
         freshness = self._compute_freshness(fibers)
         orphan_rate = await self._compute_orphan_rate(neuron_count, fibers, connected=connected)
@@ -398,13 +439,16 @@ class DiagnosticsEngine:
 
         grade = _score_to_grade(purity)
 
-        # Generate warnings and recommendations
-        raw_connectivity = synapse_count / max(neuron_count, 1)
+        # Generate warnings and recommendations. The ratio quoted to the user must be
+        # the one the score was computed from, otherwise the text and the bar disagree.
+        raw_connectivity = semantic_synapse_count / max(neuron_count, 1)
         warnings, recommendations = self._generate_diagnostics(
             neuron_count=neuron_count,
             synapse_count=synapse_count,
             fiber_count=fiber_count,
             raw_connectivity=raw_connectivity,
+            semantic_synapse_count=semantic_synapse_count,
+            connectivity_score=connectivity,
             synapse_stats=synapse_stats,
             orphan_rate=orphan_rate,
             consolidation_ratio=consolidation_ratio,
@@ -427,6 +471,7 @@ class DiagnosticsEngine:
         penalty_metrics = {
             "neuron_count": neuron_count,
             "synapse_count": synapse_count,
+            "semantic_synapse_count": semantic_synapse_count,
             "fiber_count": fiber_count,
             "freshness": freshness,
             "orphan_rate": orphan_rate,
@@ -455,20 +500,43 @@ class DiagnosticsEngine:
             top_penalties=top_penalties,
             contradiction_count=contradicts_count,
             conflict_rate=round(conflict_rate, 4),
+            semantic_synapse_count=semantic_synapse_count,
         )
 
     # ── Metric computations ──────────────────────────────────────
 
-    @staticmethod
-    def _compute_connectivity(synapse_count: int, neuron_count: int) -> float:
-        """Compute connectivity score via sigmoid normalization.
+    @classmethod
+    def _count_semantic_synapses(cls, synapse_count: int, synapse_stats: dict[str, Any]) -> int:
+        """Total synapses minus the structural/dedup buckets.
 
-        Target: 3-8 synapses per neuron is ideal.
-        sigmoid(-1.5 * (x - 3)): at x=0 -> ~0.01, x=3 -> 0.5, x=8 -> ~1.0
+        Falls back to the raw total when a backend reports no by_type breakdown —
+        a possibly-inflated number beats silently claiming zero connectivity.
+        """
+        by_type = synapse_stats.get("by_type", {})
+        if not by_type:
+            return synapse_count
+
+        structural = 0
+        for stype, entry in by_type.items():
+            # Backends key by SynapseType value ("alias"); some fixtures use the
+            # member name ("ALIAS"), so match case-insensitively.
+            if str(stype).lower() in cls._STRUCTURAL_SYNAPSE_TYPES:
+                structural += int(entry["count"] if isinstance(entry, dict) else entry)
+        return max(0, synapse_count - structural)
+
+    @staticmethod
+    def _compute_connectivity(semantic_synapse_count: int, neuron_count: int) -> float:
+        """Normalize semantic synapses/neuron to a saturating 0-1 score.
+
+        Takes the SEMANTIC synapse count (see _count_semantic_synapses), not the
+        table total. sigmoid(-1.5 * (x - 3)) over that ratio: x=0 -> ~0.01,
+        x=3 -> 0.5, x=8 -> ~1.0. Note 1.0 is a CEILING, not a ratio — anything
+        from ~8 semantic synapses/neuron upward reports 1.0, so this score must
+        never be presented against the raw "3-8 per neuron" target.
         """
         if neuron_count == 0:
             return 0.0
-        raw = synapse_count / neuron_count
+        raw = semantic_synapse_count / neuron_count
         return 1.0 / (1.0 + math.exp(-1.5 * (raw - 3.0)))
 
     # Synapse types realistically expected in typical usage.
@@ -607,8 +675,15 @@ class DiagnosticsEngine:
         freshness: float,
         fibers: list[Any],
         contradicts_count: int = 0,
+        semantic_synapse_count: int | None = None,
+        connectivity_score: float | None = None,
     ) -> tuple[list[DiagnosticWarning], list[str]]:
-        """Generate warnings and recommendations from metrics."""
+        """Generate warnings and recommendations from metrics.
+
+        `raw_connectivity` is semantic synapses per neuron; `connectivity_score` is
+        the 0-1 sigmoid of it. Both are accepted so the text can name each number's
+        unit instead of mixing them.
+        """
         warnings: list[DiagnosticWarning] = []
         recommendations: list[str] = []
 
@@ -627,23 +702,44 @@ class DiagnosticsEngine:
                 "to reactivate relevant memories."
             )
 
-        # Low connectivity
+        # Low connectivity. Every number here is in synapses/neuron, the same unit as
+        # the 3-8 target; the 0-1 score rides along in details so a renderer showing
+        # both never implies "score 1.0 is below the 3-8 target".
         if raw_connectivity < 2.0 and neuron_count > 0:
-            gap = max(0, int(3.0 * neuron_count) - synapse_count)
+            semantic_count = (
+                synapse_count if semantic_synapse_count is None else semantic_synapse_count
+            )
+            gap = max(0, int(3.0 * neuron_count) - semantic_count)
+            details: dict[str, Any] = {
+                "semantic_synapses_per_neuron": round(raw_connectivity, 2),
+                "semantic_synapse_count": semantic_count,
+                "structural_synapse_count": max(0, synapse_count - semantic_count),
+            }
+            if connectivity_score is not None:
+                details["connectivity_score"] = round(connectivity_score, 4)
             warnings.append(
                 DiagnosticWarning(
                     severity=WarningSeverity.WARNING,
                     code="LOW_CONNECTIVITY",
-                    message=f"Low connectivity: {raw_connectivity:.1f} synapses/neuron (target: 3-8).",
+                    message=(
+                        f"Low connectivity: {raw_connectivity:.1f} semantic synapses/neuron "
+                        "(healthy: 3-8 per neuron; alias and audit edges excluded)."
+                    ),
+                    details=details,
                 )
             )
             recommendations.append(
-                f"Low connectivity ({raw_connectivity:.1f} synapses/neuron, target: 3+). "
-                f"~{gap} more connections needed. Store memories with context like "
+                f"Low connectivity ({raw_connectivity:.1f} semantic synapses/neuron, "
+                f"healthy 3-8 per neuron). ~{gap} more connections needed — alias and "
+                "audit edges do not count. Store memories with context like "
                 "'X because Y' or 'after doing A, I learned B' to build richer links."
             )
 
-        # Low diversity
+        # Low diversity. Fires on type COVERAGE (fewer than 3 distinct types in the
+        # by_type breakdown), which is a different question from the 0-1 diversity
+        # score — that one is entropy over the same breakdown and can sit low while
+        # many types are in use but one dominates. A brain using 17 types is not
+        # under-covered, so this warning stays silent there by design.
         by_type = synapse_stats.get("by_type", {})
         types_used = len(by_type)
         expected = DiagnosticsEngine._EXPECTED_SYNAPSE_TYPES
@@ -658,7 +754,10 @@ class DiagnosticsEngine:
                 DiagnosticWarning(
                     severity=WarningSeverity.WARNING,
                     code="LOW_DIVERSITY",
-                    message=f"Low synapse diversity: {types_used} of {expected} expected types used.",
+                    message=(
+                        f"Low synapse diversity: {types_used} of {expected} common "
+                        "synapse types in use."
+                    ),
                     details={"types_used": types_used, "types_expected": expected},
                 )
             )

--- a/src/surreal_memory/engine/lifecycle.py
+++ b/src/surreal_memory/engine/lifecycle.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 from surreal_memory.core.neuron import NeuronState
 from surreal_memory.core.synapse import Synapse, SynapseType
-from surreal_memory.utils.timeutils import utcnow
+from surreal_memory.utils.timeutils import ensure_naive_utc, utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -198,18 +198,65 @@ class DecayManager:
             if synapse.source_id in pinned_neuron_ids or synapse.target_id in pinned_neuron_ids:
                 continue
 
-            # Use last_activated if available, otherwise fall back to created_at
+            # Eligibility gate: how long this synapse has been *idle*. Deliberately
+            # still measured from last_activated/created_at rather than from the decay
+            # bookmark below, because the two answer different questions. This one is
+            # "is the memory unused enough to deserve decay at all", and a decay pass is
+            # not usage. Gating on the bookmark instead would reset the clock every run,
+            # so any schedule firing more often than min_age_days would starve the gate
+            # and freeze decay permanently.
             if synapse.last_activated is None:
-                synapse_reference = (
+                idle_since = (
                     synapse.created_at if hasattr(synapse, "created_at") else reference_time
                 )
             else:
-                synapse_reference = synapse.last_activated
+                idle_since = synapse.last_activated
+            idle_since = ensure_naive_utc(idle_since)
 
-            time_diff = reference_time - synapse_reference
-            days_elapsed = time_diff.total_seconds() / 86400
+            idle_days = (reference_time - idle_since).total_seconds() / 86400
 
-            if days_elapsed < self.min_age_days:
+            if idle_days < self.min_age_days:
+                continue
+
+            # Charge only the stretch no earlier run has billed, starting from the decay
+            # bookmark Synapse.decay writes.
+            #
+            # Incremental decay applies the same total decay as one pass from creation,
+            # because the exponents telescope over any partition t0 < t1 < ... < tn:
+            #   multiplying exp(-r * slice) across consecutive slices gives
+            #   exp(-r * total of those slices), i.e. exp(-r * (tn - t0)).
+            # So N runs each charging their own slice land on exactly the weight a single
+            # run over the whole window produces, and how fast a memory fades per day of
+            # wall-clock time is unchanged. (The emotional exponent below is a constant
+            # per synapse, so raising each factor to it preserves the identity.)
+            #
+            # What this is NOT equal to is the code that shipped before the bookmark was
+            # read: with no record of prior runs every pass re-measured from t0 and
+            # multiplied an already-decayed weight again, giving exp(-r * Σ(ti - t0)) —
+            # quadratic in run count, so ten daily runs over ten days applied ~55 days of
+            # decay and rewrote all 57k rows each time. That over-decay is the defect the
+            # bookmark was added to fix, not a semantic worth preserving; neuron decay
+            # above has always been incremental (it stamps last_activated=reference_time
+            # every run). Synapse weights therefore fade slower than the pre-fix build,
+            # onto the Ebbinghaus curve this class documents — deliberate and stated, not
+            # a silent change.
+            #
+            # Fallback: last_decayed is None on every existing row, leaving charge_from
+            # at the `last_activated or created_at` resolved above — first pass on old
+            # data behaves exactly as before, no migration needed. max() rather than the
+            # bookmark alone because a synapse fired since its last decay must not be
+            # charged for the stretch it spent being used. Deliberately not
+            # Synapse.decay_reference_time, whose max() also folds in created_at: on a
+            # record whose last_activated predates its creation (imports, merges) that
+            # would start charging from the newer created_at and fade the row more slowly
+            # than today. Repairing anomalous timestamps is not this fix's job.
+            last_decayed = synapse.last_decayed
+            charge_from = max(idle_since, last_decayed) if last_decayed else idle_since
+            days_elapsed = (reference_time - charge_from).total_seconds() / 86400
+
+            if days_elapsed <= 0:
+                # Bookmark already at/after this reference time: nothing unbilled left
+                # (re-run of the same window, or a backdated reference_time).
                 continue
 
             # Decay synapse weight
@@ -231,11 +278,15 @@ class DecayManager:
                     report.synapses_pruned += 1
                     if not dry_run:
                         # Zero out weight for pruned synapses
-                        pruned_synapse = synapse.decay(0.0)
+                        pruned_synapse = synapse.decay(0.0, now=reference_time)
                         await storage.update_synapse(pruned_synapse)
 
+                # The bookmark records the reference time this run charged up to, not
+                # wall-clock now: the interval billed and the interval marked as billed
+                # have to be the same one, or a run with an explicit reference_time
+                # (backfill, test, catch-up) would leave a gap or a double-charge.
                 elif not dry_run:
-                    decayed_synapse = synapse.decay(decay_factor)
+                    decayed_synapse = synapse.decay(decay_factor, now=reference_time)
                     await storage.update_synapse(decayed_synapse)
 
         report.duration_ms = (time.perf_counter() - start_time) * 1000

--- a/src/surreal_memory/engine/pipeline_steps.py
+++ b/src/surreal_memory/engine/pipeline_steps.py
@@ -40,6 +40,7 @@ from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.memory_types import suggest_memory_type
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.synapse import Synapse, SynapseType
+from surreal_memory.engine.dedup.alias_edges import AliasEdgeLedger, ensure_alias_edge
 from surreal_memory.engine.pipeline import PipelineContext
 from surreal_memory.extraction.entities import EntityExtractor, EntityType
 from surreal_memory.extraction.keywords import extract_keywords, extract_weighted_keywords
@@ -824,18 +825,24 @@ class CreateAnchorStep:
             await storage.add_neuron(alias_neuron)
             ctx.neurons_created.append(alias_neuron)
 
-            alias_synapse = Synapse.create(
-                source_id=alias_neuron.id,
-                target_id=anchor_neuron.id,
-                type=SynapseType.ALIAS,
-                weight=0.9,
-                metadata={"_dedup": True},
+            # Route through the shared helper so both dedup producers agree on
+            # the edge's identity: the id is derived from the pair, which is what
+            # makes a re-run upsert instead of minting a twin row.
+            #
+            # An empty ledger, not the default per-pair probe: ``alias_neuron``
+            # was minted three statements ago with a fresh UUID, so no edge can
+            # already leave it — the probe could only ever miss, and it would
+            # cost a round-trip on every dedup hit in the encode path. Worse, a
+            # probe that *fails* fails closed (skips the write), which here would
+            # strand the alias neuron with no link to its canonical anchor.
+            alias_synapse = await ensure_alias_edge(
+                storage,
+                alias_neuron.id,
+                anchor_neuron.id,
+                ledger=AliasEdgeLedger(),
             )
-            try:
-                await storage.add_synapse(alias_synapse)
+            if alias_synapse is not None:
                 ctx.synapses_created.append(alias_synapse)
-            except ValueError:
-                logger.debug("ALIAS synapse already exists")
 
             ctx.anchor_neuron = alias_neuron
         else:

--- a/src/surreal_memory/engine/topology_analysis.py
+++ b/src/surreal_memory/engine/topology_analysis.py
@@ -14,6 +14,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from surreal_memory.engine.diagnostics import DiagnosticsEngine
+
 if TYPE_CHECKING:
     from surreal_memory.storage.base import NeuralStorage
 
@@ -38,8 +40,12 @@ class TopologyMetrics:
             neighbors are (0 = no triangles, 1 = fully meshed).
         largest_component_ratio: Fraction of neurons in the largest
             connected component (1.0 = fully connected graph).
-        density: Edge count / max possible edges (undirected).
-        knowledge_density: Synapses per neuron (NOT 0-1, raw ratio).
+        density: Edge count / max possible edges (undirected). Counts every
+            edge, including structural ones — it answers "how wired is this
+            table", not "how much is known".
+        knowledge_density: SEMANTIC synapses per neuron (NOT 0-1, raw ratio).
+            Structural edges are excluded so this agrees with the connectivity
+            figure smem_health reports for the same brain.
         enriched_synapse_ratio: Fraction of synapses created by
             ENRICH consolidation (have ``_enriched`` metadata).
     """
@@ -91,7 +97,15 @@ async def compute_topology(
     density = synapse_count / max_edges if max_edges > 0 else 0.0
 
     # ── Knowledge density ────────────────────────────────────
-    knowledge_density = synapse_count / max(1, neuron_count)
+    # "Knowledge" is the operative word: alias dedup pointers and audit/provenance
+    # edges grow with how often things were written, not with what the brain knows,
+    # so counting them let this metric (and the evolution `density` signal derived
+    # from it) claim a rich graph while smem_health reported a thin one for the same
+    # brain. Counted off the fetched rows rather than by subtracting from the table
+    # total, so a caller that hands in a partial synapse list under-reports rather
+    # than silently inflating.
+    semantic_synapse_count = sum(1 for s in all_synapses if not _is_structural(s))
+    knowledge_density = semantic_synapse_count / max(1, neuron_count)
 
     # ── Enriched synapse ratio ───────────────────────────────
     enriched_count = sum(
@@ -119,6 +133,20 @@ async def compute_topology(
 # Max nodes/neighbors sampled for performance-bounded computation
 _MAX_SAMPLE_NODES = 200
 _MAX_SAMPLE_NEIGHBORS = 200
+
+
+def _is_structural(synapse: SynapseLike) -> bool:
+    """True for graph plumbing (alias/audit) rather than remembered meaning.
+
+    Membership is read from DiagnosticsEngine so brain health, the MCP hints and
+    this metric can never drift apart; an unknown or missing type counts as
+    semantic, which keeps a fixture or a future type from silently vanishing
+    from the density.
+    """
+    raw = getattr(synapse, "type", None)
+    # StrEnum members carry .value ("alias"); plain strings pass through unchanged.
+    value = getattr(raw, "value", raw)
+    return str(value).lower() in DiagnosticsEngine._STRUCTURAL_SYNAPSE_TYPES
 
 
 def _largest_component_ratio(

--- a/src/surreal_memory/mcp/maintenance_handler.py
+++ b/src/surreal_memory/mcp/maintenance_handler.py
@@ -57,13 +57,23 @@ class HealthHint:
 
 @dataclass(frozen=True)
 class HealthPulse:
-    """Result of a lightweight health check."""
+    """Result of a lightweight health check.
+
+    ``synapse_count`` is the raw table total, but ``connectivity`` is
+    ``semantic_synapse_count / neuron_count`` — the two must not be divided into
+    each other. Structural edges (alias/audit) are excluded from connectivity so
+    this pulse agrees with smem_health instead of reporting a ratio ~10x higher
+    for the same brain. ``semantic_synapse_count`` carries the numerator so the
+    unit stays auditable; it falls back to the raw total when a backend cannot
+    supply the per-type breakdown.
+    """
 
     fiber_count: int
     neuron_count: int
     synapse_count: int
     connectivity: float
     orphan_ratio: float
+    semantic_synapse_count: int = 0
     expired_memory_count: int = 0
     stale_fiber_ratio: float = 0.0
     consolidation_ratio: float = 0.0
@@ -107,6 +117,9 @@ class MaintenanceHandler:
     async def _health_pulse(self) -> HealthPulse | None:
         """Run a cheap health check using get_stats().
 
+        Connectivity is measured on the semantic graph (structural edges excluded),
+        so the numbers here match what `smem health` reports for the same brain.
+
         Returns None if maintenance is disabled or stats unavailable.
         """
         cfg: MaintenanceConfig = self.config.maintenance  # type: ignore[attr-defined]
@@ -125,7 +138,31 @@ class MaintenanceHandler:
         neuron_count = stats.get("neuron_count", 0)
         synapse_count = stats.get("synapse_count", 0)
 
-        connectivity = synapse_count / neuron_count if neuron_count > 0 else 0.0
+        # Connectivity describes the semantic graph, never write volume. alias rows
+        # are dedup pointers written once per repeated mention and audit edges point
+        # at agents/sources, so on a real brain 89% of the table was plumbing — enough
+        # to keep both the enrich hint and the auto-dream trigger below silent on a
+        # graph that actually held 1.4 semantic edges/neuron. The exclusion set lives
+        # in DiagnosticsEngine so this pulse and smem_health can never disagree.
+        semantic_synapse_count = synapse_count
+        try:
+            from surreal_memory.engine.diagnostics import DiagnosticsEngine
+
+            # Skip the neuron-type GROUP BY: it is the priciest part of enhanced
+            # stats and nothing here reads it. Older backends ignore the flag.
+            try:
+                enhanced = await storage.get_enhanced_stats(brain_id, include_neuron_types=False)
+            except TypeError:
+                enhanced = await storage.get_enhanced_stats(brain_id)
+            semantic_synapse_count = DiagnosticsEngine._count_semantic_synapses(
+                synapse_count, enhanced.get("synapse_stats", {})
+            )
+        except Exception:
+            # Keep the pulse alive on the raw total. That can only over-report
+            # connectivity (fewer hints), never invent a false low-connectivity alarm.
+            logger.debug("Health pulse: synapse type breakdown unavailable", exc_info=True)
+
+        connectivity = semantic_synapse_count / neuron_count if neuron_count > 0 else 0.0
 
         # Estimate orphan ratio: neurons not covered by fibers
         # Heuristic: each fiber typically creates ~5 neurons
@@ -187,6 +224,7 @@ class MaintenanceHandler:
             synapse_count=synapse_count,
             connectivity=round(connectivity, 2),
             orphan_ratio=round(orphan_ratio, 2),
+            semantic_synapse_count=semantic_synapse_count,
             consolidation_ratio=round(consolidation_ratio, 4),
             expired_memory_count=expired_memory_count,
             stale_fiber_ratio=round(stale_fiber_ratio, 2),
@@ -249,7 +287,10 @@ class MaintenanceHandler:
 
         Dream exploration discovers hidden connections via random spreading
         activation. Only fires when:
-        - connectivity < 1.5
+        - connectivity < 1.5 SEMANTIC synapses/neuron (alias and audit edges do
+          not count — a brain whose edges are all dedup plumbing needs dream MORE,
+          not less, so counting them here suppressed the trigger that was meant
+          to rescue exactly that brain)
         - neuron_count >= 50
         - dream cooldown has expired (default 24h)
         """
@@ -418,7 +459,12 @@ def _evaluate_thresholds(
     stale_fiber_ratio: float = 0.0,
     cfg: MaintenanceConfig,
 ) -> list[HealthHint]:
-    """Evaluate health thresholds and return structured hints with severity."""
+    """Evaluate health thresholds and return structured hints with severity.
+
+    ``connectivity`` is expected in SEMANTIC synapses per neuron (structural
+    alias/audit edges already subtracted by the caller), which is the unit the
+    hint text quotes and the same one smem_health reports.
+    """
     hints: list[HealthHint] = []
 
     if neuron_count > cfg.neuron_warn_threshold:
@@ -454,7 +500,8 @@ def _evaluate_thresholds(
     if neuron_count >= 10 and connectivity < 1.5:
         hints.append(
             HealthHint(
-                message=f"Low connectivity ({connectivity:.1f} synapses/neuron). "
+                message=f"Low connectivity ({connectivity:.1f} semantic synapses/neuron, "
+                "healthy: 3-8 per neuron; alias and audit edges excluded). "
                 "Consider running consolidation with enrich strategy.",
                 severity=HintSeverity.LOW,
                 recommended_strategy="enrich",

--- a/src/surreal_memory/mcp/stats_handler.py
+++ b/src/surreal_memory/mcp/stats_handler.py
@@ -189,12 +189,23 @@ class StatsHandler:
         except Exception:
             logger.debug("Activation check failed (non-critical)", exc_info=True)
 
-        # Low connectivity hint
+        # Low connectivity hint. Counted on the semantic graph only, using the same
+        # exclusion set as smem_health — alias/audit rows scale with write volume,
+        # not with what is known, so including them made this hint quote a ratio
+        # (13.5/neuron on a real brain) that contradicted the health report's 1.4
+        # for the same brain. Falls back to the raw total when a caller passes plain
+        # get_stats() output with no by_type breakdown.
         if neuron_count > 0:
-            connectivity = synapse_count / neuron_count
+            from surreal_memory.engine.diagnostics import DiagnosticsEngine
+
+            semantic_synapse_count = DiagnosticsEngine._count_semantic_synapses(
+                synapse_count, stats.get("synapse_stats", {})
+            )
+            connectivity = semantic_synapse_count / neuron_count
             if connectivity < 2.0 and neuron_count >= 20:
                 hints.append(
-                    f"Low connectivity ({connectivity:.1f} synapses/neuron, target: 3+). "
+                    f"Low connectivity ({connectivity:.1f} semantic synapses/neuron, "
+                    "healthy: 3-8 per neuron; alias and audit edges excluded). "
                     "Store memories with context like 'X because Y' to build richer links."
                 )
 

--- a/src/surreal_memory/storage/surrealdb/maturation.py
+++ b/src/surreal_memory/storage/surrealdb/maturation.py
@@ -6,11 +6,18 @@ that ``_compute_consolidation_ratio`` (= semantic maturations / fibers) and the
 through to the no-op defaults in ``storage/base.py`` — ``save_maturation`` silently
 dropped every write and ``find_maturations`` always returned ``[]`` — so the dashboard
 reported "0 semantic" regardless of processing. Mirrors ``review_schedules.py``.
+
+Every ``fiber_id`` crossing this boundary — in, out, and in the WHERE clause — is
+folded through ``_ids._to_surreal_id``. See ``_canonicalised`` for why: without it
+the field kept the caller's dash-form uuid4 while the fiber table (and this table's
+own record id) used the underscore form, so nothing could join and no memory ever
+reached SEMANTIC.
 """
 
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
@@ -49,6 +56,30 @@ def _row_to_maturation(row: dict[str, Any]) -> MaturationRecord:
     )
 
 
+def _canonicalised(record: MaturationRecord) -> MaturationRecord:
+    """Return ``record`` with ``fiber_id`` in the form the ``fiber`` table uses.
+
+    BUG: ``Fiber.create`` mints a dash-form uuid4 and ``BuildFiberStep`` handed
+    that straight to ``save_maturation``, so the ``fiber_id`` FIELD kept dashes
+    while the record id was already folded to underscores by ``_to_surreal_id``.
+    Every consumer that joins a maturation back to a fiber BY ID — the rehearsal
+    lookup in ``lifecycle.reinforce`` (fiber ids read back from the DB, so always
+    underscore-form) and the ``maturation_map`` fed to ``extract_patterns`` —
+    therefore missed those rows entirely. Rehearsals never landed, so the
+    EPISODIC->SEMANTIC spacing gate could never be satisfied: on the live brain
+    ALL 77 rehearsed and ALL 9 semantic rows were underscore-form, and not one of
+    the 1277 dash-form rows had ever been rehearsed.
+
+    Folding on the way OUT (not just on the way in) means legacy rows resolve
+    exactly like freshly written ones, so promotion resumes without waiting for a
+    data migration.
+    """
+    canonical = _to_surreal_id(record.fiber_id)
+    if canonical == record.fiber_id:
+        return record
+    return replace(record, fiber_id=canonical)
+
+
 class SurrealDBMaturationMixin:
     """Mixin providing maturation CRUD for SurrealDBStorage."""
 
@@ -61,14 +92,48 @@ class SurrealDBMaturationMixin:
     async def _query(self, sql: str, **params: Any) -> list[dict[str, Any]]:
         raise NotImplementedError
 
+    async def _find_maturation_row(self, fiber_id: str, brain_id: str) -> dict[str, Any] | None:
+        """Locate a fiber's maturation row, tolerating either ``fiber_id`` spelling.
+
+        The RECORD ID is the one identifier that has always been canonical — ``sid``
+        went through ``_to_surreal_id`` even before this fix — while the ``fiber_id``
+        FIELD kept whatever the caller passed: a dash-form uuid4 from
+        ``BuildFiberStep``, the underscore form from anything read back out of the
+        DB. A field-equality lookup therefore missed every row whose spelling
+        differed from the caller's, which is precisely why rehearsal never found the
+        1277 dash-form rows on the live brain. Probing the record id first reaches
+        legacy and new rows alike with one brain-scoped PK lookup; the field query is
+        only needed after a brain rename, which leaves the record id carrying the OLD
+        brain prefix while the field still identifies the row.
+        """
+        sid = f"{_to_surreal_id(brain_id)}_{_to_surreal_id(fiber_id)}"
+        rows = await self._query(
+            "SELECT * FROM maturation WHERE brain_id = $brain_id "
+            "AND id = type::record('maturation', $sid) LIMIT 1",
+            brain_id=brain_id,
+            sid=sid,
+        )
+        if not rows:
+            rows = await self._query(
+                "SELECT * FROM maturation WHERE brain_id = $brain_id "
+                "AND (fiber_id = $fiber_id OR fiber_id = $legacy_fiber_id) LIMIT 1",
+                brain_id=brain_id,
+                fiber_id=_to_surreal_id(fiber_id),
+                legacy_fiber_id=fiber_id,
+            )
+        return rows[0] if rows else None
+
     async def save_maturation(self, record: MaturationRecord) -> None:
         """Upsert a maturation record keyed by (brain_id, fiber_id)."""
         brain_id = self._get_brain_id()
         conn = self._ensure_conn()
-        sid = f"{_to_surreal_id(brain_id)}_{_to_surreal_id(record.fiber_id)}"
+        # The fiber table stores ids folded through _to_surreal_id, so the field
+        # must use that same form or nothing can ever join maturation -> fiber.
+        canonical_fiber_id = _to_surreal_id(record.fiber_id)
+        sid = f"{_to_surreal_id(brain_id)}_{canonical_fiber_id}"
 
         record_data: dict[str, Any] = {
-            "fiber_id": record.fiber_id,
+            "fiber_id": canonical_fiber_id,
             "brain_id": brain_id,
             "stage": record.stage.value,
             "stage_entered_at": record.stage_entered_at,
@@ -76,32 +141,27 @@ class SurrealDBMaturationMixin:
             "reinforcement_timestamps": list(record.reinforcement_timestamps),
         }
 
-        existing = await self._query(
-            "SELECT id FROM maturation WHERE brain_id = $brain_id AND fiber_id = $fiber_id LIMIT 1",
-            brain_id=brain_id,
-            fiber_id=record.fiber_id,
-        )
+        existing = await self._find_maturation_row(record.fiber_id, brain_id)
         try:
             if existing:
                 # Merge by the existing record id (not the recomputed sid) so a
                 # post-rename brain prefix mismatch can't silently no-op the write.
-                await conn.merge(existing[0]["id"], record_data)
+                # record_data also rewrites a legacy dash-form field to the canonical
+                # form, so surviving rows self-heal on their next write.
+                await conn.merge(existing["id"], record_data)
             else:
                 insert_data = dict(record_data)
                 insert_data["id"] = sid
                 await conn.insert("maturation", insert_data)
         except Exception:
             # Fiber may have been deleted between read and write (parity with SQLite).
-            logger.debug("Skipping maturation save for fiber %s", record.fiber_id)
+            # exc_info because this catch previously hid the id-mismatch collision:
+            # the missed lookup fell through to an insert on an id already taken.
+            logger.debug("Skipping maturation save for %s", record.fiber_id, exc_info=True)
 
     async def get_maturation(self, fiber_id: str) -> MaturationRecord | None:
-        brain_id = self._get_brain_id()
-        rows = await self._query(
-            "SELECT * FROM maturation WHERE brain_id = $brain_id AND fiber_id = $fiber_id LIMIT 1",
-            brain_id=brain_id,
-            fiber_id=fiber_id,
-        )
-        return _row_to_maturation(rows[0]) if rows else None
+        row = await self._find_maturation_row(fiber_id, self._get_brain_id())
+        return _canonicalised(_row_to_maturation(row)) if row else None
 
     async def find_maturations(
         self,
@@ -124,7 +184,9 @@ class SurrealDBMaturationMixin:
             f"SELECT * FROM maturation WHERE {where} LIMIT 5000",
             **params,
         )
-        return [_row_to_maturation(r) for r in rows]
+        # Canonicalise before handing out: callers key these by fiber_id and join
+        # them against fiber ids (e.g. consolidation's maturation_map -> extract_patterns).
+        return [_canonicalised(_row_to_maturation(r)) for r in rows]
 
     async def cleanup_orphaned_maturations(self) -> int:
         """Delete maturation rows whose fiber no longer exists."""
@@ -173,13 +235,16 @@ class SurrealDBMaturationMixin:
         )
 
         brain_id = self._get_brain_id()
-        existing = {m.fiber_id for m in await self.find_maturations()}
+        # Compare on the canonical form on both sides: a legacy dash-form row read
+        # as "already exists" under one spelling and "missing" under the other made
+        # the skip check miss, and the resulting insert collided on the record id.
+        existing = {_to_surreal_id(m.fiber_id) for m in await self.find_maturations()}
         fibers = await self.get_fibers(limit=100000)  # type: ignore[attr-defined]
         now = utcnow()
         counts = {"stm": 0, "working": 0, "episodic": 0, "semantic": 0, "skipped": 0}
 
         for fiber in fibers:
-            if fiber.id in existing:
+            if _to_surreal_id(fiber.id) in existing:
                 counts["skipped"] += 1
                 continue
             base = fiber.time_start or fiber.created_at or now

--- a/src/surreal_memory/surface/resolver.py
+++ b/src/surreal_memory/surface/resolver.py
@@ -24,6 +24,11 @@ def get_surface_path(brain_name: str = "default", *, for_write: bool = False) ->
     a project root is detected — this ensures the first save creates
     the file at project level instead of always falling through to global.
 
+    Read and write therefore agree on the same file as long as they resolve the
+    same project root: outside a project both land on the global path, and inside
+    one the reader picks up whatever the writer created. See
+    ``detect_project_root`` for why the home directory is not a project.
+
     Args:
         brain_name: Brain to resolve surface for.
         for_write: If True, prefer project path even when file doesn't exist yet.
@@ -47,11 +52,56 @@ def _global_surface_path(brain_name: str = "default") -> Path:
     return get_surrealmemory_dir() / "surfaces" / f"{brain_name}.nm"
 
 
+_NM_DIR = ".surrealmemory"
+
+_PROJECT_MARKERS: tuple[str, ...] = (
+    _NM_DIR,
+    ".git",
+    "pyproject.toml",
+    "package.json",
+    "Cargo.toml",
+    "go.mod",
+)
+
+
+def _global_config_dir() -> Path | None:
+    """Resolve the global ``.surrealmemory`` directory, or None if unavailable."""
+    from surreal_memory.unified_config import get_surrealmemory_dir
+
+    try:
+        return get_surrealmemory_dir().resolve()
+    except (OSError, RuntimeError):
+        return None
+
+
+def _is_project_root(candidate: Path, global_dir: Path | None) -> bool:
+    """Check whether a directory carries a project marker."""
+    for marker in _PROJECT_MARKERS:
+        marker_path = candidate / marker
+        if not marker_path.exists():
+            continue
+
+        # The global config directory is itself named ``.surrealmemory``, so a bare
+        # existence check would promote whatever contains it (normally $HOME) to a
+        # project root. Only a *project's own* .surrealmemory counts.
+        if marker == _NM_DIR and global_dir is not None:
+            try:
+                if marker_path.resolve() == global_dir:
+                    continue
+            except OSError:
+                pass
+
+        return True
+
+    return False
+
+
 def detect_project_root() -> Path | None:
     """Detect the project root directory.
 
     Walks up from CWD looking for common project markers.
-    Returns None if no project root found (e.g., in home directory).
+    Returns None if no project root found (e.g., in home directory) — callers
+    then fall back to the global surface.
 
     Markers (first match wins):
     - ``.surrealmemory/`` directory (NM project config)
@@ -60,28 +110,32 @@ def detect_project_root() -> Path | None:
     - ``package.json``
     - ``Cargo.toml``
     - ``go.mod``
-    """
-    markers = (
-        ".surrealmemory",
-        ".git",
-        "pyproject.toml",
-        "package.json",
-        "Cargo.toml",
-        "go.mod",
-    )
 
+    The home directory is never a project root, and neither is the parent of the
+    global config directory wherever ``SURREAL_MEMORY_DIR`` points it. Matching
+    ``~/.surrealmemory`` as a project marker made the resolved surface depend on
+    the shell's cwd: ``surface generate`` run from ``~`` wrote
+    ``~/.surrealmemory/surface.nm`` while ``doctor`` run from a repo checkout
+    looked for ``~/.surrealmemory/surfaces/<brain>.nm`` and reported the surface as
+    never generated. Per-project surfaces stay supported — a repo checkout with its
+    own ``.surrealmemory/`` (or any other marker) is still a project root.
+    """
     try:
         current = Path.cwd().resolve()
     except OSError:
         return None
 
-    home = Path.home().resolve()
+    try:
+        home: Path | None = Path.home().resolve()
+    except (OSError, RuntimeError):
+        home = None
+
+    global_dir = _global_config_dir()
 
     # Walk up, but don't go above home or root
     for _ in range(20):  # safety cap
-        for marker in markers:
-            if (current / marker).exists():
-                return current
+        if current != home and _is_project_root(current, global_dir):
+            return current
 
         parent = current.parent
         if parent == current or current == home:

--- a/tests/unit/test_connectivity_consistency.py
+++ b/tests/unit/test_connectivity_consistency.py
@@ -1,0 +1,299 @@
+"""One brain, one connectivity number — every surface must agree.
+
+`smem health` scores connectivity on the semantic graph (alias dedup rows and
+audit/provenance edges excluded, see ``DiagnosticsEngine._STRUCTURAL_SYNAPSE_TYPES``).
+Four other surfaces used to divide the RAW synapse total by the neuron count, so the
+same brain was simultaneously advertised as 13.5 synapses/neuron and 1.4 — and the
+loudest number was the one that hid the problem.
+
+This pins the agreement itself, not each formula separately: whatever the exclusion
+set becomes, diagnostics / smem_stats hints / the maintenance pulse / topology
+knowledge_density must keep returning the SAME ratio for the SAME brain.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from surreal_memory.core.brain import Brain, BrainConfig
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.core.synapse import Synapse, SynapseType
+from surreal_memory.engine.diagnostics import DiagnosticsEngine
+from surreal_memory.engine.topology_analysis import compute_topology
+from surreal_memory.mcp.maintenance_handler import (
+    HealthPulse,
+    MaintenanceHandler,
+    _evaluate_thresholds,
+)
+from surreal_memory.mcp.stats_handler import StatsHandler
+from surreal_memory.storage.memory_store import InMemoryStorage
+from surreal_memory.unified_config import MaintenanceConfig, UnifiedConfig
+
+# 20 neurons; 180 alias rows (dedup plumbing) + 20 real relations.
+# Raw ratio 10.0/neuron, semantic ratio 1.0/neuron — a 10x gap, so any surface
+# still counting the raw total is impossible to mistake for a rounding artefact.
+NEURONS = 20
+ALIAS_EDGES = 180
+SEMANTIC_EDGES = 20
+EXPECTED_RATIO = SEMANTIC_EDGES / NEURONS  # 1.0
+RAW_RATIO = (ALIAS_EDGES + SEMANTIC_EDGES) / NEURONS  # 10.0
+
+
+# ── Fixtures ─────────────────────────────────────────────────────
+
+
+async def _build_brain() -> tuple[InMemoryStorage, str]:
+    """A brain whose synapse table is 90% dedup plumbing."""
+    store = InMemoryStorage()
+    brain = Brain.create(name="connectivity-consistency", config=BrainConfig(), owner_id="test")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    for i in range(NEURONS):
+        await store.add_neuron(
+            Neuron.create(type=NeuronType.ENTITY, content=f"node-{i}", neuron_id=f"n-{i}")
+        )
+
+    synapse_ids: set[str] = set()
+    edges: list[tuple[str, str, SynapseType]] = [
+        (f"n-{i % NEURONS}", f"n-{(i + 1) % NEURONS}", SynapseType.ALIAS)
+        for i in range(ALIAS_EDGES)
+    ] + [
+        (f"n-{i % NEURONS}", f"n-{(i + 3) % NEURONS}", SynapseType.RELATED_TO)
+        for i in range(SEMANTIC_EDGES)
+    ]
+    for idx, (src, tgt, stype) in enumerate(edges):
+        sid = f"s-{idx}"
+        await store.add_synapse(
+            Synapse.create(
+                source_id=src,
+                target_id=tgt,
+                type=stype,
+                weight=0.0 if stype is SynapseType.ALIAS else 0.6,
+                synapse_id=sid,
+            )
+        )
+        synapse_ids.add(sid)
+
+    await store.add_fiber(
+        Fiber.create(
+            neuron_ids={f"n-{i}" for i in range(NEURONS)},
+            synapse_ids=synapse_ids,
+            anchor_neuron_id="n-0",
+            fiber_id="f-0",
+        )
+    )
+    return store, brain.id
+
+
+@pytest_asyncio.fixture
+async def brain() -> tuple[InMemoryStorage, str]:
+    return await _build_brain()
+
+
+class _FakeServer(MaintenanceHandler):
+    """Minimal MCP server stub exposing the storage the pulse reads."""
+
+    def __init__(self, storage: InMemoryStorage) -> None:
+        self._storage = storage
+        self.config = UnifiedConfig(maintenance=MaintenanceConfig())
+
+    async def get_storage(self) -> InMemoryStorage:
+        return self._storage
+
+    async def _maybe_run_expiry_cleanup(self) -> int:
+        return 0
+
+
+# ── Per-surface ratios ───────────────────────────────────────────
+
+
+async def _diagnostics_ratio(store: InMemoryStorage, brain_id: str) -> float:
+    report = await DiagnosticsEngine(store).analyze(brain_id)
+    return report.semantic_synapse_count / report.neuron_count
+
+
+async def _stats_hint(store: InMemoryStorage, brain_id: str) -> str:
+    """The smem_stats connectivity hint for this brain."""
+    handler = StatsHandler.__new__(StatsHandler)
+    stats = await store.get_enhanced_stats(brain_id)
+    hints = await handler._generate_stats_hints(store, brain_id, stats)
+    return next(h for h in hints if "connectivity" in h.lower())
+
+
+async def _pulse(store: InMemoryStorage) -> HealthPulse:
+    pulse = await _FakeServer(store)._health_pulse()
+    assert pulse is not None
+    return pulse
+
+
+# ── The regression that matters ──────────────────────────────────
+
+
+class TestAllSurfacesAgree:
+    """Same brain, same ratio — whatever the exclusion set says."""
+
+    @pytest.mark.asyncio
+    async def test_every_surface_reports_the_semantic_ratio(
+        self, brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        store, brain_id = brain
+
+        diagnostics = await _diagnostics_ratio(store, brain_id)
+        pulse = await _pulse(store)
+        topo = await compute_topology(store, brain_id)
+        hint = await _stats_hint(store, brain_id)
+
+        assert diagnostics == pytest.approx(EXPECTED_RATIO)
+        assert pulse.connectivity == pytest.approx(EXPECTED_RATIO)
+        assert topo.knowledge_density == pytest.approx(EXPECTED_RATIO)
+        # The hint prints the same ratio it was computed from.
+        assert f"{EXPECTED_RATIO:.1f} semantic synapses/neuron" in hint
+
+    @pytest.mark.asyncio
+    async def test_none_of_them_quote_the_raw_ratio(
+        self, brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        """10.0/neuron is the number that hid the thin graph."""
+        store, brain_id = brain
+
+        pulse = await _pulse(store)
+        topo = await compute_topology(store, brain_id)
+        hint = await _stats_hint(store, brain_id)
+
+        assert pulse.connectivity != pytest.approx(RAW_RATIO)
+        assert topo.knowledge_density != pytest.approx(RAW_RATIO)
+        assert f"{RAW_RATIO:.1f}" not in hint
+
+    @pytest.mark.asyncio
+    async def test_raw_totals_are_still_reported_untouched(
+        self, brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        """Excluding structural edges from a RATIO must not hide them from counts."""
+        store, brain_id = brain
+        report = await DiagnosticsEngine(store).analyze(brain_id)
+        pulse = await _pulse(store)
+
+        assert report.synapse_count == ALIAS_EDGES + SEMANTIC_EDGES
+        assert pulse.synapse_count == ALIAS_EDGES + SEMANTIC_EDGES
+        assert pulse.semantic_synapse_count == SEMANTIC_EDGES
+
+    @pytest.mark.asyncio
+    async def test_a_semantic_brain_agrees_too(self) -> None:
+        """The agreement is not an artefact of the alias-heavy shape."""
+        store = InMemoryStorage()
+        b = Brain.create(name="all-semantic", config=BrainConfig(), owner_id="test")
+        await store.save_brain(b)
+        store.set_brain(b.id)
+        for i in range(NEURONS):
+            await store.add_neuron(
+                Neuron.create(type=NeuronType.ENTITY, content=f"node-{i}", neuron_id=f"n-{i}")
+            )
+        sids: set[str] = set()
+        for i in range(SEMANTIC_EDGES):
+            sid = f"s-{i}"
+            await store.add_synapse(
+                Synapse.create(
+                    source_id=f"n-{i % NEURONS}",
+                    target_id=f"n-{(i + 1) % NEURONS}",
+                    type=SynapseType.CAUSED_BY,
+                    weight=0.6,
+                    synapse_id=sid,
+                )
+            )
+            sids.add(sid)
+        await store.add_fiber(
+            Fiber.create(
+                neuron_ids={f"n-{i}" for i in range(NEURONS)},
+                synapse_ids=sids,
+                anchor_neuron_id="n-0",
+                fiber_id="f-0",
+            )
+        )
+
+        diagnostics = await _diagnostics_ratio(store, b.id)
+        pulse = await _pulse(store)
+        topo = await compute_topology(store, b.id)
+
+        assert diagnostics == pytest.approx(EXPECTED_RATIO)
+        assert pulse.connectivity == pytest.approx(EXPECTED_RATIO)
+        assert topo.knowledge_density == pytest.approx(EXPECTED_RATIO)
+
+
+# ── Unit-consistent messaging ────────────────────────────────────
+
+
+class TestHintsStateTheUnit:
+    """A ratio and a 0-1 score must never be printed against the same target."""
+
+    @pytest.mark.asyncio
+    async def test_stats_hint_names_the_unit_and_the_exclusion(
+        self, brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        store, brain_id = brain
+        hint = await _stats_hint(store, brain_id)
+
+        assert "semantic synapses/neuron" in hint
+        assert "3-8 per neuron" in hint
+        assert "alias and audit edges excluded" in hint
+        # "target: 3+" sat next to a number that could be a 0-1 score.
+        assert "target: 3+" not in hint
+
+    def test_maintenance_hint_names_the_unit_and_the_exclusion(self) -> None:
+        hints = _evaluate_thresholds(
+            fiber_count=1,
+            neuron_count=NEURONS,
+            synapse_count=ALIAS_EDGES + SEMANTIC_EDGES,
+            connectivity=EXPECTED_RATIO,
+            orphan_ratio=0.0,
+            cfg=MaintenanceConfig(),
+        )
+        message = next(h.message for h in hints if "connectivity" in h.message.lower())
+
+        assert "semantic synapses/neuron" in message
+        assert "3-8 per neuron" in message
+        assert "alias and audit edges excluded" in message
+        # Alert routing keys off this prefix — keep it recognisable.
+        assert message.startswith("Low connectivity (")
+
+
+# ── Behaviour the exclusion is supposed to restore ───────────────
+
+
+class TestSuppressedSignalsFireAgain:
+    """Alias inflation used to silence the very hints this brain needs."""
+
+    @pytest.mark.asyncio
+    async def test_low_connectivity_hint_fires_on_an_alias_flooded_brain(
+        self, brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        """At the raw 10.0/neuron both thresholds (<2.0, <1.5) stayed silent."""
+        store, brain_id = brain
+
+        assert "connectivity" in (await _stats_hint(store, brain_id)).lower()
+        pulse = await _pulse(store)
+        assert any("connectivity" in h.message.lower() for h in pulse.hints)
+
+    @pytest.mark.asyncio
+    async def test_pulse_falls_back_to_the_raw_total_without_a_breakdown(
+        self, brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        """A backend that cannot break down by type must still produce a pulse.
+
+        Over-reporting connectivity is the safe failure: it can only withhold a
+        hint, never fabricate a low-connectivity alarm.
+        """
+        store, _ = brain
+
+        async def _no_breakdown(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise RuntimeError("backend has no per-type synapse stats")
+
+        store.get_enhanced_stats = _no_breakdown  # type: ignore[method-assign]
+        pulse = await _pulse(store)
+
+        assert pulse.connectivity == pytest.approx(RAW_RATIO)
+        assert pulse.semantic_synapse_count == ALIAS_EDGES + SEMANTIC_EDGES

--- a/tests/unit/test_connectivity_semantic_only.py
+++ b/tests/unit/test_connectivity_semantic_only.py
@@ -1,0 +1,298 @@
+"""Connectivity must score the semantic graph, and say so in matching units.
+
+Two regressions are pinned here:
+
+1. `alias` rows are dedup plumbing (weight 0.0, one per repeated mention). On a real
+   brain they were 89% of all synapses and pinned connectivity at its 1.0 ceiling
+   while the semantic graph held 1.4 edges/neuron — the metric hid the weakness it
+   exists to expose.
+2. The 0-1 connectivity score was reported next to the raw "3-8 synapses/neuron"
+   target, so a saturated 1.0 read as "under-connected".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import pytest_asyncio
+
+from surreal_memory.core.brain import Brain, BrainConfig
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.core.synapse import Synapse, SynapseType
+from surreal_memory.engine.diagnostics import DiagnosticsEngine, _build_dynamic_action
+from surreal_memory.storage.memory_store import InMemoryStorage
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+def _stats(**counts: int) -> dict[str, Any]:
+    """Build a synapse_stats payload shaped like the storage backends emit."""
+    return {"by_type": {stype: {"count": n} for stype, n in counts.items()}}
+
+
+async def _brain_with(
+    name: str,
+    *,
+    neuron_count: int,
+    edges: list[tuple[str, str, SynapseType]],
+) -> tuple[InMemoryStorage, str]:
+    """Storage holding `neuron_count` neurons wired by `edges`, all in one fiber."""
+    store = InMemoryStorage()
+    brain = Brain.create(name=name, config=BrainConfig(), owner_id="test")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    for i in range(neuron_count):
+        await store.add_neuron(
+            Neuron.create(type=NeuronType.ENTITY, content=f"node-{i}", neuron_id=f"n-{i}")
+        )
+    synapse_ids: set[str] = set()
+    for idx, (src, tgt, stype) in enumerate(edges):
+        sid = f"s-{idx}"
+        await store.add_synapse(
+            Synapse.create(
+                source_id=src,
+                target_id=tgt,
+                type=stype,
+                weight=0.0 if stype is SynapseType.ALIAS else 0.6,
+                synapse_id=sid,
+            )
+        )
+        synapse_ids.add(sid)
+
+    await store.add_fiber(
+        Fiber.create(
+            neuron_ids={f"n-{i}" for i in range(neuron_count)},
+            synapse_ids=synapse_ids,
+            anchor_neuron_id="n-0",
+            fiber_id=f"f-{name}",
+        )
+    )
+    return store, brain.id
+
+
+@pytest_asyncio.fixture
+async def alias_only_brain() -> tuple[InMemoryStorage, str]:
+    """20 neurons joined exclusively by dedup `alias` edges — 10 edges/neuron of nothing."""
+    edges = [(f"n-{i % 20}", f"n-{(i + 1) % 20}", SynapseType.ALIAS) for i in range(200)]
+    return await _brain_with("alias-only", neuron_count=20, edges=edges)
+
+
+# ── Structural exclusion ─────────────────────────────────────────
+
+
+class TestSemanticSynapseCount:
+    """`alias` and audit/provenance edges are not part of the semantic graph."""
+
+    def test_alias_is_excluded(self) -> None:
+        stats = _stats(alias=137871, co_occurs=4711, related_to=2069)
+        total = 137871 + 4711 + 2069
+        assert DiagnosticsEngine._count_semantic_synapses(total, stats) == 4711 + 2069
+
+    def test_audit_and_provenance_edges_are_excluded(self) -> None:
+        """They point at an agent/user/source record, not at another memory."""
+        stats = _stats(
+            related_to=100,
+            stored_by=151,
+            verified_at=7,
+            approved_by=3,
+            source_of=11,
+        )
+        assert DiagnosticsEngine._count_semantic_synapses(272, stats) == 100
+
+    def test_similar_to_is_kept(self) -> None:
+        """Embedding-derived, but it joins two content neurons and is traversed on recall."""
+        stats = _stats(similar_to=4177, alias=100)
+        assert DiagnosticsEngine._count_semantic_synapses(4277, stats) == 4177
+
+    def test_table_structure_edges_are_kept(self) -> None:
+        """in_row/in_column link content to content — real structure, not plumbing."""
+        stats = _stats(in_row=40, in_column=83, has_value=166)
+        assert DiagnosticsEngine._count_semantic_synapses(289, stats) == 289
+
+    def test_member_name_keys_also_match(self) -> None:
+        """Some fixtures key by enum member name rather than value."""
+        stats = _stats(ALIAS=50, RELATED_TO=10)
+        assert DiagnosticsEngine._count_semantic_synapses(60, stats) == 10
+
+    def test_missing_breakdown_falls_back_to_total(self) -> None:
+        """A possibly-inflated number beats silently claiming zero connectivity."""
+        assert DiagnosticsEngine._count_semantic_synapses(500, {}) == 500
+
+    def test_plain_int_counts_supported(self) -> None:
+        """by_type entries are sometimes bare counts rather than dicts."""
+        stats: dict[str, Any] = {"by_type": {"alias": 90, "related_to": 10}}
+        assert DiagnosticsEngine._count_semantic_synapses(100, stats) == 10
+
+    def test_never_negative(self) -> None:
+        """Inconsistent totals must not produce a negative semantic count."""
+        stats = _stats(alias=500)
+        assert DiagnosticsEngine._count_semantic_synapses(100, stats) == 0
+
+
+class TestConnectivityIgnoresPlumbing:
+    """The score follows the semantic graph, not write volume."""
+
+    def test_alias_flood_does_not_saturate_score(self) -> None:
+        """The live brain's shape: 13.5 raw edges/neuron, 1.4 of them semantic."""
+        stats = _stats(alias=137871, co_occurs=4711, similar_to=4177, related_to=2069)
+        total, neurons = 148828, 11457
+
+        inflated = DiagnosticsEngine._compute_connectivity(total, neurons)
+        semantic = DiagnosticsEngine._count_semantic_synapses(total, stats)
+        honest = DiagnosticsEngine._compute_connectivity(semantic, neurons)
+
+        assert inflated > 0.99, "raw counting saturates the sigmoid"
+        assert honest < 0.2, "the semantic graph is genuinely thin"
+
+    @pytest.mark.asyncio
+    async def test_alias_only_brain_scores_near_zero(
+        self, alias_only_brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        """10 alias edges/neuron is still an empty semantic graph."""
+        store, brain_id = alias_only_brain
+        report = await DiagnosticsEngine(store).analyze(brain_id)
+
+        assert report.synapse_count == 200
+        assert report.semantic_synapse_count == 0
+        assert report.connectivity < 0.02
+        assert "LOW_CONNECTIVITY" in {w.code for w in report.warnings}
+
+    @pytest.mark.asyncio
+    async def test_semantic_edges_still_count(self) -> None:
+        """Same brain, real relations instead of alias rows — score recovers."""
+        edges = [(f"n-{i % 20}", f"n-{(i + 1) % 20}", SynapseType.RELATED_TO) for i in range(200)]
+        store, brain_id = await _brain_with("semantic", neuron_count=20, edges=edges)
+        report = await DiagnosticsEngine(store).analyze(brain_id)
+
+        assert report.semantic_synapse_count == 200
+        assert report.connectivity > 0.99
+        assert "LOW_CONNECTIVITY" not in {w.code for w in report.warnings}
+
+
+# ── Unit-consistent messaging ────────────────────────────────────
+
+
+class TestWarningUnitsMatch:
+    """A 0-1 score must never be printed against the raw 3-8/neuron target."""
+
+    def _warn(self, **overrides: Any) -> tuple[list[Any], list[str]]:
+        engine = DiagnosticsEngine.__new__(DiagnosticsEngine)
+        kwargs: dict[str, Any] = {
+            "neuron_count": 100,
+            "synapse_count": 1000,
+            "fiber_count": 10,
+            "raw_connectivity": 1.0,
+            "semantic_synapse_count": 100,
+            "connectivity_score": DiagnosticsEngine._compute_connectivity(100, 100),
+            "synapse_stats": _stats(alias=900, related_to=60, co_occurs=40),
+            "orphan_rate": 0.0,
+            "consolidation_ratio": 1.0,
+            "freshness": 1.0,
+            "fibers": [],
+        }
+        kwargs.update(overrides)
+        return engine._generate_diagnostics(**kwargs)
+
+    def test_message_quotes_the_semantic_ratio_not_the_score(self) -> None:
+        warnings, _ = self._warn()
+        warning = next(w for w in warnings if w.code == "LOW_CONNECTIVITY")
+        assert "1.0 semantic synapses/neuron" in warning.message
+        # The normalised score (~0.05) must not be the number sitting next to "3-8".
+        assert "0.05 synapses/neuron" not in warning.message
+        assert "score" not in warning.message.lower()
+
+    def test_target_is_stated_in_per_neuron_units(self) -> None:
+        warnings, recommendations = self._warn()
+        warning = next(w for w in warnings if w.code == "LOW_CONNECTIVITY")
+        assert "per neuron" in warning.message
+        assert any("per neuron" in r for r in recommendations)
+
+    def test_score_travels_in_details_not_in_the_ratio_text(self) -> None:
+        warnings, _ = self._warn()
+        details = next(w for w in warnings if w.code == "LOW_CONNECTIVITY").details
+        assert details["semantic_synapses_per_neuron"] == pytest.approx(1.0)
+        assert details["semantic_synapse_count"] == 100
+        assert details["structural_synapse_count"] == 900
+        assert 0.0 <= details["connectivity_score"] <= 1.0
+        assert details["connectivity_score"] < 0.5
+
+    def test_recommended_gap_is_measured_against_semantic_edges(self) -> None:
+        """Advice must not count the 900 alias rows as progress toward 3/neuron."""
+        _, recommendations = self._warn()
+        rec = next(r for r in recommendations if r.startswith("Low connectivity"))
+        assert "~200 more connections" in rec
+
+    def test_action_string_labels_both_units(self) -> None:
+        action = _build_dynamic_action(
+            "connectivity",
+            "fallback",
+            {"neuron_count": 100, "synapse_count": 1000, "semantic_synapse_count": 100},
+        )
+        assert "1.0 semantic synapses/neuron" in action
+        assert "0-1 connectivity score" in action
+        # The old text claimed a bare "target: 3.0+" beside a 0-1 rendered score.
+        assert "target: 3.0+" not in action
+
+    def test_action_falls_back_to_total_without_semantic_metric(self) -> None:
+        """Older callers pass no semantic count; the string must still be coherent."""
+        action = _build_dynamic_action(
+            "connectivity", "fallback", {"neuron_count": 100, "synapse_count": 300}
+        )
+        assert "3.0 semantic synapses/neuron" in action
+
+
+class TestLowDiversityThreshold:
+    """LOW_DIVERSITY is about type coverage; a 17-type brain is not under-covered."""
+
+    def _warn(self, synapse_stats: dict[str, Any], synapse_count: int) -> list[Any]:
+        engine = DiagnosticsEngine.__new__(DiagnosticsEngine)
+        warnings, _ = engine._generate_diagnostics(
+            neuron_count=100,
+            synapse_count=synapse_count,
+            fiber_count=10,
+            raw_connectivity=5.0,
+            synapse_stats=synapse_stats,
+            orphan_rate=0.0,
+            consolidation_ratio=1.0,
+            freshness=1.0,
+            fibers=[],
+        )
+        return warnings
+
+    def test_seventeen_types_does_not_fire(self) -> None:
+        """Real brain distribution: skewed, but 17 distinct types are in use."""
+        stats = _stats(
+            alias=137871,
+            co_occurs=4711,
+            similar_to=4177,
+            related_to=2069,
+            happened_at=1976,
+            after=1868,
+            involves=1014,
+            has_value=166,
+            stored_by=151,
+            in_column=83,
+            effective_for=70,
+            felt=41,
+            used_with=25,
+            before=20,
+            caused_by=5,
+            evolves_from=3,
+            leads_to=2,
+        )
+        codes = {w.code for w in self._warn(stats, 154252)}
+        assert "LOW_DIVERSITY" not in codes
+
+    def test_three_types_does_not_fire(self) -> None:
+        codes = {w.code for w in self._warn(_stats(alias=10, related_to=10, felt=10), 30)}
+        assert "LOW_DIVERSITY" not in codes
+
+    def test_two_types_fires(self) -> None:
+        warnings = self._warn(_stats(related_to=50, co_occurs=50), 100)
+        warning = next(w for w in warnings if w.code == "LOW_DIVERSITY")
+        assert warning.details["types_used"] == 2
+        # Counts on both sides of the comparison — never a 0-1 entropy score.
+        assert "2 of 8" in warning.message

--- a/tests/unit/test_decay_bookmark.py
+++ b/tests/unit/test_decay_bookmark.py
@@ -1,0 +1,264 @@
+"""Decay reads the ``_last_decayed`` bookmark, so each run charges only its own slice.
+
+Every assertion here drives the real ``DecayManager.apply_decay`` against the real
+``InMemoryStorage``. Nothing re-implements the elapsed-time arithmetic locally: a test
+that computed ``days_elapsed`` itself would keep passing even if lifecycle.py never
+read the bookmark at all, which is exactly how the bookmark shipped dead the first time.
+Expected weights are written as closed-form Ebbinghaus values so a regression shows up
+as a wrong number rather than as agreement with a copy of the bug.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import replace as dc_replace
+from datetime import datetime, timedelta
+
+import pytest
+
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.core.synapse import Synapse, SynapseType
+from surreal_memory.engine.lifecycle import DecayManager
+from surreal_memory.storage.memory_store import InMemoryStorage
+from surreal_memory.utils.timeutils import utcnow
+
+RATE = 0.1
+
+
+def _manager(min_age_days: float = 0.0, prune_threshold: float = 0.0) -> DecayManager:
+    """Decay manager with the age gate open unless a test is about the gate itself."""
+    return DecayManager(decay_rate=RATE, prune_threshold=prune_threshold, min_age_days=min_age_days)
+
+
+async def _seed(
+    now: datetime,
+    *,
+    idle_days: float = 10.0,
+    weight: float = 1.0,
+    created_days_ago: float | None = None,
+) -> tuple[InMemoryStorage, str]:
+    """A brain holding one synapse last used ``idle_days`` ago and never decayed.
+
+    Shaped like every row already in production: a real timestamp pair and no bookmark
+    in metadata, so the fallback path is what the first run exercises.
+    """
+    storage = InMemoryStorage()
+    storage.set_brain("decay-bookmark-test")
+
+    source = Neuron.create(type=NeuronType.ENTITY, content="source")
+    target = Neuron.create(type=NeuronType.ENTITY, content="target")
+    await storage.add_neuron(source)
+    await storage.add_neuron(target)
+
+    stamp = now - timedelta(days=idle_days)
+    born = now - timedelta(days=idle_days if created_days_ago is None else created_days_ago)
+    synapse = dc_replace(
+        Synapse.create(
+            source_id=source.id,
+            target_id=target.id,
+            type=SynapseType.RELATED_TO,
+            weight=weight,
+        ),
+        created_at=born,
+        last_activated=stamp,
+    )
+    await storage.add_synapse(synapse)
+    return storage, synapse.id
+
+
+async def _weight(storage: InMemoryStorage, synapse_id: str) -> float:
+    stored = await storage.get_synapse(synapse_id)
+    assert stored is not None
+    return stored.weight
+
+
+class TestBookmarkIsRead:
+    """The elapsed time charged comes from the bookmark, not from creation."""
+
+    async def test_first_run_on_a_pre_bookmark_row_decays_from_last_activated(self) -> None:
+        """Existing rows carry no bookmark, so run one must behave exactly as before."""
+        now = utcnow()
+        storage, synapse_id = await _seed(now, idle_days=7)
+
+        await _manager().apply_decay(storage, reference_time=now)
+
+        assert await _weight(storage, synapse_id) == pytest.approx(math.exp(-RATE * 7))
+
+    async def test_row_activated_before_it_was_created_keeps_the_old_base(self) -> None:
+        """Imports and merges can leave last_activated older than created_at.
+
+        The fallback stays on last_activated for those rows, as today. Taking the newest
+        of the three stamps instead would charge from the fresher created_at and fade
+        such a memory more slowly — a rate change this fix has no business making.
+        """
+        now = utcnow()
+        storage, synapse_id = await _seed(now, idle_days=10, created_days_ago=0.0)
+
+        await _manager().apply_decay(storage, reference_time=now)
+
+        assert await _weight(storage, synapse_id) == pytest.approx(math.exp(-RATE * 10))
+
+    async def test_run_records_the_reference_time_it_charged_up_to(self) -> None:
+        """The bookmark has to name the same instant the charge stopped at."""
+        now = utcnow()
+        storage, synapse_id = await _seed(now)
+
+        await _manager().apply_decay(storage, reference_time=now)
+
+        stored = await storage.get_synapse(synapse_id)
+        assert stored is not None
+        assert stored.last_decayed == now
+
+    async def test_second_run_charges_only_the_new_interval(self) -> None:
+        """The regression: run two must not re-apply the eleven days run one already did."""
+        now = utcnow()
+        storage, synapse_id = await _seed(now, idle_days=10)
+        manager = _manager()
+
+        await manager.apply_decay(storage, reference_time=now)
+        await manager.apply_decay(storage, reference_time=now + timedelta(days=1))
+
+        incremental = math.exp(-RATE * 10) * math.exp(-RATE * 1)
+        compounding = math.exp(-RATE * 10) * math.exp(-RATE * 11)  # the pre-fix result
+        assert await _weight(storage, synapse_id) == pytest.approx(incremental)
+        assert incremental > compounding  # guards the constants above from drifting equal
+
+    async def test_repeat_run_at_the_same_reference_time_changes_nothing(self) -> None:
+        """Nothing unbilled left means no weight change and no row rewritten."""
+        now = utcnow()
+        storage, synapse_id = await _seed(now)
+        manager = _manager()
+
+        await manager.apply_decay(storage, reference_time=now)
+        settled = await _weight(storage, synapse_id)
+        report = await manager.apply_decay(storage, reference_time=now)
+
+        assert report.synapses_decayed == 0
+        assert await _weight(storage, synapse_id) == settled
+
+    async def test_use_since_the_last_decay_is_not_charged(self) -> None:
+        """A synapse fired after its last decay must not pay for the time it was in use."""
+        now = utcnow()
+        storage, synapse_id = await _seed(now, idle_days=10)
+        manager = _manager()
+
+        await manager.apply_decay(storage, reference_time=now)
+        after_first = await _weight(storage, synapse_id)
+
+        fired = await storage.get_synapse(synapse_id)
+        assert fired is not None
+        await storage.update_synapse(dc_replace(fired, last_activated=now + timedelta(days=2)))
+        await manager.apply_decay(storage, reference_time=now + timedelta(days=3))
+
+        # One day (now+3 back to the firing at now+2), not three back to the bookmark.
+        assert await _weight(storage, synapse_id) == pytest.approx(after_first * math.exp(-RATE))
+
+
+class TestTotalDecayIsPreserved:
+    """Incremental decay must land on the same curve as one pass from creation."""
+
+    async def test_ten_daily_runs_equal_a_single_ten_day_run(self) -> None:
+        """exp(-r*d) chained over a partition of a window telescopes to exp(-r*window).
+
+        Ten runs of one day each and one run of ten days must produce the identical
+        weight — otherwise "incremental" would mean "memories fade at a different rate".
+        """
+        now = utcnow()
+        start = now - timedelta(days=10)
+        incremental, incremental_id = await _seed(now, idle_days=10)
+        one_shot, one_shot_id = await _seed(now, idle_days=10)
+        manager = _manager()
+
+        for day in range(1, 11):
+            await manager.apply_decay(incremental, reference_time=start + timedelta(days=day))
+        await manager.apply_decay(one_shot, reference_time=now)
+
+        assert await _weight(incremental, incremental_id) == pytest.approx(
+            await _weight(one_shot, one_shot_id)
+        )
+        assert await _weight(incremental, incremental_id) == pytest.approx(math.exp(-RATE * 10))
+
+    async def test_uneven_run_cadence_lands_on_the_same_curve(self) -> None:
+        """The partition need not be regular — only the window endpoints matter."""
+        now = utcnow()
+        start = now - timedelta(days=12)
+        storage, synapse_id = await _seed(now, idle_days=12)
+        manager = _manager()
+
+        for offset in (0.5, 3.0, 3.25, 12.0):
+            await manager.apply_decay(storage, reference_time=start + timedelta(days=offset))
+
+        assert await _weight(storage, synapse_id) == pytest.approx(math.exp(-RATE * 12))
+
+
+class TestAgeGateStillHolds:
+    """min_age_days keeps measuring idleness, not time since the last decay pass."""
+
+    async def test_recently_used_synapse_is_still_skipped(self) -> None:
+        now = utcnow()
+        storage, synapse_id = await _seed(now, idle_days=0.5)
+
+        report = await _manager(min_age_days=1.0).apply_decay(storage, reference_time=now)
+
+        assert report.synapses_decayed == 0
+        assert await _weight(storage, synapse_id) == 1.0
+        stored = await storage.get_synapse(synapse_id)
+        assert stored is not None
+        assert stored.last_decayed is None
+
+    async def test_runs_closer_together_than_min_age_days_still_decay(self) -> None:
+        """Gating on the bookmark would freeze decay forever on a sub-daily schedule.
+
+        The synapse is thirty days idle; two runs twelve hours apart must both charge,
+        because the gate asks how long the memory went unused, not how long ago the
+        previous pass ran.
+        """
+        now = utcnow()
+        storage, synapse_id = await _seed(now, idle_days=30)
+        manager = _manager(min_age_days=1.0)
+
+        await manager.apply_decay(storage, reference_time=now)
+        after_first = await _weight(storage, synapse_id)
+        await manager.apply_decay(storage, reference_time=now + timedelta(hours=12))
+        after_second = await _weight(storage, synapse_id)
+
+        assert after_second < after_first
+        assert after_second == pytest.approx(after_first * math.exp(-RATE * 0.5))
+
+
+class TestPrunePath:
+    """The zero-out branch bookmarks too, so a pruned row settles instead of churning."""
+
+    async def test_pruned_synapse_is_bookmarked_and_left_alone(self) -> None:
+        now = utcnow()
+        storage, synapse_id = await _seed(now, idle_days=10)
+        manager = DecayManager(decay_rate=1.0, prune_threshold=0.5, min_age_days=0.0)
+
+        first = await manager.apply_decay(storage, reference_time=now)
+        stored = await storage.get_synapse(synapse_id)
+        assert stored is not None
+        assert first.synapses_pruned == 1
+        assert stored.weight == 0.0
+        assert stored.last_decayed == now
+
+        second = await manager.apply_decay(storage, reference_time=now + timedelta(days=1))
+        assert second.synapses_decayed == 0
+
+
+class TestDryRun:
+    """A dry run must not leave a bookmark, or it would silently skip the real pass."""
+
+    async def test_dry_run_leaves_no_bookmark_and_no_weight_change(self) -> None:
+        now = utcnow()
+        storage, synapse_id = await _seed(now, idle_days=10)
+        manager = _manager()
+
+        report = await manager.apply_decay(storage, reference_time=now, dry_run=True)
+        stored = await storage.get_synapse(synapse_id)
+        assert stored is not None
+        assert report.synapses_decayed == 1
+        assert stored.weight == 1.0
+        assert stored.last_decayed is None
+
+        await manager.apply_decay(storage, reference_time=now)
+        assert await _weight(storage, synapse_id) == pytest.approx(math.exp(-RATE * 10))

--- a/tests/unit/test_dedup_alias_edges.py
+++ b/tests/unit/test_dedup_alias_edges.py
@@ -1,0 +1,447 @@
+"""Tests for idempotent dedup ALIAS edge creation.
+
+Regression guard for the live-brain finding: 144,565 alias synapse rows
+backing only 2,375 distinct (source, target) pairs, because the old
+``except ValueError`` guard could never fire against a fresh UUID id.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.core.synapse import Synapse, SynapseType
+from surreal_memory.engine.consolidation import ConsolidationEngine, ConsolidationReport
+from surreal_memory.engine.dedup.alias_edges import (
+    ALIAS_EDGE_WEIGHT,
+    AliasEdgeLedger,
+    alias_edge_id,
+    ensure_alias_edge,
+)
+from surreal_memory.engine.pipeline import PipelineContext
+from surreal_memory.engine.pipeline_steps import CreateAnchorStep
+
+
+class FakeStorage:
+    """Minimal storage stub with the no-uniqueness semantics of both backends.
+
+    Neither SQLite nor SurrealDB constrains ``(source, target, type)``; only
+    the synapse primary key collides. This stub reproduces exactly that, so a
+    test that passes here would also have caught the production bug.
+    """
+
+    def __init__(self, synapses: list[Synapse] | None = None) -> None:
+        self.synapses: list[Synapse] = list(synapses or [])
+        self.get_calls: list[dict] = []
+        self.fail_reads = False
+
+    async def get_synapses(
+        self,
+        source_id: str | None = None,
+        target_id: str | None = None,
+        type: SynapseType | None = None,
+        min_weight: float | None = None,
+        limit: int | None = None,
+    ) -> list[Synapse]:
+        self.get_calls.append({"source_id": source_id, "target_id": target_id, "type": type})
+        if self.fail_reads:
+            raise RuntimeError("storage unavailable")
+        hits = [
+            s
+            for s in self.synapses
+            if (source_id is None or s.source_id == source_id)
+            and (target_id is None or s.target_id == target_id)
+            and (type is None or s.type == type)
+        ]
+        return hits[:limit] if limit is not None else hits
+
+    async def add_synapse(self, synapse: Synapse) -> str:
+        if any(s.id == synapse.id for s in self.synapses):
+            raise ValueError(f"Synapse {synapse.id} already exists")
+        self.synapses.append(synapse)
+        return synapse.id
+
+
+def _alias(source_id: str, target_id: str) -> Synapse:
+    return Synapse.create(
+        source_id=source_id,
+        target_id=target_id,
+        type=SynapseType.ALIAS,
+        weight=ALIAS_EDGE_WEIGHT,
+        metadata={"_dedup": True},
+    )
+
+
+class TestAliasEdgeId:
+    def test_id_is_deterministic_for_a_pair(self) -> None:
+        assert alias_edge_id("dup-1", "canon-1") == alias_edge_id("dup-1", "canon-1")
+
+    def test_id_is_direction_sensitive(self) -> None:
+        # source -> target and target -> source are different claims.
+        assert alias_edge_id("dup-1", "canon-1") != alias_edge_id("canon-1", "dup-1")
+
+    def test_distinct_pairs_get_distinct_ids(self) -> None:
+        assert alias_edge_id("dup-1", "canon-1") != alias_edge_id("dup-2", "canon-1")
+
+
+class TestEnsureAliasEdgeSingleShot:
+    @pytest.mark.asyncio
+    async def test_creates_edge_when_absent(self) -> None:
+        storage = FakeStorage()
+
+        created = await ensure_alias_edge(storage, "dup-1", "canon-1")
+
+        assert created is not None
+        assert created.type is SynapseType.ALIAS
+        assert created.source_id == "dup-1"
+        assert created.target_id == "canon-1"
+        assert created.weight == ALIAS_EDGE_WEIGHT
+        assert created.metadata == {"_dedup": True}
+        assert len(storage.synapses) == 1
+
+    @pytest.mark.asyncio
+    async def test_second_call_for_same_pair_writes_nothing(self) -> None:
+        storage = FakeStorage()
+
+        first = await ensure_alias_edge(storage, "dup-1", "canon-1")
+        second = await ensure_alias_edge(storage, "dup-1", "canon-1")
+
+        assert first is not None
+        assert second is None
+        assert len(storage.synapses) == 1
+
+    @pytest.mark.asyncio
+    async def test_repeated_runs_do_not_amplify(self) -> None:
+        # The production failure mode: the same edge set re-created every
+        # consolidation run. 100 runs must still leave exactly one row.
+        storage = FakeStorage()
+
+        for _ in range(100):
+            await ensure_alias_edge(storage, "dup-1", "canon-1")
+
+        assert len(storage.synapses) == 1
+
+    @pytest.mark.asyncio
+    async def test_respects_preexisting_edge_created_elsewhere(self) -> None:
+        # Rows already in the brain carry random UUID ids, so recognising them
+        # has to work off the pair, not the id.
+        storage = FakeStorage([_alias("dup-1", "canon-1")])
+
+        result = await ensure_alias_edge(storage, "dup-1", "canon-1")
+
+        assert result is None
+        assert len(storage.synapses) == 1
+
+    @pytest.mark.asyncio
+    async def test_existence_check_is_type_scoped(self) -> None:
+        # A SIMILAR_TO edge between the same anchors is a different claim and
+        # must not suppress the alias edge.
+        other = Synapse.create(
+            source_id="dup-1",
+            target_id="canon-1",
+            type=SynapseType.SIMILAR_TO,
+            weight=0.4,
+        )
+        storage = FakeStorage([other])
+
+        created = await ensure_alias_edge(storage, "dup-1", "canon-1")
+
+        assert created is not None
+        assert storage.get_calls[0]["type"] is SynapseType.ALIAS
+
+    @pytest.mark.asyncio
+    async def test_distinct_pairs_each_get_an_edge(self) -> None:
+        storage = FakeStorage()
+
+        await ensure_alias_edge(storage, "dup-1", "canon-1")
+        await ensure_alias_edge(storage, "dup-2", "canon-1")
+        await ensure_alias_edge(storage, "dup-3", "canon-2")
+
+        assert len(storage.synapses) == 3
+
+
+class TestEnsureAliasEdgeGuards:
+    @pytest.mark.asyncio
+    async def test_self_alias_is_rejected(self) -> None:
+        storage = FakeStorage()
+
+        result = await ensure_alias_edge(storage, "dup-1", "dup-1")
+
+        assert result is None
+        assert storage.synapses == []
+
+    @pytest.mark.parametrize(("source", "target"), [("", "canon-1"), ("dup-1", "")])
+    @pytest.mark.asyncio
+    async def test_empty_endpoint_is_rejected(self, source: str, target: str) -> None:
+        storage = FakeStorage()
+
+        assert await ensure_alias_edge(storage, source, target) is None
+        assert storage.synapses == []
+
+    @pytest.mark.asyncio
+    async def test_read_failure_skips_the_write(self) -> None:
+        # Failing open would resurrect unbounded growth; a skipped edge is
+        # recoverable on the next dedup pass, a duplicate row is not.
+        storage = FakeStorage()
+        storage.fail_reads = True
+
+        result = await ensure_alias_edge(storage, "dup-1", "canon-1")
+
+        assert result is None
+        assert storage.synapses == []
+
+    @pytest.mark.asyncio
+    async def test_primary_key_collision_is_not_raised(self) -> None:
+        # Backstop layer: a racing writer already inserted the deterministic
+        # id, so add_synapse rejects. Losing that race is the correct outcome.
+        preexisting = Synapse.create(
+            source_id="dup-1",
+            target_id="canon-1",
+            type=SynapseType.ALIAS,
+            synapse_id=alias_edge_id("dup-1", "canon-1"),
+        )
+        storage = FakeStorage()
+        ledger = AliasEdgeLedger()
+        storage.synapses.append(preexisting)
+
+        result = await ensure_alias_edge(storage, "dup-1", "canon-1", ledger=ledger)
+
+        assert result is None
+        assert len(storage.synapses) == 1
+
+
+class TestAliasEdgeLedger:
+    @pytest.mark.asyncio
+    async def test_load_collects_existing_pairs(self) -> None:
+        storage = FakeStorage([_alias("dup-1", "canon-1"), _alias("dup-2", "canon-1")])
+
+        ledger = await AliasEdgeLedger.load(storage)
+
+        assert len(ledger) == 2
+        assert ledger.has("dup-1", "canon-1")
+        assert ("dup-2", "canon-1") in ledger
+        assert not ledger.has("dup-3", "canon-1")
+
+    @pytest.mark.asyncio
+    async def test_load_ignores_non_alias_edges(self) -> None:
+        storage = FakeStorage(
+            [
+                _alias("dup-1", "canon-1"),
+                Synapse.create(
+                    source_id="a", target_id="b", type=SynapseType.RELATED_TO, weight=0.3
+                ),
+            ]
+        )
+
+        ledger = await AliasEdgeLedger.load(storage)
+
+        assert len(ledger) == 1
+
+    @pytest.mark.asyncio
+    async def test_ledger_path_issues_no_per_pair_queries(self) -> None:
+        # The consolidation pass compares up to 2000 anchors; the whole point
+        # of the ledger is one query per run rather than one per pair.
+        storage = FakeStorage()
+        ledger = await AliasEdgeLedger.load(storage)
+        queries_after_load = len(storage.get_calls)
+
+        for i in range(50):
+            await ensure_alias_edge(storage, f"dup-{i}", "canon-1", ledger=ledger)
+
+        assert len(storage.get_calls) == queries_after_load
+        assert len(storage.synapses) == 50
+
+    @pytest.mark.asyncio
+    async def test_ledger_suppresses_repeats_within_one_run(self) -> None:
+        storage = FakeStorage()
+        ledger = await AliasEdgeLedger.load(storage)
+
+        first = await ensure_alias_edge(storage, "dup-1", "canon-1", ledger=ledger)
+        second = await ensure_alias_edge(storage, "dup-1", "canon-1", ledger=ledger)
+
+        assert first is not None
+        assert second is None
+        assert len(storage.synapses) == 1
+
+    @pytest.mark.asyncio
+    async def test_second_run_over_a_reloaded_ledger_is_a_no_op(self) -> None:
+        # Full production shape: run dedup, reload, run it again.
+        storage = FakeStorage()
+        pairs = [(f"dup-{i}", "canon-1") for i in range(20)]
+
+        run_one = await AliasEdgeLedger.load(storage)
+        for src, tgt in pairs:
+            await ensure_alias_edge(storage, src, tgt, ledger=run_one)
+        assert len(storage.synapses) == 20
+
+        run_two = await AliasEdgeLedger.load(storage)
+        for src, tgt in pairs:
+            await ensure_alias_edge(storage, src, tgt, ledger=run_two)
+
+        assert len(storage.synapses) == 20
+
+    @pytest.mark.asyncio
+    async def test_load_propagates_read_failure(self) -> None:
+        # Silently returning an empty ledger would mean "nothing exists" —
+        # precisely the bug being fixed. Callers must fall back explicitly.
+        storage = FakeStorage()
+        storage.fail_reads = True
+
+        with pytest.raises(RuntimeError):
+            await AliasEdgeLedger.load(storage)
+
+
+# ---------------------------------------------------------------------------
+# Call sites
+#
+# The helper above was correct but unreferenced for one release: both dedup
+# producers still minted their own fresh-UUID edge. These tests assert the
+# wiring, not the helper — they fail if either producer goes back to calling
+# ``Synapse.create`` directly.
+# ---------------------------------------------------------------------------
+
+
+ANCHOR_HASH = 0xDEADBEEFCAFEF00D
+
+
+def _anchor(content: str, content_hash: int = ANCHOR_HASH) -> Neuron:
+    return Neuron.create(
+        type=NeuronType.CONCEPT,
+        content=content,
+        metadata={"is_anchor": True},
+        content_hash=content_hash,
+    )
+
+
+class FakeAnchorStorage(FakeStorage):
+    """FakeStorage plus the neuron read that ``_dedup`` paginates over."""
+
+    def __init__(self, neurons: list[Neuron], synapses: list[Synapse] | None = None) -> None:
+        super().__init__(synapses)
+        self.neurons = list(neurons)
+        self.current_brain_id = "brain-1"
+
+    async def find_neurons(
+        self,
+        limit: int | None = None,
+        offset: int = 0,
+        **kwargs: object,
+    ) -> list[Neuron]:
+        window = self.neurons[offset:]
+        return window[:limit] if limit is not None else window
+
+
+class FakeEncodeStorage(FakeStorage):
+    """FakeStorage plus the neuron write CreateAnchorStep performs."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.neurons: list[Neuron] = []
+
+    async def add_neuron(self, neuron: Neuron) -> str:
+        self.neurons.append(neuron)
+        return neuron.id
+
+
+class TestConsolidationDedupCallSite:
+    @pytest.mark.asyncio
+    async def test_repeated_runs_leave_one_row_per_pair(self) -> None:
+        # The production shape exactly: consolidation re-derives the same
+        # duplicate pair on every run. Three runs, one row.
+        canonical = _anchor("deployment notes")
+        duplicate = _anchor("deployment notes (copy)")
+        storage = FakeAnchorStorage([canonical, duplicate])
+        engine = ConsolidationEngine(storage)
+
+        for _ in range(3):
+            await engine._dedup(ConsolidationReport(), dry_run=False)
+
+        alias_rows = [s for s in storage.synapses if s.type is SynapseType.ALIAS]
+        assert len(alias_rows) == 1
+        edge = alias_rows[0]
+        assert (edge.source_id, edge.target_id) == (duplicate.id, canonical.id)
+        assert edge.id == alias_edge_id(duplicate.id, canonical.id)
+        assert edge.weight == ALIAS_EDGE_WEIGHT
+        assert edge.metadata == {"_dedup": True}
+
+    @pytest.mark.asyncio
+    async def test_preexisting_random_id_row_is_not_duplicated(self) -> None:
+        # Brains already hold alias rows with random UUID ids. Recognising them
+        # is what stops the 61x backlog from growing further.
+        canonical = _anchor("deployment notes")
+        duplicate = _anchor("deployment notes (copy)")
+        legacy = _alias(duplicate.id, canonical.id)
+        storage = FakeAnchorStorage([canonical, duplicate], [legacy])
+
+        await ConsolidationEngine(storage)._dedup(ConsolidationReport(), dry_run=False)
+
+        assert storage.synapses == [legacy]
+
+    @pytest.mark.asyncio
+    async def test_dry_run_writes_nothing(self) -> None:
+        storage = FakeAnchorStorage([_anchor("a"), _anchor("b")])
+        report = ConsolidationReport()
+
+        await ConsolidationEngine(storage)._dedup(report, dry_run=True)
+
+        assert storage.synapses == []
+        assert report.duplicates_found == 1
+
+    @pytest.mark.asyncio
+    async def test_pass_scales_with_runs_not_pairs(self) -> None:
+        # One ledger preload per run, no per-pair probe: 20 duplicates of the
+        # same anchor must cost exactly one read.
+        anchors = [_anchor(f"note {i}") for i in range(21)]
+        storage = FakeAnchorStorage(anchors)
+
+        await ConsolidationEngine(storage)._dedup(ConsolidationReport(), dry_run=False)
+
+        assert len(storage.get_calls) == 1
+        assert len(storage.synapses) == 20
+
+
+class TestCreateAnchorStepCallSite:
+    @staticmethod
+    def _context() -> PipelineContext:
+        return PipelineContext(
+            content="deployment notes",
+            timestamp=datetime(2026, 1, 1, 12, 0, 0),
+            metadata={},
+            tags=set(),
+            language="en",
+        )
+
+    @pytest.mark.asyncio
+    async def test_alias_edge_id_is_derived_from_the_pair(self) -> None:
+        anchor = _anchor("deployment notes")
+        ctx = self._context()
+        ctx.effective_metadata["_dedup_reused_anchor"] = anchor
+        storage = FakeEncodeStorage()
+
+        result = await CreateAnchorStep().execute(ctx, storage, None)
+
+        assert result.anchor_neuron is not None
+        assert len(storage.synapses) == 1
+        edge = storage.synapses[0]
+        assert edge.type is SynapseType.ALIAS
+        assert edge.source_id == result.anchor_neuron.id
+        assert edge.target_id == anchor.id
+        assert edge.id == alias_edge_id(edge.source_id, edge.target_id)
+        assert edge.weight == ALIAS_EDGE_WEIGHT
+        assert edge.metadata == {"_dedup": True}
+        assert ctx.synapses_created == [edge]
+
+    @pytest.mark.asyncio
+    async def test_encode_path_adds_no_read_round_trip(self) -> None:
+        # The alias neuron is minted in this step, so no edge can already leave
+        # it — probing for one would be a guaranteed-miss query on every dedup
+        # hit during encode.
+        ctx = self._context()
+        ctx.effective_metadata["_dedup_reused_anchor"] = _anchor("deployment notes")
+        storage = FakeEncodeStorage()
+
+        await CreateAnchorStep().execute(ctx, storage, None)
+
+        assert storage.get_calls == []

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.14.0"
+        assert surreal_memory.__version__ == "2.15.0"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_health_roadmap.py
+++ b/tests/unit/test_health_roadmap.py
@@ -17,8 +17,15 @@ class TestBuildDynamicAction:
             "fiber_count": 30,
         }
         action = _build_dynamic_action("connectivity", "fallback", metrics)
-        assert "0.5 synapses/neuron" in action
-        assert "target: 3.0" in action
+        # "semantic synapses/neuron": the ratio now excludes structural/dedup edges, and
+        # the text names its unit so a 0-1 score is never read as sitting below the raw
+        # 3-8 target — the units collision this wording used to invite.
+        assert "0.5 semantic synapses/neuron" in action
+        # The bare word "target" is gone on purpose: pairing a 0-1 score with a raw
+        # "target: 3.0" was the units collision. The text now states where the score
+        # sits on its own scale instead.
+        assert "reaches 0.5 at 3/neuron" in action
+        assert "target: 3.0" not in action
 
     def test_connectivity_action_includes_gap(self) -> None:
         metrics: dict[str, Any] = {

--- a/tests/unit/test_maturation_id_normalisation.py
+++ b/tests/unit/test_maturation_id_normalisation.py
@@ -1,0 +1,220 @@
+"""Regression tests for fiber-id normalisation in the SurrealDB maturation mixin.
+
+THE BUG: ``Fiber.create`` mints a dash-form uuid4, ``BuildFiberStep`` passed that
+straight to ``save_maturation``, and the mixin stored it verbatim in the
+``fiber_id`` FIELD — while the ``fiber`` table (and this table's own record id)
+folds ids to the underscore form via ``_to_surreal_id``. Consequences on the live
+brain, all measured:
+
+* 1277 of 1920 maturation rows carried a dash-form ``fiber_id``.
+* ``lifecycle.reinforce`` looks up ``get_maturation(fiber.id)`` with an id read
+  back from the DB (underscore form), so those 1277 rows were never found:
+  ALL 77 rehearsed rows and ALL 9 semantic rows were underscore-form, and zero
+  dash-form rows had ever been rehearsed.
+* No rehearsals => the EPISODIC->SEMANTIC spacing gate can never be met =>
+  consolidation_ratio 0.0037 and "all memories still episodic" after months.
+* ``extract_patterns`` keys maturations by ``fiber_id`` and tests ``f.id in
+  maturations``, so the same rows were invisible to pattern extraction too.
+* Repair was impossible from inside: the existence check missed, the insert
+  branch then collided with the row's already-underscore record id, and
+  ``save_maturation``'s blanket ``except Exception`` swallowed it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from surreal_memory.engine.memory_stages import MaturationRecord, MemoryStage
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
+from surreal_memory.storage.surrealdb.maturation import SurrealDBMaturationMixin
+
+_DASH = "0019e251-94df-4a6b-b446-72c76a083635"
+_UNDERSCORE = "0019e251_94df_4a6b_b446_72c76a083635"
+
+
+class _FakeMaturationStore(SurrealDBMaturationMixin):
+    """In-memory stand-in that mimics SurrealDB's field/record-id semantics.
+
+    Rows are keyed by record id (which the real engine enforces as a primary key),
+    so an insert onto an occupied id raises — exactly the collision that used to be
+    swallowed. ``_query`` understands only the mixin's own WHERE shapes.
+    """
+
+    def __init__(self, brain_id: str = "default") -> None:
+        self._brain = brain_id
+        self.rows: dict[str, dict] = {}
+        conn = MagicMock()
+        conn.merge = AsyncMock(side_effect=self._merge)
+        conn.insert = AsyncMock(side_effect=self._insert)
+        self._conn = conn
+
+    async def _merge(self, record_id: str, data: dict) -> None:
+        self.rows[record_id].update(data)
+
+    async def _insert(self, table: str, data: dict) -> None:
+        rid = f"{table}:{data['id']}"
+        if rid in self.rows:
+            raise RuntimeError(f"Database record `{rid}` already exists")
+        row = dict(data)
+        row["id"] = rid
+        self.rows[rid] = row
+
+    def seed_legacy_row(self, fiber_id: str, **overrides: object) -> str:
+        """Insert a row the way the pre-fix code did: raw field, folded record id."""
+        rid = f"maturation:{self._brain}_{_to_surreal_id(fiber_id)}"
+        self.rows[rid] = {
+            "id": rid,
+            "fiber_id": fiber_id,
+            "brain_id": self._brain,
+            "stage": "episodic",
+            "stage_entered_at": "2026-06-20T00:00:00Z",
+            "rehearsal_count": 0,
+            "reinforcement_timestamps": [],
+            **overrides,
+        }
+        return rid
+
+    def _ensure_conn(self) -> MagicMock:
+        return self._conn
+
+    def _get_brain_id(self) -> str:
+        return self._brain
+
+    async def _query(self, sql: str, **params: object) -> list[dict]:
+        """Model the three WHERE shapes the mixin issues, brain-scoped."""
+        candidates = [r for r in self.rows.values() if r["brain_id"] == params["brain_id"]]
+        if "sid" in params:  # record-id probe
+            candidates = [r for r in candidates if r["id"] == f"maturation:{params['sid']}"]
+        elif "fiber_id" in params:  # field probe (brain-rename fallback)
+            wanted = (params.get("fiber_id"), params.get("legacy_fiber_id"))
+            candidates = [r for r in candidates if r["fiber_id"] in wanted]
+        else:  # find_maturations filters
+            if "stage" in params:
+                candidates = [r for r in candidates if r["stage"] == params["stage"]]
+            if "min_rc" in params:
+                candidates = [r for r in candidates if r["rehearsal_count"] >= params["min_rc"]]
+        return [dict(r) for r in candidates]
+
+
+@pytest.mark.asyncio
+async def test_write_then_read_roundtrips_a_dash_form_id() -> None:
+    """The exact BuildFiberStep path: write with a dash-form uuid4, read it back."""
+    store = _FakeMaturationStore()
+
+    await store.save_maturation(
+        MaturationRecord(fiber_id=_DASH, brain_id="default", stage=MemoryStage.EPISODIC)
+    )
+    found = await store.get_maturation(_DASH)
+
+    assert found is not None
+    assert found.stage is MemoryStage.EPISODIC
+
+
+@pytest.mark.asyncio
+async def test_both_id_forms_resolve_to_the_same_row() -> None:
+    """Dash and underscore spellings must hit one row, not two."""
+    store = _FakeMaturationStore()
+
+    await store.save_maturation(
+        MaturationRecord(fiber_id=_DASH, brain_id="default", stage=MemoryStage.EPISODIC)
+    )
+
+    by_dash = await store.get_maturation(_DASH)
+    by_underscore = await store.get_maturation(_UNDERSCORE)
+
+    assert len(store.rows) == 1
+    assert by_dash is not None
+    assert by_underscore is not None
+    assert by_dash == by_underscore
+
+
+@pytest.mark.asyncio
+async def test_stored_field_uses_the_form_the_fiber_table_uses() -> None:
+    """The persisted field must match ``fiber:<id>`` or no join can ever succeed."""
+    store = _FakeMaturationStore()
+
+    await store.save_maturation(MaturationRecord(fiber_id=_DASH, brain_id="default"))
+
+    (row,) = store.rows.values()
+    assert row["fiber_id"] == _UNDERSCORE
+    assert row["id"] == f"maturation:default_{_UNDERSCORE}"
+
+
+@pytest.mark.asyncio
+async def test_rehearsal_lands_on_a_legacy_dash_form_row() -> None:
+    """THE promotion bug: reinforce() looks up by the DB (underscore) form.
+
+    Pre-fix the legacy row was invisible, so ``rehearse`` never ran and the
+    3-distinct-days gate to SEMANTIC could never be satisfied.
+    """
+    store = _FakeMaturationStore()
+    rid = store.seed_legacy_row(_DASH)
+
+    record = await store.get_maturation(_UNDERSCORE)
+    assert record is not None, "legacy dash-form row must be reachable by the fiber's DB id"
+
+    await store.save_maturation(record.rehearse())
+
+    assert len(store.rows) == 1
+    assert store.rows[rid]["rehearsal_count"] == 1
+    # ...and the write self-heals the field to the canonical form.
+    assert store.rows[rid]["fiber_id"] == _UNDERSCORE
+
+
+@pytest.mark.asyncio
+async def test_save_over_legacy_row_updates_instead_of_colliding() -> None:
+    """Pre-fix this took the insert branch and died on the record-id collision."""
+    store = _FakeMaturationStore()
+    rid = store.seed_legacy_row(_DASH, rehearsal_count=4)
+
+    await store.save_maturation(
+        MaturationRecord(
+            fiber_id=_UNDERSCORE,
+            brain_id="default",
+            stage=MemoryStage.SEMANTIC,
+            rehearsal_count=5,
+        )
+    )
+
+    assert len(store.rows) == 1
+    assert store.rows[rid]["stage"] == "semantic"
+    assert store.rows[rid]["rehearsal_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_find_maturations_returns_ids_that_join_to_fibers() -> None:
+    """``extract_patterns`` does ``f.id in maturations`` — the keys must match."""
+    store = _FakeMaturationStore()
+    store.seed_legacy_row(_DASH)
+    store.seed_legacy_row("aaaa1111-2222-3333-4444-555566667777")
+
+    records = await store.find_maturations()
+
+    # Fiber ids as _row_to_fiber hands them out (record-id suffix, underscore form).
+    fiber_ids = {_UNDERSCORE, "aaaa1111_2222_3333_4444_555566667777"}
+    assert {m.fiber_id for m in records} == fiber_ids
+
+
+@pytest.mark.asyncio
+async def test_backfill_skips_fibers_that_already_have_a_legacy_row() -> None:
+    """Pre-fix the skip check missed and the resulting insert collided silently."""
+
+    class _Fiber:
+        def __init__(self, fid: str) -> None:
+            self.id = fid
+            self.time_start = None
+            self.created_at = None
+
+    class _WithFibers(_FakeMaturationStore):
+        async def get_fibers(self, limit: int = 0) -> list[_Fiber]:
+            return [_Fiber(_UNDERSCORE)]
+
+    store = _WithFibers()
+    store.seed_legacy_row(_DASH)
+
+    counts = await store.backfill_maturations()
+
+    assert counts["skipped"] == 1
+    assert len(store.rows) == 1

--- a/tests/unit/test_surface_path_and_decay.py
+++ b/tests/unit/test_surface_path_and_decay.py
@@ -1,0 +1,342 @@
+"""Regression tests for two cwd/bookkeeping defects.
+
+D1: the resolved knowledge-surface path depended on the shell's cwd, because the
+global config dir ``~/.surrealmemory`` matched the project marker of the same name
+and promoted ``$HOME`` to a "project root".
+
+D2: ``Synapse.decay()`` recorded nothing, so every decay run re-processed (and
+re-decayed) the same synapses. Decay must not advance ``last_activated``, which
+means "last fired".
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from surreal_memory.core.synapse import LAST_DECAYED_KEY, Synapse, SynapseType
+from surreal_memory.surface.resolver import (
+    detect_project_root,
+    get_surface_path,
+    load_surface_text,
+    save_surface_text,
+)
+from surreal_memory.utils.timeutils import utcnow
+
+# ── D1: surface path must not depend on cwd ────────────
+
+
+class TestProjectRootDetection:
+    """detect_project_root must not mistake the home directory for a project."""
+
+    def test_home_with_global_config_dir_is_not_a_project_root(self, tmp_path: Path) -> None:
+        """The live bug: ~/.surrealmemory made $HOME look like a project root."""
+        home = tmp_path / "home"
+        global_dir = home / ".surrealmemory"
+        global_dir.mkdir(parents=True)
+
+        with (
+            patch("surreal_memory.surface.resolver.Path.cwd", return_value=home),
+            patch("surreal_memory.surface.resolver.Path.home", return_value=home),
+            patch(
+                "surreal_memory.unified_config.get_surrealmemory_dir",
+                return_value=global_dir,
+            ),
+        ):
+            assert detect_project_root() is None
+
+    def test_relocated_global_config_dir_is_not_a_project_root(self, tmp_path: Path) -> None:
+        """SURREAL_MEMORY_DIR elsewhere must not promote its parent either."""
+        home = tmp_path / "home"
+        home.mkdir()
+        data_dir = tmp_path / "srv" / "data"
+        global_dir = data_dir / ".surrealmemory"
+        global_dir.mkdir(parents=True)
+
+        with (
+            patch("surreal_memory.surface.resolver.Path.cwd", return_value=data_dir),
+            patch("surreal_memory.surface.resolver.Path.home", return_value=home),
+            patch(
+                "surreal_memory.unified_config.get_surrealmemory_dir",
+                return_value=global_dir,
+            ),
+        ):
+            assert detect_project_root() is None
+
+    def test_project_owned_nm_dir_is_still_a_project_root(self, tmp_path: Path) -> None:
+        """Per-project surfaces stay supported — only the global dir is excluded."""
+        home = tmp_path / "home"
+        global_dir = home / ".surrealmemory"
+        global_dir.mkdir(parents=True)
+        project = home / "repos" / "myproject"
+        (project / ".surrealmemory").mkdir(parents=True)
+
+        with (
+            patch("surreal_memory.surface.resolver.Path.cwd", return_value=project),
+            patch("surreal_memory.surface.resolver.Path.home", return_value=home),
+            patch(
+                "surreal_memory.unified_config.get_surrealmemory_dir",
+                return_value=global_dir,
+            ),
+        ):
+            assert detect_project_root() == project
+
+    def test_repo_under_home_is_still_detected(self, tmp_path: Path) -> None:
+        """A .git checkout below home is a project; the walk stops at home."""
+        home = tmp_path / "home"
+        (home / ".surrealmemory").mkdir(parents=True)
+        repo = home / "repos" / "checkout"
+        (repo / ".git").mkdir(parents=True)
+        nested = repo / "src" / "pkg"
+        nested.mkdir(parents=True)
+
+        with (
+            patch("surreal_memory.surface.resolver.Path.cwd", return_value=nested),
+            patch("surreal_memory.surface.resolver.Path.home", return_value=home),
+            patch(
+                "surreal_memory.unified_config.get_surrealmemory_dir",
+                return_value=home / ".surrealmemory",
+            ),
+        ):
+            assert detect_project_root() == repo
+
+
+class TestSurfacePathConsistency:
+    """Generator (write) and doctor (read) must resolve the same file."""
+
+    def test_write_from_home_lands_on_the_global_surface(self, tmp_path: Path) -> None:
+        """`surface generate` from ~ must not write ~/.surrealmemory/surface.nm."""
+        home = tmp_path / "home"
+        global_dir = home / ".surrealmemory"
+        global_dir.mkdir(parents=True)
+
+        with (
+            patch("surreal_memory.surface.resolver.Path.cwd", return_value=home),
+            patch("surreal_memory.surface.resolver.Path.home", return_value=home),
+            patch(
+                "surreal_memory.unified_config.get_surrealmemory_dir",
+                return_value=global_dir,
+            ),
+        ):
+            write_path = get_surface_path("default", for_write=True)
+
+        assert write_path == global_dir / "surfaces" / "default.nm"
+        assert write_path != global_dir / "surface.nm"
+
+    def test_generate_from_home_then_read_from_repo_finds_the_file(self, tmp_path: Path) -> None:
+        """The false alarm: doctor in a repo said "not generated yet" after a ~ run."""
+        home = tmp_path / "home"
+        global_dir = home / ".surrealmemory"
+        global_dir.mkdir(parents=True)
+        repo = home / "repos" / "checkout"
+        (repo / ".git").mkdir(parents=True)
+
+        cfg_patch = patch(
+            "surreal_memory.unified_config.get_surrealmemory_dir",
+            return_value=global_dir,
+        )
+
+        # Generate from the home directory...
+        with (
+            patch("surreal_memory.surface.resolver.Path.cwd", return_value=home),
+            patch("surreal_memory.surface.resolver.Path.home", return_value=home),
+            cfg_patch,
+        ):
+            written = save_surface_text("# surface", "default")
+
+        # ...then run the doctor check from a repo checkout.
+        with (
+            patch("surreal_memory.surface.resolver.Path.cwd", return_value=repo),
+            patch("surreal_memory.surface.resolver.Path.home", return_value=home),
+            cfg_patch,
+        ):
+            read_path = get_surface_path("default")
+            assert read_path == written
+            assert read_path.exists()
+            assert load_surface_text("default") == "# surface"
+
+    def test_project_surface_round_trips_within_the_project(self, tmp_path: Path) -> None:
+        """Inside a project, write then read resolve to the project-level file."""
+        home = tmp_path / "home"
+        global_dir = home / ".surrealmemory"
+        global_dir.mkdir(parents=True)
+        project = home / "repos" / "myproject"
+        (project / ".git").mkdir(parents=True)
+
+        with (
+            patch("surreal_memory.surface.resolver.Path.cwd", return_value=project),
+            patch("surreal_memory.surface.resolver.Path.home", return_value=home),
+            patch(
+                "surreal_memory.unified_config.get_surrealmemory_dir",
+                return_value=global_dir,
+            ),
+        ):
+            written = save_surface_text("# project surface", "default")
+            assert written == project / ".surrealmemory" / "surface.nm"
+            assert get_surface_path("default") == written
+            assert load_surface_text("default") == "# project surface"
+
+
+# ── D2: decay must bookmark itself, not fake activity ──
+
+
+def _make_synapse(
+    weight: float = 1.0,
+    *,
+    activated_hours_ago: float | None = None,
+    created_hours_ago: float = 100.0,
+) -> Synapse:
+    """Build a synapse with controlled timestamps."""
+    now = utcnow()
+    synapse = Synapse.create(
+        source_id="n1",
+        target_id="n2",
+        type=SynapseType.RELATED_TO,
+        weight=weight,
+    )
+    # A synapse cannot have fired before it existed — keep fixtures coherent so the
+    # newest-stamp semantics of decay_reference_time are exercised, not fought.
+    age_hours = max(created_hours_ago, activated_hours_ago or 0.0)
+    return replace(
+        synapse,
+        created_at=now - timedelta(hours=age_hours),
+        last_activated=(
+            None if activated_hours_ago is None else now - timedelta(hours=activated_hours_ago)
+        ),
+    )
+
+
+class TestDecayBookmark:
+    """decay() records when it ran without touching last_activated."""
+
+    def test_decay_does_not_advance_last_activated(self) -> None:
+        """last_activated means "last fired" — a decay pass is not a firing."""
+        synapse = _make_synapse(activated_hours_ago=48)
+
+        decayed = synapse.decay(factor=0.9)
+
+        assert decayed.last_activated == synapse.last_activated
+
+    def test_decay_leaves_never_activated_synapse_unactivated(self) -> None:
+        """A synapse that never fired must not gain a last_activated from decay."""
+        synapse = _make_synapse(activated_hours_ago=None)
+
+        assert synapse.decay(factor=0.9).last_activated is None
+
+    def test_decay_records_last_decayed(self) -> None:
+        before = utcnow()
+        synapse = _make_synapse()
+
+        decayed = synapse.decay(factor=0.9)
+
+        assert decayed.last_decayed is not None
+        assert before <= decayed.last_decayed <= utcnow()
+        assert decayed.weight == 0.9
+
+    def test_decay_accepts_explicit_timestamp(self) -> None:
+        """The decay pass stamps one reference time across the whole run."""
+        stamp = utcnow() - timedelta(hours=3)
+        synapse = _make_synapse()
+
+        assert synapse.decay(factor=0.5, now=stamp).last_decayed == stamp
+
+    def test_undecayed_synapse_has_no_bookmark(self) -> None:
+        assert _make_synapse().last_decayed is None
+
+    def test_decay_does_not_mutate_original_metadata(self) -> None:
+        """Frozen dataclass: the decayed copy must not share the source dict."""
+        synapse = replace(_make_synapse(), metadata={"_dedup": True})
+
+        decayed = synapse.decay(factor=0.9)
+
+        assert synapse.metadata == {"_dedup": True}
+        assert decayed.metadata["_dedup"] is True
+        assert LAST_DECAYED_KEY in decayed.metadata
+
+    def test_repeated_decay_refreshes_the_bookmark(self) -> None:
+        first_stamp = utcnow() - timedelta(days=2)
+        second_stamp = utcnow() - timedelta(days=1)
+        synapse = _make_synapse()
+
+        twice = synapse.decay(factor=0.9, now=first_stamp).decay(factor=0.9, now=second_stamp)
+
+        assert twice.last_decayed == second_stamp
+
+    def test_bookmark_accepts_datetime_value_from_storage(self) -> None:
+        """SurrealDB decodes object fields into datetimes, not ISO strings."""
+        stamp = utcnow() - timedelta(hours=5)
+        synapse = replace(_make_synapse(), metadata={LAST_DECAYED_KEY: stamp})
+
+        assert synapse.last_decayed == stamp
+
+    def test_corrupt_bookmark_reads_as_never_decayed(self) -> None:
+        """A bad value must degrade, not raise in the middle of a decay run."""
+        for bad in ("not-a-date", 12345, None):
+            synapse = replace(_make_synapse(), metadata={LAST_DECAYED_KEY: bad})
+            assert synapse.last_decayed is None
+
+    def test_time_decay_writes_no_bookmark(self) -> None:
+        """time_decay is a read-side estimate; its result is not persisted."""
+        synapse = _make_synapse(activated_hours_ago=1440)
+
+        estimated = synapse.time_decay()
+
+        assert estimated.last_decayed is None
+        assert estimated.last_activated == synapse.last_activated
+
+
+class TestDecayReferenceTime:
+    """decay_reference_time is the base callers should measure elapsed time from."""
+
+    def test_falls_back_to_created_at_when_never_used(self) -> None:
+        synapse = _make_synapse(activated_hours_ago=None, created_hours_ago=100)
+
+        assert synapse.decay_reference_time == synapse.created_at
+
+    def test_prefers_last_activated_over_created_at(self) -> None:
+        synapse = _make_synapse(activated_hours_ago=10, created_hours_ago=100)
+
+        assert synapse.decay_reference_time == synapse.last_activated
+
+    def test_prefers_last_decayed_when_it_is_newest(self) -> None:
+        stamp = utcnow() - timedelta(hours=1)
+        synapse = _make_synapse(activated_hours_ago=10).decay(factor=0.9, now=stamp)
+
+        assert synapse.decay_reference_time == stamp
+
+    def test_reinforcement_after_decay_resets_the_clock(self) -> None:
+        """A synapse used since its last decay must not be charged for that gap."""
+        decayed = _make_synapse(activated_hours_ago=100).decay(
+            factor=0.9, now=utcnow() - timedelta(hours=50)
+        )
+
+        reinforced = decayed.reinforce(0.05)
+
+        assert reinforced.decay_reference_time == reinforced.last_activated
+
+    def test_second_pass_over_the_same_window_has_nothing_to_decay(self) -> None:
+        """The 57k-rewrite regression: elapsed time must not be re-counted."""
+        run_at = utcnow()
+        synapse = _make_synapse(activated_hours_ago=240)  # 10 days stale
+
+        def elapsed_days(candidate: Synapse) -> float:
+            return (run_at - candidate.decay_reference_time).total_seconds() / 86400
+
+        first_elapsed = elapsed_days(synapse)
+        decayed = synapse.decay(factor=0.5, now=run_at)
+        second_elapsed = elapsed_days(decayed)
+
+        assert first_elapsed > 9.9
+        assert second_elapsed == 0.0
+
+    def test_naive_and_aware_timestamps_compare(self) -> None:
+        """Stores hand back both shapes; the property must not raise on mixing."""
+        aware = datetime.now(UTC) - timedelta(hours=2)
+        synapse = replace(_make_synapse(activated_hours_ago=None), last_activated=aware)
+
+        reference = synapse.decay_reference_time
+
+        assert reference.tzinfo is None
+        assert reference == aware.replace(tzinfo=None)

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
Six defects found by triaging a live 11.4k-neuron brain used daily for months whose consolidation ratio never moved. Every number here was measured against that brain.

## ⚠️ Purity will drop ~23 points on upgrade. That is the fix working.

| metric | before | after | after optional alias cleanup |
|---|---|---|---|
| connectivity | 1.0 (saturated) | **0.085** | 0.085 |
| diversity | 0.256 | 0.256 | **0.948** |
| purity | — | **−23** | **+14** |

Connectivity counted `alias` edges — dedup pointers with weight 0.0 that carry no meaning. They were **89.4% of all synapses** (137,871 of 154,252), so the metric measured plumbing. Stored purity/grade from before this release is **not comparable** with after; treat the upgrade as a new baseline.

## 1. Memories never matured

`Fiber.create` mints a dash-form uuid4; storage folds ids to underscore form; `maturation` stored whichever form the caller passed. The two never joined.

Live evidence — 1,920 maturation rows:

| | dash-form | underscore |
|---|---|---|
| total | 1,277 | 643 |
| ever rehearsed | **0** | 77 |
| promoted to semantic | **0** | 9 |

`get_maturation` returned `None`, `rehearse()` never ran, the spacing gate could never be met. Pattern extraction was blind to the same 1,277 fibers. A blanket `except Exception` logged the resulting collisions as "Skipping maturation save" for months.

Lookups now resolve via the **record id** — the one identifier canonical in both eras — so legacy rows heal on their next write, no migration required. Expect the first consolidation after upgrade to do more work: those 1,277 fibers become promotable.

## 2. Decay compounded

Nothing marked a synapse as decayed, so each run re-measured from `created_at` and re-multiplied an already-decayed weight — quadratic in run count (ten daily runs applied ~55 days of decay, not 10). Now bills only the interval since `_last_decayed`. The exponents telescope, so decay per day of wall-clock time matches the documented curve.

**Weights fade slower than in previous builds** — the compounding was the bug. Rows with nothing to bill are skipped, removing ~57k pointless rewrites per run.

## 3. Dedup re-inserted the same edge every run

2,375 distinct pairs had produced 144,565 rows, growing ~40k/day. Alias edges now carry a deterministic per-pair id, so consolidation is idempotent.

The eligibility gate still measures from `last_activated` deliberately — gating on the bookmark would reset the clock each run and freeze decay permanently on any schedule firing more often than `min_age_days`. There is a test for that.

## 4–6. Consistency and false alarms

- **Connectivity contradicted itself** across `smem health`, `smem_stats`, the maintenance handler and topology analysis. One shared definition now.
- **Surface path depended on cwd**: `$HOME` was classified as a project root because it holds the global `.surrealmemory/`, so `doctor` and the generator resolved different files. Project-level surfaces still work.
- **Warning texts collided units** — a 0-1 score paired with a raw "target 3-8" reads as "far below" when the raw ratio was 13.5, far above.
- `LOW_DIVERSITY` no longer fires on brains using many types. This brain uses **17**; the warning claiming "1 of 8" was reading an empty scope.

## Review found two fixes shipping as dead code — fixed before this PR

An adversarial review caught that `alias_edges.py` was imported by nothing and the decay bookmark was written but never read. CI would have been green while the ~40k/day growth continued. Both are now wired, with tests that fail if either producer reverts to a direct `Synapse.create`.

## Test plan

- [x] `pytest tests/unit` — 6718 passed, 48 skipped
- [x] New: maturation id normalisation, connectivity semantic-only, alias-edge idempotence, decay bookmark, surface path, connectivity consistency
- [x] Maturation fix proven RED against pre-fix code: all three failure modes reproduce
- [x] Alias idempotence proven by driving the real `_dedup` and `CreateAnchorStep` three times over one pair → 1 row
- [x] `ruff check` / `ruff format --check` clean
- [x] Live DB read-only throughout; `SELECT id, name FROM brain` returns only `default`
