### PR TITLE
fix(maturation): reach orphaned rows whose brain no longer exists

### DIFF
--- a/src/surreal_memory/storage/surrealdb/maturation.py
+++ b/src/surreal_memory/storage/surrealdb/maturation.py
@@ -210,14 +210,26 @@ class SurrealDBMaturationMixin:
         return [_canonicalised(_row_to_maturation(r)) for r in rows]
 
     async def cleanup_orphaned_maturations(self) -> int:
-        """Delete maturation rows whose fiber no longer exists."""
+        """Delete maturation rows whose fiber -- or whose whole brain -- is gone.
+
+        Two kinds of orphan, and the second used to be unreachable:
+
+        1. The row's brain still exists but its fiber does not (a fiber deleted
+           without a cascade). Found by comparing against that brain's fibers.
+        2. The row's *brain* no longer exists. Deleting a brain leaves its
+           maturation rows behind, and because this scan was scoped
+           ``WHERE brain_id = $brain_id`` it could only ever see rows belonging
+           to the brain being cleaned -- so rows from a deleted brain were
+           structurally unreachable and accumulated across every consolidation.
+
+        Returns:
+            Total rows removed across both kinds.
+        """
         brain_id = self._get_brain_id()
         existing_rows = await self._query(
             "SELECT id, fiber_id FROM maturation WHERE brain_id = $brain_id",
             brain_id=brain_id,
         )
-        if not existing_rows:
-            return 0
         fiber_rows = await self._query(
             "SELECT id FROM fiber WHERE brain_id = $brain_id",
             brain_id=brain_id,
@@ -226,13 +238,52 @@ class SurrealDBMaturationMixin:
 
         conn = self._ensure_conn()
         removed = 0
-        for row in existing_rows:
+        for row in existing_rows or []:
             fid = str(row.get("fiber_id", ""))
             if _to_surreal_id(fid) not in live_fibers and fid not in live_fibers:
                 rid = str(row.get("id", ""))
                 if rid:
                     await conn.delete(rid)
                     removed += 1
+
+        removed += await self._cleanup_brainless_maturations()
+        return removed
+
+    async def _cleanup_brainless_maturations(self) -> int:
+        """Delete maturation rows whose ``brain_id`` matches no surviving brain.
+
+        Scoped deliberately by *absence*: a brain-scoped query can never reach
+        these, which is why they accumulated. Brains are addressed by name, and
+        legacy rows may carry the record UUID, so both spellings count as alive.
+        """
+        brain_rows = await self._query("SELECT id, name FROM brain")
+        if not brain_rows:
+            # No brains readable: refuse to interpret that as "every row is an
+            # orphan" -- that would delete the entire table on a transient read.
+            return 0
+
+        alive: set[str] = set()
+        for r in brain_rows:
+            name = str(r.get("name") or "")
+            if name:
+                alive.add(name)
+            rid = str(r.get("id") or "").rsplit(":", 1)[-1].strip("`")
+            if rid:
+                alive.add(rid)
+                alive.add(rid.replace("_", "-"))
+
+        rows = await self._query("SELECT id, brain_id FROM maturation")
+        conn = self._ensure_conn()
+        removed = 0
+        for row in rows or []:
+            if str(row.get("brain_id", "")) in alive:
+                continue
+            rid = str(row.get("id", ""))
+            if rid:
+                await conn.delete(rid)
+                removed += 1
+        if removed:
+            logger.info("Removed %d maturation rows belonging to deleted brains", removed)
         return removed
 
     async def backfill_maturations(self) -> dict[str, int]:

--- a/tests/unit/test_maturation_orphan_cleanup.py
+++ b/tests/unit/test_maturation_orphan_cleanup.py
@@ -1,0 +1,170 @@
+"""`cleanup_orphaned_maturations` must also reach rows whose brain is gone.
+
+The scan was scoped ``WHERE brain_id = $brain_id``, so it could only ever see
+rows belonging to the brain being cleaned. Rows left behind by a *deleted* brain
+were therefore structurally unreachable: no consolidation could ever remove
+them, however many times it ran.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from surreal_memory.storage.surrealdb.maturation import SurrealDBMaturationMixin
+
+BRAIN = "default"
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.deleted: list[str] = []
+
+    async def delete(self, record_id: str) -> None:
+        self.deleted.append(record_id)
+
+
+class _Store(SurrealDBMaturationMixin):
+    """Drives the mixin against in-memory rows, mimicking the SurrealQL shapes."""
+
+    def __init__(
+        self,
+        maturations: list[dict[str, Any]],
+        fibers: list[dict[str, Any]],
+        brains: list[dict[str, Any]],
+    ) -> None:
+        self._maturations = maturations
+        self._fibers = fibers
+        self._brains = brains
+        self.conn = _FakeConn()
+
+    def _get_brain_id(self) -> str:
+        return BRAIN
+
+    def _ensure_conn(self) -> _FakeConn:
+        return self.conn
+
+    async def _query(self, query: str, **params: Any) -> list[dict[str, Any]]:
+        if "FROM brain" in query:
+            return list(self._brains)
+        if "FROM fiber" in query:
+            bid = params.get("brain_id")
+            return [f for f in self._fibers if f["brain_id"] == bid]
+        if "FROM maturation" in query:
+            if "brain_id = $brain_id" in query:
+                bid = params.get("brain_id")
+                return [m for m in self._maturations if m["brain_id"] == bid]
+            return list(self._maturations)
+        return []
+
+
+def _mat(rid: str, brain_id: str, fiber_id: str) -> dict[str, Any]:
+    return {"id": f"maturation:{rid}", "brain_id": brain_id, "fiber_id": fiber_id}
+
+
+class TestOrphanedByMissingFiber:
+    """The pre-existing behaviour must keep working."""
+
+    async def test_removes_a_row_whose_fiber_is_gone(self) -> None:
+        store = _Store(
+            maturations=[_mat("m1", BRAIN, "f1"), _mat("m2", BRAIN, "f2")],
+            fibers=[{"id": "fiber:f1", "brain_id": BRAIN}],
+            brains=[{"id": "brain:uuid-1", "name": BRAIN}],
+        )
+
+        removed = await store.cleanup_orphaned_maturations()
+
+        assert removed == 1
+        assert store.conn.deleted == ["maturation:m2"]
+
+    async def test_keeps_rows_whose_fiber_survives(self) -> None:
+        store = _Store(
+            maturations=[_mat("m1", BRAIN, "f1")],
+            fibers=[{"id": "fiber:f1", "brain_id": BRAIN}],
+            brains=[{"id": "brain:uuid-1", "name": BRAIN}],
+        )
+
+        assert await store.cleanup_orphaned_maturations() == 0
+        assert store.conn.deleted == []
+
+
+class TestOrphanedByDeletedBrain:
+    """The case a brain-scoped scan could never reach."""
+
+    async def test_removes_rows_belonging_to_a_deleted_brain(self) -> None:
+        store = _Store(
+            maturations=[
+                _mat("m1", BRAIN, "f1"),
+                _mat("dead1", "dead-brain-1", "gone-1"),
+                _mat("dead2", "dead-brain-2", "gone-2"),
+            ],
+            fibers=[{"id": "fiber:f1", "brain_id": BRAIN}],
+            brains=[{"id": "brain:uuid-1", "name": BRAIN}],
+        )
+
+        removed = await store.cleanup_orphaned_maturations()
+
+        assert removed == 2
+        assert sorted(store.conn.deleted) == ["maturation:dead1", "maturation:dead2"]
+
+    async def test_a_live_brain_addressed_by_its_record_uuid_is_not_an_orphan(self) -> None:
+        """Legacy rows may carry the record UUID; that brain is still alive."""
+        store = _Store(
+            maturations=[_mat("legacy", "uuid-1", "f1")],
+            fibers=[{"id": "fiber:f1", "brain_id": BRAIN}],
+            brains=[{"id": "brain:uuid-1", "name": BRAIN}],
+        )
+
+        assert await store.cleanup_orphaned_maturations() == 0
+        assert store.conn.deleted == []
+
+    async def test_underscore_spelling_of_a_record_uuid_also_counts_as_alive(self) -> None:
+        store = _Store(
+            maturations=[_mat("legacy", "uuid-1-2", "f1")],
+            fibers=[{"id": "fiber:f1", "brain_id": BRAIN}],
+            brains=[{"id": "brain:uuid_1_2", "name": BRAIN}],
+        )
+
+        assert await store.cleanup_orphaned_maturations() == 0
+
+    async def test_an_unreadable_brain_table_deletes_nothing(self) -> None:
+        """A transient read failure must not be read as 'every row is an orphan'."""
+        store = _Store(
+            maturations=[_mat("m1", "some-brain", "f1"), _mat("m2", "other", "f2")],
+            fibers=[],
+            brains=[],
+        )
+
+        removed = await store.cleanup_orphaned_maturations()
+
+        assert removed == 0
+        assert store.conn.deleted == []
+
+    async def test_both_orphan_kinds_are_counted_together(self) -> None:
+        store = _Store(
+            maturations=[
+                _mat("keep", BRAIN, "f1"),
+                _mat("nofiber", BRAIN, "vanished"),
+                _mat("nobrain", "dead-brain", "whatever"),
+            ],
+            fibers=[{"id": "fiber:f1", "brain_id": BRAIN}],
+            brains=[{"id": "brain:uuid-1", "name": BRAIN}],
+        )
+
+        removed = await store.cleanup_orphaned_maturations()
+
+        assert removed == 2
+        assert "maturation:keep" not in store.conn.deleted
+        assert sorted(store.conn.deleted) == ["maturation:nobrain", "maturation:nofiber"]
+
+
+@pytest.mark.parametrize("dead_count", [1, 5, 24])
+async def test_scales_to_however_many_dead_brains_exist(dead_count: int) -> None:
+    store = _Store(
+        maturations=[_mat(f"d{i}", f"dead-{i}", f"g{i}") for i in range(dead_count)],
+        fibers=[],
+        brains=[{"id": "brain:uuid-1", "name": BRAIN}],
+    )
+
+    assert await store.cleanup_orphaned_maturations() == dead_count


### PR DESCRIPTION
## Summary

- `cleanup_orphaned_maturations` could not remove maturation rows left behind by a **deleted brain**, so they accumulated with no way to clear them.
- The scan now removes rows whose `brain_id` matches no surviving brain, alongside the existing "fiber is gone" case.

## Why

The scan queried `SELECT id, fiber_id FROM maturation WHERE brain_id = $brain_id`. That restricts it to rows belonging to the brain currently being cleaned — which means a row whose brain has since been deleted is, by construction, invisible to it. Consolidation calls this on every maturation pass, so those rows survive every run indefinitely and there is no other code path that would collect them.

Two details matter for safety:

- **Brains are addressed by name, but legacy rows may carry the record UUID.** Both spellings are treated as alive, so a row pointing at a live brain by its UUID is never mistaken for an orphan.
- **An unreadable `brain` table returns zero.** Interpreting an empty read as "no brain exists" would classify every row in the table as an orphan and delete all of them; a transient read failure must not be able to empty the table.

Both orphan kinds are summed into the single return value, so the existing `Cleaned up N orphaned maturation records` log line already covers the new case.

## Test plan

- [x] `tests/unit/test_maturation_orphan_cleanup.py` — 10 new tests driving the mixin against in-memory rows: the pre-existing missing-fiber case, the deleted-brain case, a live brain addressed by UUID (both `-` and `_` spellings), the empty-`brain`-table guard, and both kinds counted together.
- [x] `pytest tests/ -m "not stress"` — 6897 passed, 44 skipped, 1 xfailed.
- [x] `ruff check src/ tests/` clean · `ruff format --check src/ tests/` clean.
- [x] `mypy src/ --ignore-missing-imports` clean.