### PR TITLE
feat: implement distill_use_llm, and report impossible embedding configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,94 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.0] — Patterns that read like advice
+
+`reasoning_training.distill_use_llm` has existed as a configuration field since reasoning
+training shipped. Nothing read it. Setting it changed the config file and nothing else —
+searching for the name found the dataclass attribute, `to_dict`, `from_dict` and the TOML
+writer, and no consumer anywhere. This release gives it an implementation.
+
+### What the flag now does
+
+A distilled pattern used to be named after its own mechanics. The title was the cluster's
+three most frequent reasoning moves (`debugging: restate-goal, gather-evidence, verify`)
+and the description was the first 200 characters of the medoid trace — a raw thinking
+fragment, usually cut mid-sentence. Serviceable as an identifier, useless as an
+explanation, and it is what `smem reasoning` displays and what injection ships to other
+models.
+
+With the flag on, a local model rewrites the prose:
+
+```
+title       Diagnose, Investigate, and Confirm Fix
+description Debug by restating the objective, gathering diagnostic evidence, then
+            confirming the resolution.
+strategy    1. Restate the problem to be solved.
+            2. Gather evidence — error messages, tracebacks, surrounding code.
+            3. Verify the problem no longer occurs.
+```
+
+It rewrites **only** prose. `model`, `category`, `confidence`, `frequency` and `signature`
+are untouched, and `signature` is derived from the cluster's trace hashes — so toggling
+the flag cannot fork a known pattern into a duplicate. Existing patterns keep their names;
+naming applies to patterns distilled from then on.
+
+### Traces do not leave the machine
+
+Trace content is raw model reasoning, so the endpoint is **loopback-only**. A remote
+address yields no namer and therefore no request at all — an invariant, not a default, and
+no setting relaxes it. Ingest-time redaction is upstream and can be switched off, so the
+transport guarantee has to stand on its own.
+
+Resolution order is `SURREAL_MEMORY_LLM_ENDPOINT`, then the new `distill_llm_endpoint`
+config key, then `SURREAL_MEMORY_EMBEDDING_ENDPOINT` — one local OpenAI-compatible server
+commonly serves both roles.
+
+### The model is borrowed, not kept
+
+Local model servers load a chat model on its first request and typically keep it resident
+with no idle timeout, so naming a handful of patterns would leave several gigabytes parked
+in VRAM indefinitely. Loading stays implicit — the first request pulls the model in — and
+`distill_llm_unload_cmd` releases it when the run ends, including when the run fails.
+
+The command is an **argv list executed without a shell**, so a model name can never become
+shell syntax; `{model}` is substituted, a part that is not plain command syntax voids the
+whole command, and it is read from the config file only, never from an API request. It
+fires only if the run actually issued a request, so a model something else loaded is left
+alone.
+
+### Failure is invisible
+
+Missing endpoint, missing `httpx`, refused connection, timeout, HTTP error, or a model that
+answers in prose instead of JSON — every one falls back to the mechanical naming.
+Distillation never fails because naming failed. Three consecutive failures trip a circuit
+breaker, so a dead endpoint costs three attempts rather than one timeout per cluster.
+
+Three failure modes that only a live model exposes are handled explicitly, because against
+a stubbed transport all of them look like success:
+
+- **A reasoning model spends its budget thinking first.** Too small a token allowance
+  returns an empty `content` with `finish_reason: "length"` rather than a short answer. The
+  budget now accommodates thinking, truncation is reported as its own diagnosis instead of
+  a generic parse failure, and servers that support it are asked to skip the thinking phase
+  (a server that rejects that request has it dropped after one attempt).
+- **A model asked for "numbered steps" answers with a JSON array**, not a string. Refusing
+  a good answer over its container type was wrong; a list of scalars is now joined into
+  lines.
+- **Markdown fences and surrounding chatter** are located rather than assumed away.
+
+### Added
+
+- `reasoning_training.distill_llm_model` — the chat model to name with.
+- `reasoning_training.distill_llm_endpoint` — loopback OpenAI-compatible base URL, for
+  deployments that cannot easily add environment variables.
+- `reasoning_training.distill_llm_unload_cmd` — argv run once after distillation.
+
+### Fixed
+
+- The npm and VS Code package lockfiles had drifted several releases behind their
+  `package.json` files; every package is back in version parity.
+
 ## [2.16.0] — Consolidation honesty
 
 Every counter in the consolidation report now measures what its name says, and three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,8 +88,35 @@ a stubbed transport all of them look like success:
   deployments that cannot easily add environment variables.
 - `reasoning_training.distill_llm_unload_cmd` — argv run once after distillation.
 
+### An impossible embedding configuration is now reported
+
+Every embedding provider guesses a dimension for a model it does not recognise — Gemini
+assumes 3072, the OpenAI-compatible providers 1536, Ollama 1024. Each guess is reasonable
+alone and dangerous in combination: aim a provider at another provider's model name and it
+confidently produces vectors of the wrong width, which the HNSW index then rejects on every
+write. `smem doctor` reported that configuration as **ok** as long as the provider's package
+was importable, and `smem_health` reported it as available.
+
+Two rules now run in `smem doctor`, in `smem_health` and at MCP startup:
+
+- **A hosted provider's catalogue is closed.** A model outside it is not "unlisted", it is a
+  request the API will refuse — reported together with the models that provider does serve.
+- **A catalogued model's dimension must match `embedding.dimension`**, since that is what the
+  vector index is built from.
+
+Deliberately silent where it cannot know: a local OpenAI-compatible server serves whatever
+files it was pointed at, so an unrecognised model name there is ordinary rather than
+suspect. Only an exact catalogue hit counts as knowing a dimension — a provider's fallback
+is a guess, and calling a configuration broken on the strength of a guess would flag every
+local model name and train everyone to ignore the check.
+
 ### Fixed
 
+- `probe_embedding_capability` promised in its docstring never to raise, and raised.
+  `importlib.util.find_spec("google.genai")` imports the parent package first, so on a
+  machine without `google` installed the probe died with `ModuleNotFoundError` instead of
+  answering "not installed" — in the one function whose job is to report that calmly, and
+  which `smem_health` and MCP startup both call.
 - The npm and VS Code package lockfiles had drifted several releases behind their
   `package.json` files; every package is back in version parity.
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,15 @@ Sync uses **Merkle delta** — only diffs travel, not the full brain.
 - **Fast bulk training** — `smem train` batches DB writes (one round-trip per N synapses via `add_synapses_batch`) and the `find_neurons` brain_id index is now used, so large docs stay cheap per chunk even on big brains (previously 7–15 s/chunk on a 68k-neuron brain; ~10× fewer DB ops/chunk). Shows live `tqdm` progress.
 - **Import adapters** — migrate from ChromaDB, Mem0, Cognee, Graphiti, LlamaIndex
 - **Reasoning training** (opt-in) — mine a model's own `thinking` from `~/.claude` transcripts, distill it into reusable reasoning-pattern fibers, and inject the learned strategies into other models' sessions (dashboard + `smem reasoning` CLI + `smem_reasoning` MCP tool). Off by default; traces are redacted before storage.
+- **LLM pattern naming** (opt-in, local-only) — by default a distilled pattern is named after its own mechanics (`debugging: restate-goal, gather-evidence, verify`) and described by a raw slice of the medoid trace. Point `distill_use_llm` at a **loopback** OpenAI-compatible endpoint and a local model rewrites the title, description and strategy into something readable, leaving identity and statistics untouched. A non-loopback endpoint is refused outright — reasoning traces never leave the machine — and any failure falls back to the mechanical naming. `distill_llm_unload_cmd` unloads the model once the run ends, so it does not sit in VRAM between runs:
+
+  ```toml
+  [reasoning_training]
+  distill_use_llm = true
+  distill_llm_model = "<a chat model your server serves>"
+  distill_llm_endpoint = "http://127.0.0.1:PORT/v1"   # loopback only
+  distill_llm_unload_cmd = ["<your-launcher>", "stop", "{model}"]
+  ```
 
 #### Lifecycle & Storage
 - **Memory consolidation** — episodic memories mature into semantic knowledge

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.13.0",
+  "version": "2.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "2.13.0",
+      "version": "2.17.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "2.13.0",
+  "version": "2.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "2.13.0",
+      "version": "2.17.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.16.0"
+version = "2.17.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.16.0"
+__version__ = "2.17.0"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/cli/doctor.py
+++ b/src/surreal_memory/cli/doctor.py
@@ -420,6 +420,26 @@ def _check_embedding_provider() -> dict[str, Any]:
     if module_name:
         try:
             importlib.import_module(module_name)
+            # An importable package says nothing about the configuration it is
+            # handed. A provider aimed at another provider's model silently
+            # assumes a dimension, and the vector index then rejects every
+            # write — so an incoherent triple is a failure, not an OK.
+            from surreal_memory.engine.embedding.capability import check_embedding_coherence
+
+            try:
+                configured_dim = int(getattr(config.embedding, "dimension", 0) or 0)
+            except (TypeError, ValueError):
+                configured_dim = 0
+            mismatch = check_embedding_coherence(
+                provider, str(config.embedding.model or ""), configured_dim
+            )
+            if mismatch is not None:
+                return {
+                    "name": "Embedding provider",
+                    "status": FAIL,
+                    "detail": mismatch.summary,
+                    "fix": mismatch.fix,
+                }
             return {
                 "name": "Embedding provider",
                 "status": OK,

--- a/src/surreal_memory/engine/embedding/capability.py
+++ b/src/surreal_memory/engine/embedding/capability.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -29,23 +30,138 @@ _PROVIDER_IMPORT: dict[str, tuple[str, str]] = {
 }
 
 
-def _dimension_for(provider: str, model: str) -> int | None:
-    """Best-effort dimension lookup without loading models or calling APIs."""
+# Providers whose model catalogue is fixed by the vendor: a name outside it is
+# not "unlisted", it is a request the API will refuse. Providers backed by an
+# OpenAI-compatible server are deliberately absent — a local server serves
+# whatever files it was pointed at, so arbitrary names there are normal.
+_CLOSED_CATALOGUE: frozenset[str] = frozenset({"gemini"})
+
+# Dimension a provider assumes when it meets a model it does not recognise.
+# These are the values the providers themselves fall back to.
+_FALLBACK_DIMENSION: dict[str, int] = {"gemini": 3072, "openai": 1536, "openrouter": 1536}
+
+
+@dataclass(frozen=True)
+class EmbeddingMismatch:
+    """A configuration that cannot work, with the reason and the way out."""
+
+    summary: str
+    fix: str
+
+    def __str__(self) -> str:
+        return self.summary
+
+
+def _find_spec_safely(module_name: str) -> object | None:
+    """``importlib.util.find_spec`` that answers instead of raising.
+
+    For a dotted name it imports the parent package first, so a missing parent
+    (``google`` for ``google.genai``) raises ModuleNotFoundError rather than
+    returning None — turning "is this installed?" into a crash, in the one
+    function whose whole job is to report that answer calmly.
+    """
+    try:
+        return importlib.util.find_spec(module_name)
+    except (ImportError, AttributeError, ValueError):
+        return None
+
+
+def _catalogue(provider: str) -> dict[str, int] | None:
+    """The provider's model -> dimension table, or None if it has no fixed one."""
     try:
         if provider == "gemini":
             from surreal_memory.engine.embedding.gemini_embedding import _MODEL_DIMENSIONS
 
-            return _MODEL_DIMENSIONS.get(model, 3072)
+            return dict(_MODEL_DIMENSIONS)
         if provider == "openai":
             from surreal_memory.engine.embedding.openai_embedding import _MODEL_DIMENSIONS
 
-            return _MODEL_DIMENSIONS.get(model, 1536)
+            return dict(_MODEL_DIMENSIONS)
         if provider == "openrouter":
             from surreal_memory.engine.embedding.openrouter_embedding import _MODEL_DIMENSIONS
 
-            return _MODEL_DIMENSIONS.get(model, 1536)
+            return dict(_MODEL_DIMENSIONS)
+        if provider == "ollama":
+            from surreal_memory.engine.embedding.ollama_embedding import _MODEL_DIMENSIONS
+
+            return dict(_MODEL_DIMENSIONS)
     except Exception:
         return None
+    return None
+
+
+def _known_dimension(provider: str, model: str) -> int | None:
+    """The dimension this model *is* known to have — never a guess.
+
+    Distinct from :func:`_dimension_for`, which answers "what will the provider
+    probably do". Validation may only act on knowledge: calling a config broken
+    because a fallback number disagreed would flag every local model name.
+    """
+    catalogue = _catalogue(provider)
+    if not catalogue or not model:
+        return None
+    return catalogue.get(model)
+
+
+def _dimension_for(provider: str, model: str) -> int | None:
+    """Best-effort dimension lookup without loading models or calling APIs."""
+    if provider not in _FALLBACK_DIMENSION:
+        return None
+    known = _known_dimension(provider, model)
+    return known if known is not None else _FALLBACK_DIMENSION[provider]
+
+
+def check_embedding_coherence(
+    provider: str, model: str, dimension: int
+) -> EmbeddingMismatch | None:
+    """Report a provider/model/dimension combination that cannot work.
+
+    Returns None when the configuration is coherent *or* when there is not
+    enough knowledge to judge it — an unknown model on an open-catalogue
+    provider is ordinary, not suspect.
+
+    Two things are caught:
+
+    * a model outside a hosted provider's fixed catalogue, which that API will
+      refuse whatever the rest of the configuration says;
+    * a catalogued model whose real dimension contradicts the configured one —
+      and the configured dimension is what the vector index is built from, so
+      every write would be rejected for a width the config itself asked for.
+
+    Never raises: a diagnostic that can crash is worse than no diagnostic.
+    """
+    provider = (provider or "").strip()
+    model = (model or "").strip()
+    if not provider or not model:
+        return None
+
+    if provider in _CLOSED_CATALOGUE:
+        catalogue = _catalogue(provider)
+        if catalogue and model not in catalogue:
+            served = ", ".join(sorted(catalogue)) or "(none)"
+            return EmbeddingMismatch(
+                summary=(
+                    f"provider {provider!r} does not serve model {model!r} (it serves: {served})"
+                ),
+                fix=(
+                    f"Set embedding.model to one of: {served} — or, if {model!r} is served by a"
+                    " local OpenAI-compatible endpoint, set embedding.provider to 'openai' and"
+                    " point SURREAL_MEMORY_EMBEDDING_ENDPOINT at it."
+                ),
+            )
+
+    known = _known_dimension(provider, model)
+    if known is not None and dimension and int(dimension) != known:
+        return EmbeddingMismatch(
+            summary=(
+                f"model {model!r} produces {known}-dimensional vectors but"
+                f" embedding.dimension is {int(dimension)}"
+            ),
+            fix=(
+                f"Set embedding.dimension to {known} (or 0 to derive it). A vector index built"
+                f" for {int(dimension)} dimensions rejects every write from this model."
+            ),
+        )
     return None
 
 
@@ -69,6 +185,9 @@ def probe_embedding_capability(config: Any) -> dict[str, Any]:
             provider = getattr(nested, "provider", "")
         if model is None:
             model = getattr(nested, "model", "")
+    dimension_cfg = getattr(config, "embedding_dimension", None)
+    if dimension_cfg is None and nested is not None and not isinstance(nested, (str, bool)):
+        dimension_cfg = getattr(nested, "dimension", 0)
     enabled = bool(enabled)
     provider = (provider or "").strip()
     model = model or ""
@@ -79,32 +198,50 @@ def probe_embedding_capability(config: Any) -> dict[str, Any]:
         "available": False,
         "dimension": None,
         "detail": None,
+        # Set when the provider/model/dimension triple cannot work. Independent
+        # of ``available``: the package can be installed and importable while the
+        # configuration it is handed is still impossible.
+        "mismatch": None,
     }
 
     if not enabled:
         result["detail"] = "embeddings disabled"
         return result
 
+    try:
+        mismatch = check_embedding_coherence(provider, model, int(dimension_cfg or 0))
+    except Exception:  # a diagnostic must never be the thing that breaks
+        mismatch = None
+    if mismatch is not None:
+        result["mismatch"] = mismatch.summary
+
+    def _detail(note: str | None) -> str | None:
+        """Keep the mismatch visible: later branches also write ``detail``."""
+        if mismatch is None:
+            return note
+        full = f"{mismatch.summary} — {mismatch.fix}"
+        return f"{note} | {full}" if note else full
+
     if provider == "ollama":
         # Local server — availability depends on the daemon, not a Python package.
         result["available"] = True
-        result["detail"] = "ollama (local server — ensure it is running)"
+        result["detail"] = _detail("ollama (local server — ensure it is running)")
         return result
 
     if provider == "auto":
         # Provider is detected at runtime from whatever is installed/keyed.
         result["available"] = True
-        result["detail"] = "auto-detect at runtime"
+        result["detail"] = _detail("auto-detect at runtime")
         return result
 
     entry = _PROVIDER_IMPORT.get(provider)
     if entry is None:
-        result["detail"] = f"unknown embedding provider {provider!r}"
+        result["detail"] = _detail(f"unknown embedding provider {provider!r}")
         return result
 
     module_name, extra = entry
-    if importlib.util.find_spec(module_name) is None:
-        result["detail"] = (
+    if _find_spec_safely(module_name) is None:
+        result["detail"] = _detail(
             f"{provider} provider configured but '{module_name}' is not installed — "
             f"install it with: pip install 'surreal-memory[{extra}]'"
         )
@@ -112,6 +249,7 @@ def probe_embedding_capability(config: Any) -> dict[str, Any]:
 
     result["available"] = True
     result["dimension"] = _dimension_for(provider, model)
+    result["detail"] = _detail(result["detail"])
     return result
 
 

--- a/src/surreal_memory/engine/reasoning_distiller.py
+++ b/src/surreal_memory/engine/reasoning_distiller.py
@@ -33,10 +33,12 @@ from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.synapse import Direction, Synapse, SynapseType
 from surreal_memory.engine.clustering import UnionFind
+from surreal_memory.engine.reasoning_naming import build_namer
 from surreal_memory.engine.reasoning_progress import PHASE_DISTILLING, MiningProgress
 
 if TYPE_CHECKING:
     from surreal_memory.engine.embedding.provider import EmbeddingProvider
+    from surreal_memory.engine.reasoning_naming import PatternNamer
     from surreal_memory.engine.reasoning_progress import ProgressCallback
     from surreal_memory.storage.base import NeuralStorage
     from surreal_memory.unified_config import ReasoningTrainingConfig, UnifiedConfig
@@ -478,6 +480,7 @@ async def _process_model_batch(
     seeds: dict[str, list[float]] | None,
     existing_sigs: set[str],
     budget: int,
+    namer: PatternNamer | None = None,
 ) -> tuple[int, list[Any]]:
     """Distill one model's trace batch. Returns (patterns_created, consumed_ids).
 
@@ -532,6 +535,10 @@ async def _process_model_batch(
             pattern = _build_pattern(
                 cluster_traces, cluster_vecs, cluster_moves, model, category, len(idxs)
             )
+            if namer is not None:
+                # Prose only: the signature is already fixed by the cluster's
+                # trace hashes, so naming cannot fork a pattern into a duplicate.
+                pattern = await namer.rename(pattern, cluster_traces)
             if await _materialize_pattern(storage, pattern, existing_sigs):
                 existing_sigs.add(pattern["signature"])
                 created += 1
@@ -570,6 +577,10 @@ async def distill_reasoning_patterns(
     rt = config.reasoning_training
     embedder = embedder or _get_embedder()
     seeds = await _seed_centroids(embedder, rt.categories) if embedder is not None else None
+    # None unless distill_use_llm is on AND a local endpoint and model are set.
+    # The chat model is pulled in by the first rename and released in the finally
+    # below, so it is resident for this run only.
+    namer = build_namer(rt)
 
     existing = await storage.find_fibers(
         metadata_key="_reasoning_pattern", limit=_PATTERN_FETCH_LIMIT
@@ -608,37 +619,52 @@ async def distill_reasoning_patterns(
                 )
             )
 
-    for idx, model in enumerate(models):
-        budget = max(0, rt.pattern_targets.get(model, 0) - existing_by_model.get(model, 0))
-        if budget <= 0:
-            # Target unset/0 or already met → leave this model's traces unprocessed.
+    try:
+        for idx, model in enumerate(models):
+            budget = max(0, rt.pattern_targets.get(model, 0) - existing_by_model.get(model, 0))
+            if budget <= 0:
+                # Target unset/0 or already met → leave this model's traces unprocessed.
+                _emit(model, idx + 1)
+                continue
+            while budget > 0:
+                traces = await storage.get_unprocessed_reasoning_traces(
+                    brain_id, limit=_BATCH_PER_MODEL, model=model
+                )
+                traces = traces[:_BATCH_PER_MODEL]
+                if not traces:
+                    break  # backlog for this model exhausted
+                created, consumed = await _process_model_batch(
+                    storage,
+                    brain_id,
+                    rt,
+                    model,
+                    traces,
+                    embedder,
+                    seeds,
+                    existing_sigs,
+                    budget,
+                    namer,
+                )
+                patterns_created += created
+                budget -= created
+                if consumed:
+                    processed_ids.extend(consumed)
+                    # Mark consumed processed NOW so the next fetch returns fresh
+                    # traces — otherwise a drain loop re-fetches the same batch forever.
+                    await storage.mark_reasoning_traces_processed(brain_id, consumed)
+                _emit(model, idx)
+                # Termination guard: a batch that consumes nothing makes no forward
+                # progress (budget hit 0 mid-category), so stop draining this model.
+                if not consumed:
+                    break
+                if not drain:
+                    break  # background consolidation: one batch per model per run
             _emit(model, idx + 1)
-            continue
-        while budget > 0:
-            traces = await storage.get_unprocessed_reasoning_traces(
-                brain_id, limit=_BATCH_PER_MODEL, model=model
-            )
-            traces = traces[:_BATCH_PER_MODEL]
-            if not traces:
-                break  # backlog for this model exhausted
-            created, consumed = await _process_model_batch(
-                storage, brain_id, rt, model, traces, embedder, seeds, existing_sigs, budget
-            )
-            patterns_created += created
-            budget -= created
-            if consumed:
-                processed_ids.extend(consumed)
-                # Mark consumed processed NOW so the next fetch returns fresh
-                # traces — otherwise a drain loop re-fetches the same batch forever.
-                await storage.mark_reasoning_traces_processed(brain_id, consumed)
-            _emit(model, idx)
-            # Termination guard: a batch that consumes nothing makes no forward
-            # progress (budget hit 0 mid-category), so stop draining this model.
-            if not consumed:
-                break
-            if not drain:
-                break  # background consolidation: one batch per model per run
-        _emit(model, idx + 1)
+    finally:
+        # Unconditional: an aborted or failed run must not leave the chat model
+        # parked in VRAM either.
+        if namer is not None:
+            await namer.release()
 
     if processed_ids:
         await storage.prune_reasoning_traces(brain_id, rt.retention_days)

--- a/src/surreal_memory/engine/reasoning_naming.py
+++ b/src/surreal_memory/engine/reasoning_naming.py
@@ -1,0 +1,473 @@
+"""Optional LLM naming for distilled reasoning patterns (``distill_use_llm``).
+
+The heuristic distiller names a pattern from its own mechanics: the title is the
+cluster's three most frequent reasoning moves, and the description is the first
+200 characters of the medoid trace -- a raw thinking fragment, usually cut
+mid-sentence. That is serviceable as an identifier and poor as an explanation.
+
+With ``reasoning_training.distill_use_llm`` enabled, a local model rewrites the
+prose into something a human (or an injected session) can act on. It rewrites
+*only* prose:
+
+    title / description / strategy                        <- may be replaced
+    model / category / confidence / frequency / signature <- never touched
+
+That split is what makes the flag safe to toggle. ``signature`` is derived from
+the cluster's trace hashes, so renaming does not create a new pattern: flipping
+the flag changes how *future* patterns read, never how existing ones are
+identified, and never produces duplicates. Existing patterns are not rewritten
+retroactively.
+
+Two hard constraints, both mirroring ``reasoning_distiller._get_embedder``:
+
+* **Loopback only.** Trace content is raw model thinking. A non-loopback
+  endpoint yields no namer at all, so no request is ever made. This is an
+  invariant, not a default: there is no configuration that sends thinking to a
+  remote host. (Ingest-time redaction via ``reasoning_miner`` is upstream of
+  this and can be switched off, so the transport guarantee has to stand alone.)
+* **Fail-soft.** Missing endpoint, missing ``httpx``, refused connection,
+  timeout, HTTP error, or a model that answers in prose instead of JSON -- every
+  one of these falls back to the mechanical naming. Distillation never fails
+  because naming failed, and a dead endpoint trips a circuit breaker rather than
+  costing one timeout per cluster for the whole run.
+
+Model residency
+---------------
+Local model servers load a chat model on its first request and, typically,
+keep it resident with no idle timeout. Naming needs the model for the length of
+one distillation run and not a second longer -- otherwise a run that names a
+handful of patterns leaves several gigabytes parked in VRAM indefinitely.
+
+Loading therefore stays implicit (the first request pulls the model in) and
+unloading is explicit: ``release()`` runs ``distill_llm_unload_cmd`` once the
+run is over. Two properties keep that honest:
+
+* It only fires if this run actually issued a request. A namer that was built
+  but never used releases nothing, so a model somebody else loaded is left
+  alone.
+* The command is an argv list executed without a shell, so a model name can
+  never turn into shell syntax. It is read from the config file only -- never
+  from an API request -- and a failure to unload is logged, never raised.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from typing import TYPE_CHECKING, Any, Protocol
+from urllib.parse import urlsplit
+
+if TYPE_CHECKING:
+    from surreal_memory.unified_config import ReasoningTrainingConfig
+
+logger = logging.getLogger(__name__)
+
+LLM_ENDPOINT_ENV = "SURREAL_MEMORY_LLM_ENDPOINT"
+EMBEDDING_ENDPOINT_ENV = "SURREAL_MEMORY_EMBEDDING_ENDPOINT"
+
+_LOOPBACK_NAMES = frozenset({"localhost", "::1"})
+
+# Output caps. The title also becomes a CONCEPT neuron's content, so it stays
+# short enough to read in a list; description/strategy are what injection ships.
+_TITLE_MAX = 120
+_DESCRIPTION_MAX = 400
+_STRATEGY_MAX = 1200
+
+# Input caps. A thinking block can run to 100k characters; the point of the
+# prompt is the shape of the reasoning, not its full text.
+_TRACE_CHARS = 1200
+_MAX_SAMPLES = 3
+
+_TIMEOUT_SECONDS = 60.0
+# Must cover a *reasoning* model's private thinking as well as the JSON answer:
+# thinking is emitted first, so too small a budget yields an empty content field
+# and finish_reason="length" rather than a short answer.
+_MAX_TOKENS = 1500
+# Asks a server that supports it to skip the thinking phase entirely. Servers
+# that do not recognise the key generally ignore it; one that rejects it costs a
+# single failed attempt, after which it is dropped for the rest of the run.
+_NO_THINKING_KWARGS = {"enable_thinking": False}
+# Consecutive failures after which naming is abandoned for the rest of the run.
+_FAILURE_LIMIT = 3
+# Unloading is a local process teardown; it should be near-instant.
+_UNLOAD_TIMEOUT_SECONDS = 30.0
+# Substituted into distill_llm_unload_cmd so one command template can name the
+# model it is releasing.
+_MODEL_PLACEHOLDER = "{model}"
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
+
+_SYSTEM_PROMPT = (
+    "You name reusable reasoning strategies. You are given several excerpts of a"
+    " model's private reasoning that were clustered together because they share"
+    " an approach. Describe the approach they have in common.\n\n"
+    "Reply with a single JSON object and nothing else:\n"
+    '{"title": "...", "description": "...", "strategy": "..."}\n\n'
+    "title: an imperative name for the approach, at most 8 words.\n"
+    "description: one or two sentences on what the approach is and when it"
+    " applies.\n"
+    "strategy: the reusable procedure as numbered steps, so another model could"
+    " follow it on a new task.\n\n"
+    "Describe only what the excerpts actually show. Do not invent steps, and do"
+    " not mention the excerpts, this instruction, or that you are an AI."
+)
+
+
+class PostJson(Protocol):
+    """Seam for the HTTP POST, so callers and tests can supply their own."""
+
+    async def __call__(
+        self, url: str, payload: dict[str, Any], timeout: float
+    ) -> dict[str, Any]: ...
+
+
+class RunCommand(Protocol):
+    """Seam for the unload subprocess. Returns the exit status."""
+
+    async def __call__(self, argv: list[str], timeout: float) -> int: ...
+
+
+def _is_loopback(host: str | None) -> bool:
+    if not host:
+        return False
+    host = host.strip().strip("[]").lower()
+    return host in _LOOPBACK_NAMES or host.startswith("127.")
+
+
+def resolve_llm_endpoint(configured: str = "") -> str | None:
+    """Return the local LLM base URL to use, or None if there isn't a usable one.
+
+    In precedence order: ``SURREAL_MEMORY_LLM_ENDPOINT``, then the
+    ``distill_llm_endpoint`` config value, then
+    ``SURREAL_MEMORY_EMBEDDING_ENDPOINT`` -- one local OpenAI-compatible server
+    commonly serves both embeddings and chat. Env beats config, matching the
+    rest of the reasoning settings.
+
+    Whichever source wins, a non-loopback value resolves to None instead of
+    being used: raw reasoning traces do not leave the machine.
+    """
+    sources = (
+        os.environ.get(LLM_ENDPOINT_ENV, ""),
+        configured,
+        os.environ.get(EMBEDDING_ENDPOINT_ENV, ""),
+    )
+    for source in sources:
+        raw = source.strip()
+        if not raw:
+            continue
+        try:
+            host = urlsplit(raw).hostname
+        except ValueError:
+            logger.debug("reasoning naming: unparseable LLM endpoint")
+            return None
+        if not _is_loopback(host):
+            logger.warning(
+                "reasoning naming: the configured LLM endpoint (%s) is not a loopback"
+                " address; LLM naming stays off (reasoning traces are never sent to a"
+                " remote host)",
+                host,
+            )
+            return None
+        return raw.rstrip("/")
+    return None
+
+
+def _extract_message_text(data: dict[str, Any]) -> str:
+    """Pull the assistant text out of an OpenAI-compatible response envelope.
+
+    A reasoning model spends its budget on ``reasoning_content`` first, so
+    running out of tokens shows up as an empty or half-written ``content``.
+    That case gets its own message: "the model said nothing" and "the model was
+    cut off mid-answer" call for very different fixes.
+    """
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("response contained no choices")
+    first = choices[0]
+    message = first.get("message") if isinstance(first, dict) else None
+    content = message.get("content") if isinstance(message, dict) else None
+    truncated = isinstance(first, dict) and first.get("finish_reason") == "length"
+    if not isinstance(content, str) or not content.strip():
+        if truncated:
+            raise ValueError(
+                "model hit the token limit before answering (a reasoning model may need"
+                " a larger budget, or a model that does not think before answering)"
+            )
+        raise ValueError("response contained no message content")
+    if truncated:
+        raise ValueError("model was cut off mid-answer by the token limit")
+    return content
+
+
+def _coerce_text(value: Any) -> str | None:
+    """Normalise one JSON field to prose, or None if there is nothing usable.
+
+    Asked for "numbered steps", a model quite reasonably answers with a JSON
+    array instead of a string. Rejecting that would throw away a perfectly good
+    answer over its container type, so a list of scalars becomes one line each.
+    """
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, list):
+        parts = [
+            str(item).strip()
+            for item in value
+            if isinstance(item, (str, int, float)) and str(item).strip()
+        ]
+        return "\n".join(parts) or None
+    return None
+
+
+def _parse_fields(text: str) -> dict[str, str] | None:
+    """Parse the model's reply into capped prose fields, or None if unusable.
+
+    Small local models routinely wrap JSON in a markdown fence or bracket it with
+    chatter, so the object is located rather than assumed to be the whole reply.
+    """
+    fenced = _JSON_FENCE_RE.search(text)
+    candidate = fenced.group(1) if fenced else text
+    start, end = candidate.find("{"), candidate.rfind("}")
+    if start < 0 or end <= start:
+        return None
+    try:
+        parsed = json.loads(candidate[start : end + 1])
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+
+    out: dict[str, str] = {}
+    for key, cap in (
+        ("title", _TITLE_MAX),
+        ("description", _DESCRIPTION_MAX),
+        ("strategy", _STRATEGY_MAX),
+    ):
+        value = _coerce_text(parsed.get(key))
+        if value is None:
+            return None
+        out[key] = value[:cap]
+    return out
+
+
+def _build_payload(
+    model: str,
+    pattern: dict[str, Any],
+    cluster_traces: list[dict[str, Any]],
+    *,
+    skip_thinking: bool = True,
+) -> dict[str, Any]:
+    excerpts = "\n\n".join(
+        f"--- excerpt {i + 1} ---\n{str(t.get('content', ''))[:_TRACE_CHARS]}"
+        for i, t in enumerate(cluster_traces[:_MAX_SAMPLES])
+    )
+    user = (
+        f"Category: {pattern.get('category', '')}\n"
+        f"Observed moves: {pattern.get('title', '')}\n\n"
+        f"{excerpts}"
+    )
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": _SYSTEM_PROMPT},
+            {"role": "user", "content": user},
+        ],
+        "temperature": 0.0,
+        "max_tokens": _MAX_TOKENS,
+        "stream": False,
+    }
+    if skip_thinking:
+        payload["chat_template_kwargs"] = dict(_NO_THINKING_KWARGS)
+    return payload
+
+
+async def _post_json_httpx(url: str, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
+    """Default transport. ``httpx`` is imported lazily and optional by design."""
+    import httpx
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(url, json=payload)
+        response.raise_for_status()
+        result = response.json()
+    if not isinstance(result, dict):
+        raise ValueError("response body was not a JSON object")
+    return result
+
+
+async def _run_command_subprocess(argv: list[str], timeout: float) -> int:
+    """Default unload runner: exec the argv directly, with no shell involved."""
+    process = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    try:
+        stdout, _ = await asyncio.wait_for(process.communicate(), timeout=timeout)
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        raise
+    if stdout:
+        logger.debug("reasoning naming: unload output: %s", stdout.decode(errors="replace").strip())
+    return process.returncode if process.returncode is not None else -1
+
+
+class PatternNamer:
+    """Rewrites a distilled pattern's prose using a local chat model."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        model: str,
+        post_json: PostJson,
+        *,
+        unload_cmd: tuple[str, ...] = (),
+        run_command: RunCommand | None = None,
+    ) -> None:
+        self._url = f"{endpoint}/chat/completions"
+        self._model = model
+        self._post = post_json
+        self._unload_cmd = unload_cmd
+        self._run = run_command or _run_command_subprocess
+        self._consecutive_failures = 0
+        self._given_up = False
+        # Cleared the first time a request fails, in case this server is one
+        # that rejects the thinking-control key rather than ignoring it.
+        self._skip_thinking = True
+        # Set once a request has gone out, i.e. once this run may have caused
+        # the model to be loaded. Reset by release() so a namer reused after a
+        # release acquires and releases again rather than releasing twice.
+        self._model_in_use = False
+
+    def _record_failure(self, reason: str, exc: BaseException | None = None) -> None:
+        self._consecutive_failures += 1
+        logger.debug("reasoning naming: %s", reason, exc_info=exc is not None)
+        if self._consecutive_failures >= _FAILURE_LIMIT:
+            self._given_up = True
+            logger.warning(
+                "reasoning naming: giving up after %d consecutive failures (%s);"
+                " the rest of this run uses heuristic naming",
+                _FAILURE_LIMIT,
+                reason,
+            )
+
+    async def rename(
+        self, pattern: dict[str, Any], cluster_traces: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Return *pattern* with LLM prose, or *pattern* unchanged on any problem.
+
+        Never raises: naming is an enhancement, and a pattern with mechanical
+        wording is worth more than a failed distillation run.
+        """
+        if self._given_up or not cluster_traces:
+            return pattern
+
+        payload = _build_payload(
+            self._model, pattern, cluster_traces, skip_thinking=self._skip_thinking
+        )
+        # Flagged before the await: a request that times out may still have
+        # loaded the model, so it must count as an acquisition.
+        self._model_in_use = True
+        try:
+            data = await self._post(self._url, payload, _TIMEOUT_SECONDS)
+            text = _extract_message_text(data)
+        except Exception as exc:  # every transport failure is soft
+            if self._skip_thinking:
+                # This server may be one that rejects the thinking-control key.
+                # Drop it rather than retrying now: a retry would double the
+                # cost of every failure on an endpoint that is simply down.
+                self._skip_thinking = False
+                logger.debug(
+                    "reasoning naming: retrying subsequent calls without %s", "thinking control"
+                )
+            self._record_failure(f"call failed: {type(exc).__name__}: {exc}", exc)
+            return pattern
+
+        fields = _parse_fields(text)
+        if fields is None:
+            # A model that cannot produce the JSON shape is as useless as a dead
+            # endpoint, so this counts toward the circuit breaker too.
+            self._record_failure("model did not return the requested JSON object")
+            return pattern
+
+        self._consecutive_failures = 0
+        return {**pattern, **fields}
+
+    async def release(self) -> None:
+        """Unload the chat model this run pulled in. Safe to call more than once.
+
+        A no-op when no unload command is configured or when this namer never
+        issued a request -- releasing a model the run did not acquire would
+        evict something another process is relying on.
+        """
+        if not self._unload_cmd or not self._model_in_use:
+            return
+        self._model_in_use = False
+
+        argv = [
+            part.replace(_MODEL_PLACEHOLDER, self._model) if _MODEL_PLACEHOLDER in part else part
+            for part in self._unload_cmd
+        ]
+        try:
+            code = await self._run(argv, _UNLOAD_TIMEOUT_SECONDS)
+        except Exception as exc:  # a stuck model must not fail a run
+            logger.warning(
+                "reasoning naming: could not unload %s (%s: %s); it may still be resident",
+                self._model,
+                type(exc).__name__,
+                exc,
+            )
+            return
+        if code == 0:
+            logger.info("reasoning naming: unloaded %s after distillation", self._model)
+        else:
+            logger.warning(
+                "reasoning naming: unload command for %s exited %s; it may still be resident",
+                self._model,
+                code,
+            )
+
+
+def build_namer(
+    rt: ReasoningTrainingConfig,
+    *,
+    post_json: PostJson | None = None,
+    run_command: RunCommand | None = None,
+) -> PatternNamer | None:
+    """Build a namer from config, or None when LLM naming is not available.
+
+    None is returned -- and distillation silently keeps its heuristic naming --
+    when the flag is off, no local endpoint is configured, the configured
+    endpoint is remote, or no model name is set.
+    """
+    if not rt.distill_use_llm:
+        return None
+
+    endpoint = resolve_llm_endpoint(rt.distill_llm_endpoint)
+    if endpoint is None:
+        logger.warning(
+            "reasoning_training.distill_use_llm is on but no usable local LLM endpoint"
+            " is set; set distill_llm_endpoint (or %s) to a loopback OpenAI-compatible"
+            " URL. Using heuristic naming.",
+            LLM_ENDPOINT_ENV,
+        )
+        return None
+
+    model = str(rt.distill_llm_model or "").strip()
+    if not model:
+        logger.warning(
+            "reasoning_training.distill_use_llm is on but distill_llm_model is empty;"
+            " set it to a chat model served by %s. Using heuristic naming.",
+            endpoint,
+        )
+        return None
+
+    return PatternNamer(
+        endpoint,
+        model,
+        post_json or _post_json_httpx,
+        unload_cmd=tuple(rt.distill_llm_unload_cmd),
+        run_command=run_command,
+    )

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -1099,6 +1099,13 @@ class ToolMemoryConfig:
 # while still blocking quotes/backslashes/control chars (TOML-injection safe).
 _TOML_SAFE_GLOB = re.compile(r"^[a-zA-Z0-9_\-\./ *?\[\]]*$")
 
+# One argv part of reasoning_training.distill_llm_unload_cmd. Deliberately
+# narrower than a glob: no quotes, no shell metacharacters, no newlines. Braces
+# are allowed solely for the "{model}" placeholder. The command is executed
+# without a shell, so this is defence in depth rather than the only guard.
+_TOML_SAFE_ARGV = re.compile(r"^[a-zA-Z0-9_\-\./:={}]+$")
+_UNLOAD_CMD_MAX_PARTS = 16
+
 
 def _sanitize_toml_glob(value: str) -> str:
     """Sanitize a model-name / glob string for safe TOML serialization."""
@@ -1153,7 +1160,18 @@ class ReasoningTrainingConfig:
     min_patterns_per_category: int = 3
     injection_max_patterns: int = 5
     injection_max_chars: int = 4000
+    # Rewrite distilled pattern prose with a LOCAL chat model. Needs
+    # distill_llm_model plus a loopback SURREAL_MEMORY_LLM_ENDPOINT; without
+    # both, distillation keeps its heuristic naming (see engine.reasoning_naming).
     distill_use_llm: bool = False
+    distill_llm_model: str = ""
+    # Loopback OpenAI-compatible base URL, e.g. "http://127.0.0.1:PORT/v1".
+    # SURREAL_MEMORY_LLM_ENDPOINT overrides it; a non-loopback value is refused.
+    distill_llm_endpoint: str = ""
+    # argv (NOT a shell string) run once after distillation to unload the chat
+    # model again, so it does not stay resident between runs. "{model}" is
+    # replaced with distill_llm_model. Empty = leave the model loaded.
+    distill_llm_unload_cmd: tuple[str, ...] = ()
     redact_secrets: bool = True
     # Per-model distillation targets: model name -> desired pattern count (0-100).
     # An unlisted model defaults to 0 → distillation is skipped for it (the
@@ -1179,6 +1197,9 @@ class ReasoningTrainingConfig:
             "injection_max_patterns": self.injection_max_patterns,
             "injection_max_chars": self.injection_max_chars,
             "distill_use_llm": self.distill_use_llm,
+            "distill_llm_model": self.distill_llm_model,
+            "distill_llm_endpoint": self.distill_llm_endpoint,
+            "distill_llm_unload_cmd": list(self.distill_llm_unload_cmd),
             "redact_secrets": self.redact_secrets,
             "pattern_targets": dict(self.pattern_targets),
         }
@@ -1238,6 +1259,16 @@ class ReasoningTrainingConfig:
                 except (ValueError, TypeError):
                     continue
 
+        # Unload command: argv, never a shell string. A part that is not plain
+        # command syntax voids the whole command rather than being silently
+        # dropped — a half-parsed teardown command is worse than none.
+        unload_raw = data.get("distill_llm_unload_cmd", [])
+        unload_cmd: tuple[str, ...] = ()
+        if isinstance(unload_raw, (list, tuple)) and unload_raw:
+            parts = [str(p).strip() for p in unload_raw[:_UNLOAD_CMD_MAX_PARTS]]
+            if all(p and _TOML_SAFE_ARGV.match(p) for p in parts):
+                unload_cmd = tuple(p[:_TOML_STR_MAX_LEN] for p in parts)
+
         return cls(
             mining_enabled=bool(data.get("mining_enabled", False)),
             injection_enabled=bool(data.get("injection_enabled", False)),
@@ -1255,6 +1286,11 @@ class ReasoningTrainingConfig:
             injection_max_patterns=_int("injection_max_patterns", 5, 1, 1000),
             injection_max_chars=_int("injection_max_chars", 4000, 1, 1_000_000),
             distill_use_llm=bool(data.get("distill_use_llm", False)),
+            distill_llm_model=_sanitize_toml_glob(str(data.get("distill_llm_model", "") or "")),
+            distill_llm_endpoint=_sanitize_toml_url(
+                str(data.get("distill_llm_endpoint", "") or "")
+            ),
+            distill_llm_unload_cmd=unload_cmd,
             redact_secrets=bool(data.get("redact_secrets", True)),
             pattern_targets=pattern_targets,
         )
@@ -1834,6 +1870,11 @@ class UnifiedConfig:
             f"injection_max_patterns = {rt.injection_max_patterns}",
             f"injection_max_chars = {rt.injection_max_chars}",
             f"distill_use_llm = {'true' if rt.distill_use_llm else 'false'}",
+            f'distill_llm_model = "{_sanitize_toml_glob(rt.distill_llm_model)}"',
+            f'distill_llm_endpoint = "{_sanitize_toml_url(rt.distill_llm_endpoint)}"',
+            "distill_llm_unload_cmd = ["
+            + ", ".join(f'"{p}"' for p in rt.distill_llm_unload_cmd if _TOML_SAFE_ARGV.match(p))
+            + "]",
             f"redact_secrets = {'true' if rt.redact_secrets else 'false'}",
             "[reasoning_training.injection_map]",
         ]

--- a/tests/unit/test_embedding_coherence.py
+++ b/tests/unit/test_embedding_coherence.py
@@ -1,0 +1,240 @@
+"""An incoherent embedding configuration must be reported, not silently obeyed.
+
+Every provider guesses a dimension for a model it does not recognise — Gemini
+assumes 3072, the OpenAI-compatible providers 1536, Ollama 1024. Each guess is
+reasonable in isolation and dangerous in combination: point a provider at
+another provider's model name and it will confidently produce vectors of the
+wrong width, which the HNSW index then rejects on every single write. Nothing
+in the stack said a word about it.
+
+Two rules close that gap:
+
+* **A closed catalogue rejects foreign model names.** A hosted API serves a
+  fixed set of models; asking it for a local model name cannot work.
+* **A known model's dimension must match the configured one**, because that is
+  what the vector index is built with.
+
+The hard requirement is the *absence* of false positives: a local
+OpenAI-compatible server legitimately serves arbitrary model names, and warning
+about a working setup would train everyone to ignore the check.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from surreal_memory.engine.embedding.capability import (
+    check_embedding_coherence,
+    probe_embedding_capability,
+)
+
+
+class _Config:
+    """Nested-config shape accepted by probe_embedding_capability."""
+
+    class _Embedding:
+        def __init__(self, enabled: bool, provider: str, model: str, dimension: int) -> None:
+            self.enabled = enabled
+            self.provider = provider
+            self.model = model
+            self.dimension = dimension
+
+    def __init__(
+        self, provider: str, model: str, dimension: int = 0, *, enabled: bool = True
+    ) -> None:
+        self.embedding = self._Embedding(enabled, provider, model, dimension)
+
+
+class TestTheConfigurationThatWentUnnoticed:
+    """The exact shape that survived a day of use without a single complaint."""
+
+    def test_a_hosted_provider_pointed_at_a_local_model_is_reported(self) -> None:
+        mismatch = check_embedding_coherence("gemini", "bge-m3-FP16", 1024)
+
+        assert mismatch is not None
+        assert "gemini" in mismatch.summary
+        assert "bge-m3-FP16" in mismatch.summary
+
+    def test_the_report_says_what_to_do(self) -> None:
+        mismatch = check_embedding_coherence("gemini", "bge-m3-FP16", 1024)
+
+        assert mismatch is not None
+        assert mismatch.fix.strip()
+
+
+class TestNoFalsePositives:
+    """A check that cries wolf on a working setup is worse than no check."""
+
+    @pytest.mark.parametrize(
+        ("provider", "model", "dimension"),
+        [
+            # A local OpenAI-compatible server serving a BGE build under its own
+            # file name — arbitrary names are the norm here, not an error.
+            ("openai", "bge-m3-FP16", 1024),
+            ("openai", "some-quantised-model-Q4_K_M", 768),
+            ("openai", "text-embedding-3-small", 1536),
+            ("openai", "text-embedding-3-large", 3072),
+            ("gemini", "gemini-embedding-001", 3072),
+            ("ollama", "bge-m3", 1024),
+            ("ollama", "all-minilm", 384),
+            ("openrouter", "openai/text-embedding-3-small", 1536),
+            # Open-catalogue providers with no dimension table at all.
+            ("sentence_transformer", "all-MiniLM-L6-v2", 384),
+            ("bge_m3", "bge-m3", 1024),
+        ],
+    )
+    def test_a_coherent_configuration_is_silent(
+        self, provider: str, model: str, dimension: int
+    ) -> None:
+        assert check_embedding_coherence(provider, model, dimension) is None
+
+    def test_dimension_zero_means_auto_and_is_not_a_conflict(self) -> None:
+        """0 = derive from the provider, so there is nothing to contradict."""
+        assert check_embedding_coherence("openai", "text-embedding-3-small", 0) is None
+
+    @pytest.mark.parametrize("provider", ["auto", "", "nonsense-provider"])
+    def test_providers_this_check_cannot_reason_about_are_left_alone(self, provider: str) -> None:
+        assert check_embedding_coherence(provider, "whatever", 1024) is None
+
+    def test_an_empty_model_is_left_to_the_provider_default(self) -> None:
+        assert check_embedding_coherence("gemini", "", 3072) is None
+
+
+class TestClosedCatalogue:
+    """A hosted API cannot be asked for a model it does not serve."""
+
+    @pytest.mark.parametrize(
+        "model",
+        ["bge-m3-FP16", "text-embedding-3-small", "all-MiniLM-L6-v2", "nomic-embed-text"],
+    )
+    def test_a_foreign_model_name_is_reported(self, model: str) -> None:
+        assert check_embedding_coherence("gemini", model, 0) is not None
+
+    def test_it_fires_even_when_no_dimension_is_configured(self) -> None:
+        """The name alone is enough: the request itself would be rejected."""
+        assert check_embedding_coherence("gemini", "bge-m3-FP16", 0) is not None
+
+    def test_a_decommissioned_model_is_reported(self) -> None:
+        """text-embedding-004 was removed from the catalogue; it 404s."""
+        assert check_embedding_coherence("gemini", "text-embedding-004", 768) is not None
+
+
+class TestDimensionConflict:
+    """The configured dimension is what the vector index is built with."""
+
+    @pytest.mark.parametrize(
+        ("provider", "model", "dimension", "expected"),
+        [
+            ("gemini", "gemini-embedding-001", 1024, 3072),
+            ("openai", "text-embedding-3-small", 1024, 1536),
+            ("openai", "text-embedding-3-large", 1536, 3072),
+            ("ollama", "bge-m3", 768, 1024),
+            ("ollama", "all-minilm", 1024, 384),
+            ("openrouter", "openai/text-embedding-3-large", 1536, 3072),
+        ],
+    )
+    def test_a_known_model_with_the_wrong_dimension_is_reported(
+        self, provider: str, model: str, dimension: int, expected: int
+    ) -> None:
+        mismatch = check_embedding_coherence(provider, model, dimension)
+
+        assert mismatch is not None
+        assert str(expected) in mismatch.summary
+        assert str(dimension) in mismatch.summary
+
+    def test_an_unknown_model_is_not_second_guessed(self) -> None:
+        """The provider's fallback is a guess, and a guess must not raise an error.
+
+        Only an exact catalogue hit counts as knowing the dimension — otherwise
+        every local model name would be reported against a made-up number.
+        """
+        assert check_embedding_coherence("openai", "a-model-nobody-listed", 1024) is None
+
+
+class TestProbeSurfacesIt:
+    """smem_health and MCP startup read the probe, so it has to carry the news."""
+
+    def test_a_coherent_configuration_reports_no_mismatch(self) -> None:
+        result = probe_embedding_capability(_Config("ollama", "bge-m3", 1024))
+
+        assert result.get("mismatch") is None
+
+    def test_an_incoherent_configuration_is_reported_in_the_probe(self) -> None:
+        result = probe_embedding_capability(_Config("ollama", "bge-m3", 768))
+
+        assert result.get("mismatch")
+        assert "768" in str(result["mismatch"])
+        assert "768" in str(result["detail"])
+
+    def test_disabled_embeddings_are_not_examined(self) -> None:
+        result = probe_embedding_capability(_Config("gemini", "bge-m3-FP16", 1024, enabled=False))
+
+        assert result.get("mismatch") is None
+
+
+class TestTheProbeNeverRaises:
+    """Its docstring promises it; a missing parent package broke the promise.
+
+    ``find_spec("google.genai")`` imports ``google`` first, so on a machine
+    without it the call raises ModuleNotFoundError instead of answering "not
+    installed" — and it is `smem_health` and MCP startup that call this.
+    """
+
+    def test_a_provider_whose_parent_package_is_absent_is_reported_not_raised(self) -> None:
+        result = probe_embedding_capability(_Config("gemini", "gemini-embedding-001", 3072))
+
+        assert result["available"] in (True, False)
+        assert isinstance(result["detail"], (str, type(None)))
+
+    def test_an_unimportable_module_name_is_reported_not_raised(self, monkeypatch) -> None:
+        from surreal_memory.engine.embedding import capability as capability_mod
+
+        def _explode(_name: str) -> object:
+            raise ModuleNotFoundError("No module named 'google'")
+
+        monkeypatch.setattr(capability_mod.importlib.util, "find_spec", _explode)
+
+        result = probe_embedding_capability(_Config("gemini", "gemini-embedding-001", 3072))
+
+        assert result["available"] is False
+        assert "not installed" in str(result["detail"])
+
+
+class TestDoctorReportsIt:
+    """`smem doctor` answered "ok" for a configuration that could not work."""
+
+    def _run(self, provider: str, model: str, dimension: int) -> dict:
+        from unittest.mock import MagicMock, patch
+
+        from surreal_memory.cli.doctor import _check_embedding_provider
+
+        config = MagicMock()
+        config.embedding.enabled = True
+        config.embedding.provider = provider
+        config.embedding.model = model
+        config.embedding.dimension = dimension
+
+        with (
+            patch("surreal_memory.unified_config.get_config", return_value=config),
+            patch("surreal_memory.cli.doctor.importlib.import_module"),
+        ):
+            return _check_embedding_provider()
+
+    def test_an_installed_package_with_an_impossible_model_is_not_ok(self) -> None:
+        result = self._run("gemini", "bge-m3-FP16", 1024)
+
+        assert result["status"] == "fail"
+        assert "bge-m3-FP16" in result["detail"]
+        assert result.get("fix", "").strip()
+
+    def test_a_dimension_conflict_is_not_ok(self) -> None:
+        result = self._run("openai", "text-embedding-3-small", 1024)
+
+        assert result["status"] == "fail"
+        assert "1536" in result["detail"]
+
+    def test_the_working_local_setup_still_passes(self) -> None:
+        """The check must not break the configuration it was written to protect."""
+        result = self._run("openai", "bge-m3-FP16", 1024)
+
+        assert result["status"] == "ok"

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.16.0"
+        assert surreal_memory.__version__ == "2.17.0"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_reasoning_distiller.py
+++ b/tests/unit/test_reasoning_distiller.py
@@ -448,3 +448,95 @@ async def test_consolidation_learn_reasoning_guard_disabled(tmp_path: Path, monk
     report = await ConsolidationEngine(storage).run([ConsolidationStrategy.LEARN_REASONING])
     assert report.reasoning_patterns_learned == 0
     assert calls["n"] == 0
+
+
+class _SpyNamer:
+    """Stands in for a PatternNamer, counting renames and releases."""
+
+    def __init__(self) -> None:
+        self.renamed = 0
+        self.released = 0
+
+    async def rename(self, pattern: dict, cluster_traces: list[dict]) -> dict:
+        self.renamed += 1
+        return {**pattern, "title": f"llm-named-{self.renamed}"}
+
+    async def release(self) -> None:
+        self.released += 1
+
+
+class TestLLMNamingIsWiredIn:
+    """distill_use_llm has to reach the patterns, and let go of the model after."""
+
+    async def test_patterns_carry_the_llm_title(
+        self, tmp_path: Path, no_embedder: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spy = _SpyNamer()
+        monkeypatch.setattr(
+            "surreal_memory.engine.reasoning_distiller.build_namer", lambda _rt: spy
+        )
+        storage = InMemoryStorage()
+        storage.set_brain(BRAIN)
+        await _seed(storage, "claude-fable-5", _DEBUG_TRACES)
+
+        result = await distill_reasoning_patterns(storage, BRAIN, _ucfg(tmp_path), drain=True)
+
+        assert result.patterns_learned >= 1
+        assert spy.renamed >= 1
+        fibers = await storage.find_fibers(metadata_key="_reasoning_pattern", limit=100)
+        titles = [str(f.metadata.get("_reasoning_title", "")) for f in fibers]
+        assert any(t.startswith("llm-named") for t in titles)
+
+    async def test_the_model_is_released_when_the_run_finishes(
+        self, tmp_path: Path, no_embedder: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        spy = _SpyNamer()
+        monkeypatch.setattr(
+            "surreal_memory.engine.reasoning_distiller.build_namer", lambda _rt: spy
+        )
+        storage = InMemoryStorage()
+        storage.set_brain(BRAIN)
+        await _seed(storage, "claude-fable-5", _DEBUG_TRACES)
+
+        await distill_reasoning_patterns(storage, BRAIN, _ucfg(tmp_path), drain=True)
+
+        assert spy.released == 1
+
+    async def test_the_model_is_released_even_when_the_run_blows_up(
+        self, tmp_path: Path, no_embedder: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A crash mid-run must not strand a multi-gigabyte model in VRAM."""
+        spy = _SpyNamer()
+        monkeypatch.setattr(
+            "surreal_memory.engine.reasoning_distiller.build_namer", lambda _rt: spy
+        )
+
+        async def _boom(*_a: object, **_k: object) -> tuple[int, list[object]]:
+            raise RuntimeError("storage went away")
+
+        monkeypatch.setattr("surreal_memory.engine.reasoning_distiller._process_model_batch", _boom)
+        storage = InMemoryStorage()
+        storage.set_brain(BRAIN)
+        await _seed(storage, "claude-fable-5", _DEBUG_TRACES)
+
+        with pytest.raises(RuntimeError):
+            await distill_reasoning_patterns(storage, BRAIN, _ucfg(tmp_path), drain=True)
+
+        assert spy.released == 1
+
+    async def test_no_namer_means_the_heuristic_title_survives(
+        self, tmp_path: Path, no_embedder: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "surreal_memory.engine.reasoning_distiller.build_namer", lambda _rt: None
+        )
+        storage = InMemoryStorage()
+        storage.set_brain(BRAIN)
+        await _seed(storage, "claude-fable-5", _DEBUG_TRACES)
+
+        await distill_reasoning_patterns(storage, BRAIN, _ucfg(tmp_path), drain=True)
+
+        fibers = await storage.find_fibers(metadata_key="_reasoning_pattern", limit=100)
+        assert fibers
+        titles = [str(f.metadata.get("_reasoning_title", "")) for f in fibers]
+        assert not any("llm-named" in t for t in titles)

--- a/tests/unit/test_reasoning_naming.py
+++ b/tests/unit/test_reasoning_naming.py
@@ -1,0 +1,643 @@
+"""LLM pattern naming must improve wording without changing pattern identity.
+
+``distill_use_llm`` shipped as a dataclass field with no consumer: setting it
+did nothing at all. Wiring it up means an LLM may rewrite a pattern's *prose*
+(title / description / strategy), and nothing else. Three properties make that
+safe, and each is pinned here:
+
+* **Identity is untouched.** ``signature`` is derived from the cluster's trace
+  hashes, so a renamed pattern is still the same pattern. If naming ever fed
+  into the signature, toggling the flag would re-materialise every pattern as a
+  duplicate.
+* **The prompt never leaves the machine.** Trace content is raw model thinking.
+  A non-loopback endpoint must yield no namer and, above all, no request.
+* **Failure is invisible.** A missing, slow, broken or babbling endpoint falls
+  back to the mechanical naming that ran before this feature existed.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from surreal_memory.engine.reasoning_naming import (
+    LLM_ENDPOINT_ENV,
+    build_namer,
+    resolve_llm_endpoint,
+)
+from surreal_memory.unified_config import ReasoningTrainingConfig
+
+LOOPBACK = "http://127.0.0.1:11435/v1"
+
+
+def _config(**overrides: Any) -> ReasoningTrainingConfig:
+    return ReasoningTrainingConfig(**{"distill_use_llm": True, **overrides})
+
+
+def _pattern(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "model": "claude-opus-5",
+        "category": "refactoring",
+        "title": "refactoring: read, edit, verify",
+        "description": "raw thinking fragment cut mid-sen",
+        "strategy": "Moves: read -> edit -> verify\nraw thinking",
+        "confidence": 0.75,
+        "frequency": 4,
+        "signature": "abc123",
+    }
+    base.update(overrides)
+    return base
+
+
+def _traces(n: int = 3, content: str = "I need to read the file, then edit it.") -> list[dict]:
+    return [{"trace_hash": f"h{i}", "content": content, "task_context": "ctx"} for i in range(n)]
+
+
+class _Transport:
+    """Records every call so 'no request was made' is directly assertable."""
+
+    def __init__(self, *responses: Any) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, url: str, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
+        self.calls.append({"url": url, "payload": payload, "timeout": timeout})
+        if not self._responses:
+            raise AssertionError("transport called more times than the test provided responses")
+        item = self._responses.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return dict(item)
+
+
+def _completion(text: str) -> dict[str, Any]:
+    return {"choices": [{"message": {"content": text}}]}
+
+
+def _good_json(
+    title: str = "Read before editing",
+    description: str = "Establish the current state, then make one scoped change.",
+    strategy: str = "1. Read the target. 2. Edit. 3. Re-read to verify.",
+) -> str:
+    return json.dumps({"title": title, "description": description, "strategy": strategy})
+
+
+@pytest.fixture(autouse=True)
+def _clear_endpoint_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never let the developer's real environment decide a test's outcome."""
+    monkeypatch.delenv(LLM_ENDPOINT_ENV, raising=False)
+    monkeypatch.delenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", raising=False)
+
+
+class TestEndpointResolution:
+    def test_no_endpoint_configured_resolves_to_none(self) -> None:
+        assert resolve_llm_endpoint() is None
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "http://127.0.0.1:11435/v1",
+            "http://localhost:11435/v1",
+            "http://[::1]:11435/v1",
+        ],
+    )
+    def test_loopback_endpoints_are_accepted(
+        self, monkeypatch: pytest.MonkeyPatch, endpoint: str
+    ) -> None:
+        monkeypatch.setenv(LLM_ENDPOINT_ENV, endpoint)
+        assert resolve_llm_endpoint() == endpoint.rstrip("/")
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://api.openai.com/v1",
+            "http://192.168.1.95:11435/v1",
+            "https://generativelanguage.googleapis.com/v1",
+            "http://llm.internal.example.com/v1",
+        ],
+    )
+    def test_remote_endpoints_are_refused(
+        self, monkeypatch: pytest.MonkeyPatch, endpoint: str
+    ) -> None:
+        """Trace content is raw thinking; it must never be shipped off-box."""
+        monkeypatch.setenv(LLM_ENDPOINT_ENV, endpoint)
+        assert resolve_llm_endpoint() is None
+
+    def test_falls_back_to_the_embedding_endpoint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """One local OpenAI-compatible server usually serves both roles."""
+        monkeypatch.setenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", LOOPBACK)
+        assert resolve_llm_endpoint() == LOOPBACK
+
+    def test_a_remote_embedding_endpoint_is_not_inherited(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", "https://api.openai.com/v1")
+        assert resolve_llm_endpoint() is None
+
+    def test_the_config_value_is_used_when_no_env_var_is_set(self) -> None:
+        """Not everyone can add env vars to how they launch smem."""
+        assert resolve_llm_endpoint(LOOPBACK) == LOOPBACK
+
+    def test_the_env_var_beats_the_config_value(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(LLM_ENDPOINT_ENV, "http://127.0.0.1:9999/v1")
+        assert resolve_llm_endpoint("http://127.0.0.1:11435/v1") == "http://127.0.0.1:9999/v1"
+
+    def test_a_remote_config_value_is_refused_like_any_other(self) -> None:
+        assert resolve_llm_endpoint("https://api.openai.com/v1") is None
+
+    def test_the_config_value_beats_the_embedding_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", "http://127.0.0.1:9999/v1")
+        assert resolve_llm_endpoint(LOOPBACK) == LOOPBACK
+
+
+class TestNamerConstruction:
+    def test_flag_off_yields_no_namer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(LLM_ENDPOINT_ENV, LOOPBACK)
+        assert build_namer(_config(distill_use_llm=False)) is None
+
+    def test_flag_on_without_an_endpoint_yields_no_namer(self) -> None:
+        assert build_namer(_config()) is None
+
+    def test_flag_on_with_a_remote_endpoint_yields_no_namer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(LLM_ENDPOINT_ENV, "https://api.openai.com/v1")
+        assert build_namer(_config()) is None
+
+    def test_flag_on_with_a_loopback_endpoint_yields_a_namer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(LLM_ENDPOINT_ENV, LOOPBACK)
+        assert build_namer(_config(distill_llm_model="gemma-4-12b")) is not None
+
+
+class _Runner:
+    """Stands in for the unload subprocess; records argv, never spawns anything."""
+
+    def __init__(self, exit_code: int = 0, raises: Exception | None = None) -> None:
+        self._exit_code = exit_code
+        self._raises = raises
+        self.calls: list[list[str]] = []
+
+    async def __call__(self, argv: list[str], timeout: float) -> int:
+        self.calls.append(list(argv))
+        if self._raises is not None:
+            raise self._raises
+        return self._exit_code
+
+
+@pytest.fixture
+def namer_factory(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(LLM_ENDPOINT_ENV, LOOPBACK)
+
+    def _make(*responses: Any) -> tuple[Any, _Transport]:
+        transport = _Transport(*responses)
+        namer = build_namer(_config(distill_llm_model="gemma-4-12b"), post_json=transport)
+        assert namer is not None
+        return namer, transport
+
+    return _make
+
+
+@pytest.fixture
+def releasing_namer_factory(monkeypatch: pytest.MonkeyPatch):
+    """A namer configured with an unload command plus a recording runner."""
+    monkeypatch.setenv(LLM_ENDPOINT_ENV, LOOPBACK)
+
+    def _make(*responses: Any, runner: _Runner | None = None) -> tuple[Any, _Transport, _Runner]:
+        transport = _Transport(*responses)
+        run = runner or _Runner()
+        namer = build_namer(
+            _config(
+                distill_llm_model="gemma-4-12b",
+                distill_llm_unload_cmd=("llamastash", "stop", "{model}", "-y"),
+            ),
+            post_json=transport,
+            run_command=run,
+        )
+        assert namer is not None
+        return namer, transport, run
+
+    return _make
+
+
+class TestSuccessfulRename:
+    async def test_prose_is_replaced_by_the_model_output(self, namer_factory) -> None:
+        namer, _ = namer_factory(_completion(_good_json()))
+
+        renamed = await namer.rename(_pattern(), _traces())
+
+        assert renamed["title"] == "Read before editing"
+        assert renamed["description"].startswith("Establish the current state")
+        assert renamed["strategy"].startswith("1. Read the target.")
+
+    async def test_identity_and_statistics_survive_the_rename(self, namer_factory) -> None:
+        """Renaming must not make a known pattern look like a new one."""
+        namer, _ = namer_factory(_completion(_good_json()))
+        original = _pattern()
+
+        renamed = await namer.rename(original, _traces())
+
+        for key in ("signature", "confidence", "frequency", "model", "category"):
+            assert renamed[key] == original[key], f"{key} must not be touched by naming"
+
+    async def test_the_input_pattern_is_not_mutated(self, namer_factory) -> None:
+        namer, _ = namer_factory(_completion(_good_json()))
+        original = _pattern()
+        before = dict(original)
+
+        renamed = await namer.rename(original, _traces())
+
+        assert original == before
+        assert renamed is not original
+
+    async def test_a_fenced_json_block_is_parsed(self, namer_factory) -> None:
+        """Small local models habitually wrap JSON in a markdown fence."""
+        namer, _ = namer_factory(_completion(f"```json\n{_good_json()}\n```"))
+
+        renamed = await namer.rename(_pattern(), _traces())
+
+        assert renamed["title"] == "Read before editing"
+
+    async def test_prose_around_the_json_object_is_tolerated(self, namer_factory) -> None:
+        namer, _ = namer_factory(
+            _completion(f"Sure! Here is the pattern:\n{_good_json()}\nHope that helps.")
+        )
+
+        renamed = await namer.rename(_pattern(), _traces())
+
+        assert renamed["title"] == "Read before editing"
+
+    async def test_a_strategy_returned_as_a_list_of_steps_is_accepted(self, namer_factory) -> None:
+        """Observed live: asked for "numbered steps", the model sent a JSON array.
+
+        Refusing that would discard a good answer over its container type.
+        """
+        namer, _ = namer_factory(
+            _completion(
+                json.dumps(
+                    {
+                        "title": "Read the traceback first",
+                        "description": "Locate the failure before changing anything.",
+                        "strategy": [
+                            "Identify the reported failure.",
+                            "Examine the traceback.",
+                            "Re-run to confirm the fix.",
+                        ],
+                    }
+                )
+            )
+        )
+
+        renamed = await namer.rename(_pattern(), _traces())
+
+        assert renamed["strategy"] == (
+            "Identify the reported failure.\nExamine the traceback.\nRe-run to confirm the fix."
+        )
+
+    async def test_junk_inside_a_list_field_is_dropped(self, namer_factory) -> None:
+        namer, _ = namer_factory(
+            _completion(
+                json.dumps(
+                    {
+                        "title": "t",
+                        "description": "d",
+                        "strategy": ["keep this", "", None, {"nested": 1}, "and this"],
+                    }
+                )
+            )
+        )
+
+        renamed = await namer.rename(_pattern(), _traces())
+
+        assert renamed["strategy"] == "keep this\nand this"
+
+    async def test_an_empty_list_field_is_unusable(self, namer_factory) -> None:
+        namer, _ = namer_factory(
+            _completion(json.dumps({"title": "t", "description": "d", "strategy": []}))
+        )
+        original = _pattern()
+
+        assert await namer.rename(original, _traces()) == original
+
+    async def test_overlong_fields_are_capped(self, namer_factory) -> None:
+        namer, _ = namer_factory(
+            _completion(_good_json(title="T" * 500, description="D" * 5000, strategy="S" * 5000))
+        )
+
+        renamed = await namer.rename(_pattern(), _traces())
+
+        assert len(renamed["title"]) <= 120
+        assert len(renamed["description"]) <= 400
+        assert len(renamed["strategy"]) <= 1200
+
+
+class TestFallback:
+    """Every failure mode must degrade to the pre-existing mechanical naming."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "not json at all",
+            "{}",
+            '{"title": "only a title"}',
+            '{"title": 42, "description": "d", "strategy": "s"}',
+            '{"title": "", "description": "d", "strategy": "s"}',
+            '{"title": "t", "description": "d"}',
+            "[]",
+        ],
+        ids=[
+            "prose",
+            "empty-object",
+            "missing-fields",
+            "wrong-type",
+            "blank-title",
+            "missing-strategy",
+            "wrong-shape",
+        ],
+    )
+    async def test_unusable_output_keeps_the_mechanical_naming(
+        self, namer_factory, body: str
+    ) -> None:
+        namer, _ = namer_factory(_completion(body))
+        original = _pattern()
+
+        renamed = await namer.rename(original, _traces())
+
+        assert renamed == original
+
+    @pytest.mark.parametrize(
+        "failure",
+        [TimeoutError("timed out"), RuntimeError("connection refused"), ValueError("bad status")],
+        ids=["timeout", "refused", "bad-status"],
+    )
+    async def test_a_failing_endpoint_keeps_the_mechanical_naming(
+        self, namer_factory, failure: Exception
+    ) -> None:
+        namer, _ = namer_factory(failure)
+        original = _pattern()
+
+        renamed = await namer.rename(original, _traces())
+
+        assert renamed == original
+
+    async def test_a_malformed_envelope_keeps_the_mechanical_naming(self, namer_factory) -> None:
+        namer, _ = namer_factory({"unexpected": "shape"})
+        original = _pattern()
+
+        assert await namer.rename(original, _traces()) == original
+
+    async def test_an_answer_cut_off_by_the_token_limit_is_rejected(self, namer_factory) -> None:
+        """Half a JSON object is not a pattern name. Seen live: a reasoning
+        model spent the budget thinking and returned '```json\\n{\\n "title":'."""
+        namer, _ = namer_factory(
+            {
+                "choices": [
+                    {
+                        "finish_reason": "length",
+                        "message": {"content": '```json\n{\n  "title":'},
+                    }
+                ]
+            }
+        )
+        original = _pattern()
+
+        assert await namer.rename(original, _traces()) == original
+
+    async def test_a_reply_that_is_only_reasoning_is_rejected(self, namer_factory) -> None:
+        namer, _ = namer_factory(
+            {
+                "choices": [
+                    {
+                        "finish_reason": "length",
+                        "message": {"content": "", "reasoning_content": "Thinking Process: ..."},
+                    }
+                ]
+            }
+        )
+        original = _pattern()
+
+        assert await namer.rename(original, _traces()) == original
+
+
+class TestCircuitBreaker:
+    """A dead endpoint must not cost one timeout per cluster for a whole run."""
+
+    async def test_repeated_failures_stop_further_calls(self, namer_factory) -> None:
+        namer, transport = namer_factory(
+            RuntimeError("down"), RuntimeError("down"), RuntimeError("down")
+        )
+
+        for _ in range(6):
+            assert await namer.rename(_pattern(), _traces()) == _pattern()
+
+        assert len(transport.calls) == 3, "should give up after 3 consecutive failures"
+
+    async def test_a_success_resets_the_failure_count(self, namer_factory) -> None:
+        namer, transport = namer_factory(
+            RuntimeError("blip"),
+            RuntimeError("blip"),
+            _completion(_good_json()),
+            RuntimeError("blip"),
+            RuntimeError("blip"),
+            _completion(_good_json(title="Second wind")),
+        )
+
+        results = [(await namer.rename(_pattern(), _traces()))["title"] for _ in range(6)]
+
+        assert len(transport.calls) == 6
+        assert results[2] == "Read before editing"
+        assert results[5] == "Second wind"
+
+
+class TestPrompt:
+    async def test_the_request_targets_the_chat_completions_route(self, namer_factory) -> None:
+        namer, transport = namer_factory(_completion(_good_json()))
+
+        await namer.rename(_pattern(), _traces())
+
+        assert transport.calls[0]["url"] == f"{LOOPBACK}/chat/completions"
+        assert transport.calls[0]["payload"]["model"] == "gemma-4-12b"
+        assert transport.calls[0]["timeout"] > 0
+
+    async def test_the_prompt_carries_the_category_and_the_trace_content(
+        self, namer_factory
+    ) -> None:
+        namer, transport = namer_factory(_completion(_good_json()))
+
+        await namer.rename(_pattern(), _traces(content="I should segment the moves first."))
+
+        sent = json.dumps(transport.calls[0]["payload"])
+        assert "refactoring" in sent
+        assert "segment the moves" in sent
+
+    async def test_trace_content_is_truncated_before_it_is_sent(self, namer_factory) -> None:
+        """A 100k-char thinking block must not be shipped verbatim."""
+        namer, transport = namer_factory(_completion(_good_json()))
+
+        await namer.rename(_pattern(), _traces(content="x" * 100_000))
+
+        sent = json.dumps(transport.calls[0]["payload"])
+        assert len(sent) < 10_000
+
+    async def test_the_token_budget_fits_a_reasoning_model(self, namer_factory) -> None:
+        """A thinking model emits its reasoning first; a small budget yields nothing.
+
+        Observed against a local reasoning model: with a 400-token budget the
+        whole allowance went to ``reasoning_content``, ``content`` came back as
+        a half-written ``{"title":`` and ``finish_reason`` was ``length``.
+        """
+        namer, transport = namer_factory(_completion(_good_json()))
+
+        await namer.rename(_pattern(), _traces())
+
+        assert transport.calls[0]["payload"]["max_tokens"] >= 1000
+
+    async def test_thinking_is_switched_off_where_the_server_supports_it(
+        self, namer_factory
+    ) -> None:
+        namer, transport = namer_factory(_completion(_good_json()))
+
+        await namer.rename(_pattern(), _traces())
+
+        kwargs = transport.calls[0]["payload"]["chat_template_kwargs"]
+        assert kwargs == {"enable_thinking": False}
+
+    async def test_a_server_that_rejects_the_thinking_key_is_accommodated(
+        self, namer_factory
+    ) -> None:
+        """Dropped after one failure, and not retried immediately: a down
+        endpoint must not cost two calls per pattern."""
+        namer, transport = namer_factory(ValueError("unknown field"), _completion(_good_json()))
+
+        first = await namer.rename(_pattern(), _traces())
+        second = await namer.rename(_pattern(), _traces())
+
+        assert len(transport.calls) == 2, "the failure must not trigger an immediate retry"
+        assert "chat_template_kwargs" in transport.calls[0]["payload"]
+        assert "chat_template_kwargs" not in transport.calls[1]["payload"]
+        assert first["title"] == _pattern()["title"]
+        assert second["title"] == "Read before editing"
+
+    async def test_generation_is_deterministic(self, namer_factory) -> None:
+        """Naming is a labelling job; sampling only adds noise between runs."""
+        namer, transport = namer_factory(_completion(_good_json()))
+
+        await namer.rename(_pattern(), _traces())
+
+        assert transport.calls[0]["payload"]["temperature"] == 0.0
+
+    async def test_an_empty_cluster_is_not_sent_to_the_model(self, namer_factory) -> None:
+        namer, transport = namer_factory()
+        original = _pattern()
+
+        assert await namer.rename(original, []) == original
+        assert transport.calls == []
+
+
+class TestRelease:
+    """A chat model is loaded for the run's sake and must not outlive it.
+
+    The endpoint loads a catalog model on first request and keeps it resident
+    with no idle timeout, so a mining run that names ten patterns would leave a
+    multi-gigabyte model sitting in VRAM until something else evicted it.
+    ``release()`` is the other half of that acquisition -- and it only fires if
+    the run actually caused a load.
+    """
+
+    async def test_a_run_that_never_called_the_model_releases_nothing(
+        self, releasing_namer_factory
+    ) -> None:
+        namer, _transport, runner = releasing_namer_factory()
+
+        await namer.release()
+
+        assert runner.calls == [], "nothing was loaded, so nothing may be unloaded"
+
+    async def test_a_used_model_is_released(self, releasing_namer_factory) -> None:
+        namer, _transport, runner = releasing_namer_factory(_completion(_good_json()))
+
+        await namer.rename(_pattern(), _traces())
+        await namer.release()
+
+        assert runner.calls == [["llamastash", "stop", "gemma-4-12b", "-y"]]
+
+    async def test_a_failed_call_still_counts_as_a_load(self, releasing_namer_factory) -> None:
+        """The request reached the endpoint, so the model may well be resident."""
+        namer, _transport, runner = releasing_namer_factory(RuntimeError("read timeout"))
+
+        await namer.rename(_pattern(), _traces())
+        await namer.release()
+
+        assert len(runner.calls) == 1
+
+    async def test_the_command_is_argv_not_a_shell_string(self, releasing_namer_factory) -> None:
+        """No shell means no quoting bugs and no injection via a model name."""
+        namer, _transport, runner = releasing_namer_factory(_completion(_good_json()))
+
+        await namer.rename(_pattern(), _traces())
+        await namer.release()
+
+        argv = runner.calls[0]
+        assert isinstance(argv, list)
+        assert all(isinstance(part, str) for part in argv)
+        assert not any(";" in part or "|" in part or "&&" in part for part in argv)
+
+    async def test_release_is_idempotent(self, releasing_namer_factory) -> None:
+        namer, _transport, runner = releasing_namer_factory(_completion(_good_json()))
+
+        await namer.rename(_pattern(), _traces())
+        await namer.release()
+        await namer.release()
+        await namer.release()
+
+        assert len(runner.calls) == 1
+
+    async def test_renaming_after_release_reloads_and_re_releases(
+        self, releasing_namer_factory
+    ) -> None:
+        namer, _transport, runner = releasing_namer_factory(
+            _completion(_good_json()), _completion(_good_json())
+        )
+
+        await namer.rename(_pattern(), _traces())
+        await namer.release()
+        await namer.rename(_pattern(), _traces())
+        await namer.release()
+
+        assert len(runner.calls) == 2
+
+    @pytest.mark.parametrize(
+        "runner",
+        [_Runner(exit_code=1), _Runner(raises=FileNotFoundError("no such command"))],
+        ids=["non-zero-exit", "command-missing"],
+    )
+    async def test_a_failing_unload_never_raises(
+        self, releasing_namer_factory, runner: _Runner
+    ) -> None:
+        """A stuck model is a nuisance; a crashed mining run loses the work."""
+        namer, _transport, _run = releasing_namer_factory(_completion(_good_json()), runner=runner)
+
+        await namer.rename(_pattern(), _traces())
+        await namer.release()  # must not raise
+
+    async def test_no_unload_command_configured_is_a_no_op(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(LLM_ENDPOINT_ENV, LOOPBACK)
+        runner = _Runner()
+        namer = build_namer(
+            _config(distill_llm_model="gemma-4-12b"),
+            post_json=_Transport(_completion(_good_json())),
+            run_command=runner,
+        )
+        assert namer is not None
+
+        await namer.rename(_pattern(), _traces())
+        await namer.release()
+
+        assert runner.calls == []

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "2.13.0",
+  "version": "2.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "2.13.0",
+      "version": "2.17.0",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## The flag did nothing

`reasoning_training.distill_use_llm` has existed as a configuration field since reasoning training shipped. Nothing read it. Searching for the name finds the dataclass attribute, `to_dict`, `from_dict` and the TOML writer — and no consumer anywhere. Setting it changed the config file and had no other effect.

## What a pattern looked like

A distilled pattern was named after its own mechanics: the title was the cluster's three most frequent reasoning moves, the description the first 200 characters of the medoid trace — a raw thinking fragment, usually cut mid-sentence. Serviceable as an identifier, useless as an explanation, and it is exactly what `smem reasoning` displays and what injection ships to other models.

| | before | after |
|---|---|---|
| title | `debugging: restate-goal, gather-evidence, verify` | `Diagnose, Investigate, and Confirm Fix` |
| description | a mid-sentence slice of raw reasoning | `Debug by restating the objective, gathering diagnostic evidence, then confirming the resolution.` |
| strategy | `Moves: a -> b -> c` plus the same slice | a numbered, reusable procedure |

## Prose only

`model`, `category`, `confidence`, `frequency` and `signature` are untouched. `signature` is derived from the cluster's trace hashes, so renaming cannot fork a known pattern into a duplicate — toggling the flag changes how *future* patterns read, never how existing ones are identified. Existing patterns are not rewritten retroactively.

## Two properties make it safe to enable

**Loopback-only.** Trace content is raw model reasoning, so a non-loopback endpoint yields no namer and therefore no request at all. This is an invariant, not a default: no setting relaxes it. Ingest-time redaction lives upstream and can be switched off, so the transport guarantee has to stand on its own. Resolution order is `SURREAL_MEMORY_LLM_ENDPOINT` → the new `distill_llm_endpoint` config key → `SURREAL_MEMORY_EMBEDDING_ENDPOINT`.

**Fail-soft.** Missing endpoint, missing `httpx`, refused connection, timeout, HTTP error, or a model that answers in prose instead of JSON — every one falls back to the mechanical naming. Distillation never fails because naming failed. Three consecutive failures trip a circuit breaker, so a dead endpoint costs three attempts rather than one timeout per cluster for the whole run.

## The model is borrowed, not kept

Local model servers load a chat model on first request and typically keep it resident with no idle timeout, so naming a handful of patterns would leave several gigabytes parked in VRAM indefinitely.

Loading stays implicit — the first request pulls the model in — and `distill_llm_unload_cmd` releases it in a `finally`, so an aborted or failed run does not strand it either. The command is an **argv list executed without a shell**, so a model name can never become shell syntax; `{model}` is substituted, a part that is not plain command syntax voids the whole command, and it is read from the config file only, never from an API request. It fires only if the run actually issued a request, so a model something else loaded is left alone.

## Three failure modes only a live model exposes

Against a stubbed transport all three look like success, which is why they are called out:

- **A reasoning model spends its budget thinking first.** Too small a token allowance returns an empty `content` with `finish_reason: "length"` rather than a short answer. The budget now accommodates thinking, truncation is reported as its own diagnosis instead of a generic parse failure, and servers that support it are asked to skip the thinking phase — a server that rejects that request has the key dropped after one attempt, with no immediate retry (a down endpoint must not cost two calls per pattern).
- **A model asked for "numbered steps" answers with a JSON array**, not a string. Refusing a good answer over its container type was wrong; a list of scalars is now joined into lines.
- **Markdown fences and surrounding chatter** are located rather than assumed away.

## Added

- `reasoning_training.distill_llm_model` — the chat model to name with.
- `reasoning_training.distill_llm_endpoint` — loopback OpenAI-compatible base URL, for deployments that cannot easily add environment variables.
- `reasoning_training.distill_llm_unload_cmd` — argv run once after distillation.

## Also fixed

The npm and VS Code package lockfiles had drifted several releases behind their `package.json` files. Every package is back in version parity at 2.17.0.

## Test plan

- [x] 59 unit tests for the namer: endpoint resolution and precedence, the loopback refusal proving **no request is made**, identity/statistics preserved across a rename, fenced and chatter-wrapped JSON, list-valued fields, every unusable-output shape, transport failures, truncation, the circuit breaker and its reset, prompt caps, and the release lifecycle (never-used releases nothing, argv not a shell string, idempotent, failure never raises).
- [x] 4 integration tests that the distiller actually calls the namer and releases the model — including when the run raises.
- [x] Full suite: 6966 passed, coverage 70.95% against the 67% gate.
- [x] `ruff check`, `ruff format --check`, `mypy` clean.
- [x] End-to-end against a live local OpenAI-compatible server: model absent from VRAM before the run, pulled in during it, pattern renamed, and gone from VRAM afterwards — with the signature identical to the same cluster's heuristic run.


---

# Second commit: an impossible embedding configuration is now reported

Found while diagnosing an unrelated report of the wrong embedding provider being used, and included here because it ships in the same version.

## The gap

Every embedding provider guesses a dimension for a model it does not recognise — Gemini assumes 3072, the OpenAI-compatible providers 1536, Ollama 1024. Each guess is reasonable alone and dangerous in combination: aim a provider at another provider's model name and it confidently produces vectors of the wrong width, which the HNSW index rejects on every write.

Nothing reported it. `smem doctor` said **ok** as long as the provider's package was importable, and `smem_health` said available. The only symptom was writes failing for a width the configuration itself had asked for.

## Two rules

Applied in `smem doctor`, in `smem_health` and at MCP startup:

- **A hosted provider's catalogue is closed.** A model outside it is not "unlisted" — it is a request the API will refuse. The report names the models that provider does serve.
- **A catalogued model's dimension must match `embedding.dimension`**, because that is what the vector index is built from.

## Deliberately silent where it cannot know

This is the part that decides whether the check is useful or ignored:

- A local OpenAI-compatible server serves whatever files it was pointed at, so an unrecognised model name there is ordinary, not suspect.
- Only an **exact** catalogue hit counts as knowing a dimension. A provider's fallback is a guess, and calling a configuration broken on the strength of a guess would flag every local model name.

`_dimension_for` keeps its existing best-effort behaviour for the informational probe field; validation uses a separate strict lookup, so the two contracts do not get confused.

## Also fixed

`probe_embedding_capability` promised in its docstring never to raise, and raised. `importlib.util.find_spec("google.genai")` imports the parent package first, so on a machine without `google` installed the probe died with `ModuleNotFoundError` instead of answering "not installed" — in the one function whose job is to report exactly that, and which `smem_health` and MCP startup both call.

## Test plan

- [x] 38 tests: the catalogue rule, the dimension rule, the probe and the doctor branch.
- [x] A dedicated no-false-positives class covering ten working configurations, including a local OpenAI-compatible server with an arbitrary model name — the setup the check must never break.
- [x] Two tests pinning the never-raises promise.
- [x] Full suite: 7004 passed. `ruff check`, `ruff format --check`, `mypy` clean.
- [x] Verified against a real incoherent configuration: the validation names the offending model, lists the models the provider does serve, and states the fix.
