### PR TITLE
fix(reasoning): scope mining and the privacy wipe by brain name, not the record UUID

### DIFF
--- a/src/surreal_memory/server/routes/reasoning_training.py
+++ b/src/surreal_memory/server/routes/reasoning_training.py
@@ -63,6 +63,31 @@ _mining_tasks: dict[str, asyncio.Task[None]] = {}
 _mining_states: dict[str, dict[str, Any]] = {}
 
 
+def _brain_scope(brain: Brain) -> str:
+    """Return the key every reasoning row is scoped by: the brain NAME.
+
+    Never ``brain.id``. That attribute carries the brain record's UUID primary
+    key, while every reasoning row -- traces, pattern fibers, their neurons and
+    synapses -- is written under the brain *name*. Passing the UUID into
+    ``create_isolated_storage()`` binds the whole mining job to a scope nothing
+    else reads, so the patterns are mined into a brain recall never sees.
+
+    Measured on the live brain before this was fixed: 196 pattern fibers,
+    92 neurons, 84 synapses and 6070 reasoning traces stranded under the UUID
+    while 10905 traces sat under the name.
+
+    Deliberately does NOT consult ``storage.brain_id``: that reports whatever the
+    shared singleton is currently bound to, which is the same class of ambient
+    coupling this function exists to remove. ``brain`` comes from the request's
+    own dependency, so its name is authoritative here.
+
+    One helper, used by every endpoint in this router, so the derivations cannot
+    drift apart again -- which is how the status endpoint ended up correct while
+    mining and the privacy wipe stayed wrong.
+    """
+    return brain.name
+
+
 def _idle_mining_state() -> dict[str, Any]:
     return {
         "running": False,
@@ -265,11 +290,7 @@ async def get_status(
 
     config = get_config()
     rt = config.reasoning_training
-    # Rows are scoped by the brain *name*, never by the brain record's UUID
-    # primary key: passing brain.id into create_isolated_storage() bound the whole
-    # mining job to a UUID scope, so every mined neuron/fiber landed in a brain
-    # that recall never reads.
-    brain_id = storage.brain_id or brain.name
+    brain_id = _brain_scope(brain)
 
     stats = await storage.get_reasoning_stats(brain_id)
     by_model_traces: dict[str, Any] = stats.get("by_model", {})
@@ -587,7 +608,11 @@ async def trigger_mining(
         # Privacy: never scan ~/.claude transcripts unless mining is enabled.
         raise HTTPException(status_code=400, detail="Mining is disabled; enable it first")
 
-    existing = _mining_tasks.get(brain.id)
+    # Scope on the NAME. Keying the job on brain.id also made the status endpoint
+    # -- which reads by name -- miss a running job and report idle throughout.
+    scope = _brain_scope(brain)
+
+    existing = _mining_tasks.get(scope)
     if existing is not None and not existing.done():
         raise HTTPException(status_code=409, detail="A mining run is already in progress")
 
@@ -597,9 +622,9 @@ async def trigger_mining(
 
     state = _idle_mining_state()
     state.update(running=True, started_at=utcnow().isoformat(), dry_run=body.dry_run)
-    _mining_states[brain.id] = state
-    _mining_tasks[brain.id] = asyncio.create_task(
-        _run_mining(brain.id, body.backfill, body.dry_run, models)
+    _mining_states[scope] = state
+    _mining_tasks[scope] = asyncio.create_task(
+        _run_mining(scope, body.backfill, body.dry_run, models)
     )
     return MineResponse(status="started", mining=MiningJobState(**state))
 
@@ -712,6 +737,11 @@ async def delete_traces_by_model(
     brain: Annotated[Brain, Depends(get_brain)],
     model: str = Query(..., description="Delete all staged reasoning traces for this model"),
 ) -> DeleteResponse:
-    """Privacy wipe: delete all staged reasoning traces for a model."""
-    deleted = await storage.delete_reasoning_traces_by_model(brain.id, model)
+    """Privacy wipe: delete all staged reasoning traces for a model.
+
+    Scoped by name: wiping under brain.id deleted from a scope the ingest path
+    does not write to, so the user was told traces were removed while the ones
+    under the brain name survived.
+    """
+    deleted = await storage.delete_reasoning_traces_by_model(_brain_scope(brain), model)
     return DeleteResponse(deleted=deleted)

--- a/tests/unit/test_route_reasoning_training.py
+++ b/tests/unit/test_route_reasoning_training.py
@@ -602,3 +602,117 @@ def test_delete_traces_by_model(client: TestClient, mock_storage: AsyncMock) -> 
 def test_delete_traces_requires_model(client: TestClient) -> None:
     resp = client.request("DELETE", "/api/dashboard/reasoning/traces")
     assert resp.status_code == 422  # missing required query param
+
+
+# ── Brain scoping: the NAME, never the record UUID ────────────────────────────
+
+# Every fixture above builds the brain with `brain_id=BRAIN_ID`, so its id and
+# its name are the same string -- which is precisely why these bugs shipped: the
+# tests could not tell the two apart. Production brains carry a UUID primary key
+# and a human name, so this fixture keeps them distinct.
+REAL_UUID = "00000000-0000-4000-8000-000000000001"
+
+
+@pytest.fixture
+def realistic_client(mock_storage: AsyncMock) -> TestClient:
+    """A client whose brain has a UUID id and a separate name, as in production."""
+    app = FastAPI()
+    app.include_router(router)
+    brain = Brain.create(BRAIN_ID, brain_id=REAL_UUID)
+    assert brain.id != brain.name, "fixture must distinguish the UUID from the name"
+    app.dependency_overrides[get_storage] = lambda: mock_storage
+    app.dependency_overrides[get_brain] = lambda: brain
+    return TestClient(app)
+
+
+class TestBrainScopeIsTheName:
+    """Reasoning rows are written under the brain NAME; the UUID scope is empty.
+
+    Measured on the live brain before the fix: 196 pattern fibers, 92 neurons,
+    84 synapses and 6070 traces stranded under the UUID, while 10905 traces sat
+    under the name.
+    """
+
+    def test_scope_is_the_name_not_the_uuid(self) -> None:
+        brain = Brain.create(BRAIN_ID, brain_id=REAL_UUID)
+        assert rt_module._brain_scope(brain) == BRAIN_ID
+        assert rt_module._brain_scope(brain) != REAL_UUID
+
+    def test_scope_does_not_depend_on_ambient_storage_state(self) -> None:
+        """It must not read storage.brain_id -- that is the coupling being removed."""
+        import inspect
+
+        src = inspect.getsource(rt_module._brain_scope)
+        assert "storage" not in src.split('"""')[-1]
+
+    def test_privacy_wipe_deletes_under_the_name(
+        self, realistic_client: TestClient, mock_storage: AsyncMock
+    ) -> None:
+        """The wipe used the UUID, so traces stored under the name survived it."""
+        mock_storage.brain_id = "default"
+
+        resp = realistic_client.request(
+            "DELETE", "/api/dashboard/reasoning/traces", params={"model": "claude-fable-5"}
+        )
+
+        assert resp.status_code == 200
+        scope_used = mock_storage.delete_reasoning_traces_by_model.await_args.args[0]
+        assert scope_used == BRAIN_ID
+        assert scope_used != REAL_UUID
+
+    def test_mining_job_is_keyed_by_the_name_so_status_can_see_it(
+        self, realistic_client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Keying on the UUID made the status endpoint report idle mid-run."""
+        monkeypatch.setattr(
+            "surreal_memory.unified_config.get_config",
+            lambda: _cfg(tmp_path, mining_enabled=True),
+        )
+        monkeypatch.setattr(rt_module, "_run_mining", AsyncMock(return_value=None))
+
+        resp = realistic_client.post("/api/dashboard/reasoning/mine", json={})
+
+        assert resp.status_code in (200, 202)
+        assert BRAIN_ID in rt_module._mining_states
+        assert REAL_UUID not in rt_module._mining_states
+        assert BRAIN_ID in rt_module._mining_tasks
+        assert REAL_UUID not in rt_module._mining_tasks
+
+    def test_the_mined_scope_passed_to_the_job_is_the_name(
+        self, realistic_client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """create_isolated_storage(scope) binds the job's writes -- it must get the name."""
+        monkeypatch.setattr(
+            "surreal_memory.unified_config.get_config",
+            lambda: _cfg(tmp_path, mining_enabled=True),
+        )
+        spy = AsyncMock(return_value=None)
+        monkeypatch.setattr(rt_module, "_run_mining", spy)
+
+        realistic_client.post("/api/dashboard/reasoning/mine", json={})
+
+        assert spy.await_args.args[0] == BRAIN_ID
+
+    def test_no_endpoint_scopes_on_the_record_uuid(self) -> None:
+        """Source guard: `brain.id` must never be used as a scope in this router.
+
+        The status endpoint was fixed while mining and the privacy wipe were
+        missed. A source-level assertion catches the next one that drifts.
+        """
+        import ast
+        import pathlib
+
+        src = pathlib.Path(rt_module.__file__).read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        offenders = [
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Attribute)
+            and node.attr == "id"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "brain"
+        ]
+        assert not offenders, (
+            f"reasoning_training.py scopes on brain.id (the record UUID) at lines {offenders}; "
+            "use _brain_scope(brain, storage) instead — reasoning rows live under the brain name."
+        )


### PR DESCRIPTION
## Summary

- Reasoning mining wrote into a brain scope the application never reads, so learned patterns were invisible to recall, injection and the dashboard.
- The mining status endpoint reported `idle` for the whole duration of a run.
- `DELETE /traces` — the privacy wipe — deleted from a scope the ingest path never writes to, reporting success while the traces remained.
- Adds a source-level guard so a future endpoint that scopes on `brain.id` fails the suite.

## Why

`brain.id` is the brain record's UUID primary key. Every reasoning row — staged traces, pattern fibers, their neurons and synapses — is written under the brain **name**. The status endpoint already resolved the name and carried a comment explaining why; two sibling endpoints in the same router were missed:

- `trigger_mining` passed `brain.id` into `create_isolated_storage()`, binding the entire background job to the UUID scope. Everything it mined — pattern fibers, concept neurons, `EFFECTIVE_FOR` synapses — landed where nothing queries.
- The same value keyed `_mining_states` / `_mining_tasks`, while `GET /status` reads those by name, so a running job was never visible to the status endpoint.
- `delete_traces_by_model` wiped under the UUID, leaving every trace the ingest path had written under the name. The endpoint returned a success count that did not correspond to what a user asked to delete.

All three now resolve through a single `_brain_scope(brain)` helper returning the name. It deliberately does **not** consult `storage.brain_id`: that reports whatever the shared storage singleton is currently bound to, which is the same ambient coupling this change removes.

**Why the existing tests could not catch this.** Every fixture in `test_route_reasoning_training.py` constructed its brain with `brain_id=BRAIN_ID`, making the UUID and the name the same string — the two code paths were indistinguishable. The new fixture keeps them distinct, as a real brain does.

## Test plan

- [x] `pytest tests/ -m "not stress"` — 6893 passed, 44 skipped, 1 xfailed.
- [x] `tests/unit/test_route_reasoning_training.py` — 38 passed, including 6 new scope tests.
- [x] `ruff check src/ tests/` clean · `ruff format --check src/ tests/` clean.
- [x] `mypy src/ --ignore-missing-imports` clean.
- [x] `test_no_endpoint_scopes_on_the_record_uuid` — AST assertion over the router source; fails if any handler scopes on `brain.id` again.

## Scope

Code only. Rows already written under the UUID scope by the previous behaviour are a data-migration concern and are not touched here; this PR stops new rows from landing in the wrong scope.