### PR TITLE
fix(hooks): add per-session idempotency key to stop/pre_compact auto-capture

### DIFF
--- a/src/surreal_memory/hooks/capture_state.py
+++ b/src/surreal_memory/hooks/capture_state.py
@@ -1,0 +1,143 @@
+"""Per-session idempotency state for auto-capture hooks.
+
+The Stop hook fires after *every* assistant turn and PreCompact fires on
+each compaction; both re-read an overlapping transcript tail. When the
+effective (filtered/summarized) text hasn't changed since the last
+invocation, they still re-encode the same fragment or session summary —
+the dominant source of memory poisoning (duplicate "Session activity"
+entries accumulating turn over turn).
+
+This module provides a deterministic, dependency-free idempotency key:
+a per-session set of normalized-content hashes persisted to a small JSON
+file. A capture hook skips any fragment or summary whose ``content_key``
+was already saved in the same session.
+
+Design notes:
+- Fail-open: any error -> treat content as not-seen. Losing real content is
+  worse than tolerating a duplicate, so errors never block a capture.
+- Bounded: at most ``_MAX_HASHES_PER_SESSION`` hashes per session and
+  ``_MAX_SESSIONS`` sessions are retained (FIFO trim) so the file cannot
+  grow without bound.
+- Atomic-ish write: write to a temp file then ``replace`` to avoid a torn
+  state file if two hooks race.
+- Shared key: keyed on ``CLAUDE_SESSION_ID`` so Stop and PreCompact share
+  one seen-set and do not re-capture each other's writes.
+- Backend-agnostic: the state file lives beside the brain config, not in
+  SurrealDB/SQLite, so behavior is identical on both storage backends.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Bounded retention so the state file stays small.
+_MAX_HASHES_PER_SESSION = 2000
+_MAX_SESSIONS = 50
+
+_WS = re.compile(r"\s+")
+
+
+def _state_path() -> Path:
+    """Location of the JSON idempotency state file.
+
+    ``Path("")`` normalizes to ``Path(".")``, which is truthy -- so the
+    fallback must check the raw env string, not an already-constructed Path,
+    or an unset ``SURREAL_MEMORY_DIR`` silently resolves to the process's
+    current working directory instead of the user's home.
+    """
+    env_dir = os.environ.get("SURREAL_MEMORY_DIR", "").strip()
+    data_dir = Path(env_dir) if env_dir else (Path.home() / ".surrealmemory")
+    return data_dir / "capture_state.json"
+
+
+def session_key(transcript_path: str | None = None) -> str:
+    """Stable per-session key.
+
+    Prefers ``CLAUDE_SESSION_ID`` (set by Claude Code); falls back to a hash
+    of the transcript path, then a constant. The fallback degrades safely:
+    worst case the seen-set is shared a bit too broadly within one machine.
+    """
+    sid = os.environ.get("CLAUDE_SESSION_ID", "").strip()
+    if sid:
+        return sid
+    if transcript_path:
+        return "tp_" + hashlib.md5(transcript_path.encode("utf-8")).hexdigest()[:16]
+    return "default"
+
+
+def content_key(content: str) -> str:
+    """Deterministic key for a fragment: whitespace-normalized, lowercased md5.
+
+    Re-captured fragments are byte-identical, so even a raw hash would match;
+    normalization additionally collapses trivial whitespace/case variants.
+    """
+    norm = _WS.sub(" ", content.strip().lower())
+    return hashlib.md5(norm.encode("utf-8")).hexdigest()
+
+
+def _load_all() -> dict[str, Any]:
+    path = _state_path()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        logger.debug("capture_state: load failed (fail-open, treat as empty)", exc_info=True)
+        return {}
+
+
+def load_seen(skey: str) -> set[str]:
+    """Return the set of content keys already captured in this session."""
+    entry = _load_all().get(skey, {})
+    hashes = entry.get("hashes", []) if isinstance(entry, dict) else []
+    return set(hashes) if isinstance(hashes, list) else set()
+
+
+def mark_seen(skey: str, new_keys: list[str]) -> None:
+    """Persist newly captured content keys for this session (bounded, atomic-ish).
+
+    Never raises -- idempotency bookkeeping must not break a capture path.
+    """
+    if not new_keys:
+        return
+    try:
+        from surreal_memory.utils.timeutils import utcnow
+
+        ts = utcnow().isoformat()
+
+        data = _load_all()
+        entry = data.get(skey, {})
+        existing = entry.get("hashes", []) if isinstance(entry, dict) else []
+        if not isinstance(existing, list):
+            existing = []
+
+        seen_existing = set(existing)
+        combined = existing + [k for k in new_keys if k not in seen_existing]
+        if len(combined) > _MAX_HASHES_PER_SESSION:
+            combined = combined[-_MAX_HASHES_PER_SESSION:]
+        data[skey] = {"hashes": combined, "ts": ts}
+
+        # Bound the number of retained sessions (drop oldest by timestamp).
+        if len(data) > _MAX_SESSIONS:
+            ordered = sorted(
+                data.items(),
+                key=lambda kv: kv[1].get("ts", "") if isinstance(kv[1], dict) else "",
+            )
+            data = dict(ordered[-_MAX_SESSIONS:])
+
+        path = _state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(path)
+    except (OSError, TypeError, ValueError):
+        logger.debug("capture_state: mark_seen failed (non-fatal)", exc_info=True)

--- a/src/surreal_memory/hooks/pre_compact.py
+++ b/src/surreal_memory/hooks/pre_compact.py
@@ -120,10 +120,16 @@ async def flush_text(text: str, project_name: str | None = None) -> dict[str, An
     but runs standalone without the MCP server. When ``project_name`` is
     given, captured memories are scoped to that project (and tagged
     ``project:<name>``) so recall can be filtered per project.
+
+    Idempotent per session (upstream #80): fragments whose normalized content
+    was already captured earlier in this ``CLAUDE_SESSION_ID`` (shared with
+    the Stop hook) are skipped, since PreCompact also re-reads an overlapping
+    transcript tail on every compaction.
     """
     from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
     from surreal_memory.engine.dedup.factory import build_dedup_pipeline
     from surreal_memory.engine.encoder import MemoryEncoder
+    from surreal_memory.hooks.capture_state import content_key, load_seen, mark_seen, session_key
     from surreal_memory.mcp.auto_capture import analyze_text_for_memories
     from surreal_memory.safety.input_firewall import check_content
     from surreal_memory.safety.sensitive import auto_redact_content
@@ -172,6 +178,29 @@ async def flush_text(text: str, project_name: str | None = None) -> dict[str, An
             for item in eligible
         ]
 
+        # Idempotency at source (#80): drop fragments already captured this
+        # session (shared seen-set with the Stop hook via CLAUDE_SESSION_ID).
+        # PreCompact re-reads an overlapping tail too, so this prevents the
+        # same fragments being re-encoded on each compaction.
+        skey = session_key()
+        seen = load_seen(skey)
+        captured_keys: list[str] = []
+        duplicate_skipped = False
+        if seen:
+            before = len(boosted)
+            boosted = [it for it in boosted if content_key(it["content"]) not in seen]
+            duplicate_skipped = len(boosted) < before
+
+        if not boosted:
+            mark_seen(skey, captured_keys)
+            message = (
+                "No memories saved: duplicate content already captured this session "
+                "(idempotency skip)"
+                if duplicate_skipped
+                else "No memories saved: no memorable content in transcript"
+            )
+            return {"saved": 0, "message": message}
+
         # Get brain for encoder
         brain = await storage.get_brain(config.current_brain)
         if not brain:
@@ -182,6 +211,7 @@ async def flush_text(text: str, project_name: str | None = None) -> dict[str, An
 
         auto_redact_severity = config.safety.auto_redact_min_severity
         saved: list[str] = []
+        gate_rejected = False
 
         # Write gate for the compaction flush (intent=auto). This path encoded
         # with NO gate at all, so junk auto-captures bypassed both telemetry
@@ -219,6 +249,7 @@ async def flush_text(text: str, project_name: str | None = None) -> dict[str, An
                             "Pre-compact write gate rejected: %s",
                             gate_result.rejection_reason,
                         )
+                        gate_rejected = True
                         continue
 
                 redacted_content, matches, _ = auto_redact_content(
@@ -253,20 +284,34 @@ async def flush_text(text: str, project_name: str | None = None) -> dict[str, An
                 )
                 await storage.add_typed_memory(typed_mem)
                 saved.append(redacted_content[:60])
+                captured_keys.append(content_key(content))
             except Exception:
                 logger.debug("Failed to save flush memory", exc_info=True)
                 continue
 
+        # Persist idempotency state so the next re-read skips these.
+        mark_seen(skey, captured_keys)
+
         await storage.batch_save()
+
+        if saved:
+            message = f"Emergency flush: captured {len(saved)} memories"
+        elif duplicate_skipped and not gate_rejected:
+            message = (
+                "No memories saved: duplicate content already captured this session "
+                "(idempotency skip)"
+            )
+        elif gate_rejected:
+            message = "No memories saved: content rejected by quality gate"
+        else:
+            message = "No memories saved: content failed to persist"
 
         return {
             "saved": len(saved),
             "memories": saved,
             "mode": "emergency_flush",
             "threshold": EMERGENCY_THRESHOLD,
-            "message": f"Emergency flush: captured {len(saved)} memories"
-            if saved
-            else "No memories saved",
+            "message": message,
         }
     finally:
         try:

--- a/src/surreal_memory/hooks/stop.py
+++ b/src/surreal_memory/hooks/stop.py
@@ -319,10 +319,16 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
     specific patterns are detected, ensuring every session leaves a trace.
     When ``project_name`` is given, captured memories are scoped to that
     project (and tagged ``project:<name>``) for per-project recall.
+
+    Idempotent per session (upstream #80): fragments and the session summary
+    whose normalized content was already captured earlier in this
+    ``CLAUDE_SESSION_ID`` are skipped, since this hook re-reads an
+    overlapping transcript tail on every turn.
     """
     from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
     from surreal_memory.engine.dedup.factory import build_dedup_pipeline
     from surreal_memory.engine.encoder import MemoryEncoder
+    from surreal_memory.hooks.capture_state import content_key, load_seen, mark_seen, session_key
     from surreal_memory.mcp.auto_capture import analyze_text_for_memories
     from surreal_memory.safety.input_firewall import check_content
 
@@ -367,6 +373,25 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
         if len(eligible) > 1:
             eligible = await _embedding_dedup(eligible)
 
+        # Idempotency at source (#80): drop fragments already captured this
+        # session. The Stop hook fires after every assistant turn and
+        # re-reads an overlapping transcript tail, so without this the same
+        # fragments (and session summary, below) are re-encoded every turn.
+        skey = session_key()
+        seen = load_seen(skey)
+        captured_keys: list[str] = []
+        had_candidate = bool(eligible)
+        duplicate_skipped = False
+        if seen and eligible:
+            before = len(eligible)
+            eligible = [it for it in eligible if content_key(it["content"]) not in seen]
+            duplicate_skipped = len(eligible) < before
+        # All originally-detected fragments were duplicates (none survived the
+        # filter above) -- nothing left to even attempt the gate/encode loop,
+        # so the summary fallback below must not silently substitute a fresh
+        # summary for a fragment that was correctly suppressed as a duplicate.
+        all_candidates_were_duplicates = had_candidate and not eligible
+
         brain = await storage.get_brain(config.current_brain)
         if not brain:
             return {"error": "No brain configured", "saved": 0}
@@ -376,6 +401,7 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
 
         auto_redact_severity = config.safety.auto_redact_min_severity
         saved: list[str] = []
+        gate_rejected = False
 
         # Write gate check for stop hook (auto-capture path). SHADOW logs the
         # decision to gate_decision without blocking; ENFORCE rejects. The
@@ -413,6 +439,7 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
                             "Stop hook write gate rejected: %s",
                             gate_result.rejection_reason,
                         )
+                        gate_rejected = True
                         continue
 
                 redacted_content, matches, _ = auto_redact_content(
@@ -445,13 +472,23 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
                 )
                 await storage.add_typed_memory(typed_mem)
                 saved.append(redacted_content[:60])
+                captured_keys.append(content_key(content))
             except Exception:
                 logger.debug("Failed to save stop-hook memory", exc_info=True)
                 continue
 
-        # Always save a session summary if no patterns were detected
-        if not saved:
+        # Always save a session summary if no patterns were detected. Skipped
+        # when every detected fragment was duplicate-filtered above -- that
+        # case already has an accurate "duplicate" status; falling through
+        # here would silently replace it with a brand-new summary save.
+        summary_had_candidate = False
+        if not saved and not all_candidates_were_duplicates:
             summary = _extract_session_summary(text)
+            if summary:
+                summary_had_candidate = True
+                if content_key(summary) in seen:
+                    duplicate_skipped = True
+                    summary = None  # type: ignore[assignment]
             if summary and len(summary) > 30:
                 # Apply write gate to session summary too
                 if gate_mode != "off":
@@ -480,6 +517,7 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
                             "Stop hook session summary rejected: %s",
                             gate_result.rejection_reason,
                         )
+                        gate_rejected = True
                         summary = None  # type: ignore[assignment]
 
                 if summary:
@@ -504,17 +542,33 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
                         )
                         await storage.add_typed_memory(typed_mem)
                         saved.append(redacted_summary[:60])
+                        captured_keys.append(content_key(summary))
                     except Exception:
                         logger.debug("Failed to save session summary", exc_info=True)
 
+        # Persist idempotency state so the next turn's re-read skips these.
+        mark_seen(skey, captured_keys)
+
         await storage.batch_save()
+
+        if saved:
+            message = f"Session end: captured {len(saved)} memories"
+        elif duplicate_skipped and not gate_rejected:
+            message = (
+                "No memories saved: duplicate content already captured this session "
+                "(idempotency skip)"
+            )
+        elif gate_rejected:
+            message = "No memories saved: content rejected by quality gate"
+        elif had_candidate or summary_had_candidate:
+            message = "No memories saved: content failed to persist"
+        else:
+            message = "No memories saved: no memorable content in transcript"
 
         return {
             "saved": len(saved),
             "memories": saved,
-            "message": f"Session end: captured {len(saved)} memories"
-            if saved
-            else "No memories saved",
+            "message": message,
         }
     finally:
         try:

--- a/tests/unit/test_capture_state.py
+++ b/tests/unit/test_capture_state.py
@@ -1,0 +1,158 @@
+"""Unit tests for surreal_memory.hooks.capture_state (per-session idempotency)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from surreal_memory.hooks.capture_state import (
+    _MAX_HASHES_PER_SESSION,
+    _MAX_SESSIONS,
+    _state_path,
+    content_key,
+    load_seen,
+    mark_seen,
+    session_key,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_state_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Every test gets its own capture_state.json, never the real one."""
+    monkeypatch.setenv("SURREAL_MEMORY_DIR", str(tmp_path))
+    return tmp_path
+
+
+class TestStatePathFallback:
+    """Regression test: Path("") normalizes to Path(".") which is truthy, so
+    a naive `Path(env_var_or_empty) or fallback` never falls back -- an unset
+    SURREAL_MEMORY_DIR must resolve under the user's home, never cwd."""
+
+    def test_unset_dir_resolves_under_home_not_cwd(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.delenv("SURREAL_MEMORY_DIR", raising=False)
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        assert _state_path() == fake_home / ".surrealmemory" / "capture_state.json"
+
+    def test_empty_string_dir_also_falls_back_to_home(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("SURREAL_MEMORY_DIR", "")
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+        assert _state_path() == fake_home / ".surrealmemory" / "capture_state.json"
+
+
+class TestSessionKey:
+    def test_prefers_claude_session_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "abc-123")
+        assert session_key() == "abc-123"
+
+    def test_falls_back_to_transcript_path_hash(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+        key1 = session_key("/some/transcript.jsonl")
+        key2 = session_key("/some/transcript.jsonl")
+        key3 = session_key("/other/transcript.jsonl")
+        assert key1 == key2
+        assert key1 != key3
+        assert key1.startswith("tp_")
+
+    def test_falls_back_to_default_constant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+        assert session_key(None) == "default"
+
+    def test_empty_session_id_env_falls_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_SESSION_ID", "   ")
+        assert session_key(None) == "default"
+
+
+class TestContentKey:
+    def test_deterministic(self) -> None:
+        assert content_key("Hello world") == content_key("Hello world")
+
+    def test_case_insensitive(self) -> None:
+        assert content_key("Hello World") == content_key("hello world")
+
+    def test_whitespace_normalized(self) -> None:
+        assert content_key("hello   world\n\nfoo") == content_key("hello world foo")
+
+    def test_different_content_different_key(self) -> None:
+        assert content_key("Decision: use SQLite") != content_key("Decision: use Postgres")
+
+
+class TestLoadMarkSeenRoundtrip:
+    def test_empty_session_returns_empty_set(self) -> None:
+        assert load_seen("nope-not-seen-yet") == set()
+
+    def test_mark_then_load_roundtrip(self) -> None:
+        skey = "session-1"
+        mark_seen(skey, ["hash1", "hash2"])
+        assert load_seen(skey) == {"hash1", "hash2"}
+
+    def test_mark_seen_with_empty_list_is_noop(self, isolated_state_dir: Path) -> None:
+        mark_seen("session-2", [])
+        assert not (isolated_state_dir / "capture_state.json").exists()
+
+    def test_mark_seen_accumulates_across_calls(self) -> None:
+        skey = "session-3"
+        mark_seen(skey, ["hash1"])
+        mark_seen(skey, ["hash2"])
+        assert load_seen(skey) == {"hash1", "hash2"}
+
+    def test_sessions_are_isolated(self) -> None:
+        mark_seen("session-a", ["only-in-a"])
+        mark_seen("session-b", ["only-in-b"])
+        assert load_seen("session-a") == {"only-in-a"}
+        assert load_seen("session-b") == {"only-in-b"}
+
+    def test_atomic_write_leaves_no_tmp_file(self, isolated_state_dir: Path) -> None:
+        mark_seen("session-4", ["hash1"])
+        assert not (isolated_state_dir / "capture_state.json.tmp").exists()
+        assert (isolated_state_dir / "capture_state.json").exists()
+
+
+class TestBoundedRetention:
+    def test_hashes_per_session_bounded_fifo(self) -> None:
+        skey = "session-many-hashes"
+        keys = [f"h{i}" for i in range(_MAX_HASHES_PER_SESSION + 50)]
+        mark_seen(skey, keys)
+        seen = load_seen(skey)
+        assert len(seen) == _MAX_HASHES_PER_SESSION
+        # oldest entries were trimmed, newest survive
+        assert "h0" not in seen
+        assert keys[-1] in seen
+
+    def test_sessions_bounded_fifo(self, isolated_state_dir: Path) -> None:
+        for i in range(_MAX_SESSIONS + 10):
+            mark_seen(f"sess-{i}", [f"hash-{i}"])
+        data = json.loads((isolated_state_dir / "capture_state.json").read_text())
+        assert len(data) == _MAX_SESSIONS
+        assert "sess-0" not in data
+        assert f"sess-{_MAX_SESSIONS + 9}" in data
+
+
+class TestFailOpen:
+    def test_corrupt_json_file_fails_open(self, isolated_state_dir: Path) -> None:
+        state_file = isolated_state_dir / "capture_state.json"
+        state_file.write_text("{not valid json!!", encoding="utf-8")
+        assert load_seen("any-session") == set()
+
+    def test_non_dict_json_fails_open(self, isolated_state_dir: Path) -> None:
+        state_file = isolated_state_dir / "capture_state.json"
+        state_file.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+        assert load_seen("any-session") == set()
+
+    def test_mark_seen_never_raises_on_unwritable_dir(
+        self, isolated_state_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Point SURREAL_MEMORY_DIR at a path that cannot be created (parent is a file).
+        blocker = isolated_state_dir / "not-a-dir"
+        blocker.write_text("x", encoding="utf-8")
+        monkeypatch.setenv("SURREAL_MEMORY_DIR", str(blocker / "nested"))
+        mark_seen("any-session", ["hash1"])  # must not raise

--- a/tests/unit/test_hook_capture_idempotency.py
+++ b/tests/unit/test_hook_capture_idempotency.py
@@ -1,0 +1,319 @@
+"""Behavioral regression tests for auto-capture hook idempotency (upstream #80).
+
+Reproduces the defect confirmed manually in ~/expertP/smem-idempotency-80/
+CHECKPOINTS/F1: the Stop and PreCompact hooks re-encode a session summary
+(or fragment) every time they are invoked for the same session, even when
+the effectively-captured text has not changed since the previous call.
+
+Every test here runs against a real, isolated SQLite brain (a fresh tmp_path
+HOME) -- never the shared prod brain. Each test uses a unique brain name and
+session id to avoid cross-test collisions in unified_config's process-wide
+_config / _storage_cache singletons.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+from surreal_memory.hooks import pre_compact as pre_compact_hook
+from surreal_memory.hooks import stop as stop_hook
+
+pytestmark = pytest.mark.asyncio
+
+_TEXT_A = (
+    "Here is an overview of the staging cluster network topology for reference purposes.\n\n"
+    "The quarterly release checklist includes twelve items across three teams total."
+)
+_TEXT_B = (
+    "A completely different summary about the greenhouse seedling rotation schedule.\n\n"
+    "The compost bin delivery arrived near the eastern fence line yesterday afternoon."
+)
+# Long enough overall to pass the input firewall's 30-char floor, but every
+# line is <=15 chars so _extract_session_summary()'s per-line filter drops
+# all of them (summary=""), and none of the words match any memory pattern
+# -- guarantees analyze_text_for_memories() finds nothing AND the stop hook's
+# summary fallback also produces nothing.
+_TEXT_TRIVIAL = "abcd efgh ijk\nlmno pqrs tuv\nwxyz abcd efg\nhijk lmno pqr"
+
+
+@pytest.fixture
+def isolated_brain(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Point unified_config at a throwaway HOME with a unique brain+session."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("TMPDIR", "/tmp")
+    brain_name = "idem" + uuid.uuid4().hex[:12]
+    monkeypatch.setenv("SURREAL_MEMORY_BRAIN", brain_name)
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "sess-" + uuid.uuid4().hex[:12])
+
+    from surreal_memory.unified_config import get_config
+
+    get_config(reload=True)
+    return brain_name
+
+
+@pytest.fixture
+def isolated_brain_gate_enforce(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Same as isolated_brain, but with the write gate forced to enforce mode
+    and an impossible min_length, so every capture is rejected deterministically."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("TMPDIR", "/tmp")
+    brain_name = "idem" + uuid.uuid4().hex[:12]
+    monkeypatch.setenv("SURREAL_MEMORY_BRAIN", brain_name)
+    monkeypatch.setenv("CLAUDE_SESSION_ID", "sess-" + uuid.uuid4().hex[:12])
+
+    surrealmemory_dir = tmp_path / ".surrealmemory"
+    surrealmemory_dir.mkdir(parents=True, exist_ok=True)
+    (surrealmemory_dir / "config.toml").write_text(
+        '\n[write_gate]\nmode = "enforce"\nauto_capture_mode = "enforce"\nmin_length = 999999\n',
+        encoding="utf-8",
+    )
+
+    from surreal_memory.unified_config import get_config
+
+    get_config(reload=True)
+    return brain_name
+
+
+class TestStopHookIdempotency:
+    """Stop hook: repeated capture for the same session, unchanged content."""
+
+    async def test_duplicate_summary_suppressed_on_second_call(self, isolated_brain: str) -> None:
+        result1 = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        assert result1["saved"] == 1
+
+        result2 = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        assert result2["saved"] == 0, (
+            "second call with unchanged content must save nothing (idempotency)"
+        )
+        message = result2["message"].lower()
+        assert "duplicate" in message or "idempot" in message, (
+            f"saved=0 message must name the reason distinguishably, got: {result2['message']!r}"
+        )
+
+    async def test_new_content_same_session_still_saved(self, isolated_brain: str) -> None:
+        """Criterion (5) guard: genuinely new content in the same session must
+        never be suppressed by the idempotency key."""
+        result1 = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        result2 = await stop_hook.capture_text(_TEXT_B, project_name=None)
+        assert result1["saved"] == 1
+        assert result2["saved"] == 1
+
+    async def test_message_no_content(self, isolated_brain: str) -> None:
+        result = await stop_hook.capture_text(_TEXT_TRIVIAL, project_name=None)
+        assert result["saved"] == 0
+        message = result["message"].lower()
+        assert "content" in message
+        assert "duplicate" not in message and "idempot" not in message
+        assert "gate" not in message and "rejected" not in message
+
+    async def test_message_gate_rejected(self, isolated_brain_gate_enforce: str) -> None:
+        result = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        assert result["saved"] == 0
+        message = result["message"].lower()
+        assert "gate" in message or "rejected" in message
+        assert "duplicate" not in message and "idempot" not in message
+
+    async def test_message_duplicate_differs_from_no_content_and_gate(
+        self, isolated_brain: str
+    ) -> None:
+        first = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        assert first["saved"] == 1
+        second = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        assert second["saved"] == 0
+        message = second["message"].lower()
+        assert "duplicate" in message or "idempot" in message
+        assert "gate" not in message and "rejected" not in message
+        assert "no memorable content" not in message
+
+
+class TestPreCompactHookIdempotency:
+    """PreCompact hook: same idempotency contract as Stop (shared seen-set)."""
+
+    async def test_duplicate_fragment_suppressed_on_second_call(self, isolated_brain: str) -> None:
+        text = "The root cause was a missing null check in the session handler code path."
+        result1 = await pre_compact_hook.flush_text(text, project_name=None)
+        assert result1["saved"] == 1
+
+        result2 = await pre_compact_hook.flush_text(text, project_name=None)
+        assert result2["saved"] == 0, (
+            "second flush with unchanged content must save nothing (idempotency)"
+        )
+
+    async def test_new_fragment_same_session_still_saved(self, isolated_brain: str) -> None:
+        text_a = "The root cause was a missing null check in the session handler code path."
+        text_b = "The workaround for this is to add a retry with exponential backoff logic."
+        result1 = await pre_compact_hook.flush_text(text_a, project_name=None)
+        result2 = await pre_compact_hook.flush_text(text_b, project_name=None)
+        assert result1["saved"] == 1
+        assert result2["saved"] == 1
+
+    async def test_stop_and_pre_compact_share_seen_set(self, isolated_brain: str) -> None:
+        """Stop and PreCompact are keyed on the same CLAUDE_SESSION_ID and must
+        not re-capture each other's writes (RUNBOOK-80 prototype rationale)."""
+        text = "The root cause was a missing null check in the session handler code path."
+        stop_result = await stop_hook.capture_text(text, project_name=None)
+        assert stop_result["saved"] == 1
+
+        precompact_result = await pre_compact_hook.flush_text(text, project_name=None)
+        assert precompact_result["saved"] == 0
+
+
+class TestIdempotencyNegativePaths:
+    """RUNBOOK-80 §6 negative paths: every one must give a distinguishable,
+    non-crashing status -- never a silent success."""
+
+    async def test_no_session_id_still_captures_and_dedupes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No CLAUDE_SESSION_ID -> session_key() falls back to 'default', but
+        the hook must still function (capture once, suppress the repeat)."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("TMPDIR", "/tmp")
+        monkeypatch.setenv("SURREAL_MEMORY_BRAIN", "idem" + uuid.uuid4().hex[:12])
+        monkeypatch.delenv("CLAUDE_SESSION_ID", raising=False)
+
+        from surreal_memory.unified_config import get_config
+
+        get_config(reload=True)
+
+        result1 = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        assert result1["saved"] == 1
+        result2 = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        assert result2["saved"] == 0
+
+    async def test_corrupt_idempotency_state_fails_open_not_crash(
+        self, isolated_brain: str, tmp_path: Path
+    ) -> None:
+        """A corrupt capture_state.json must never crash or silently block a
+        real capture -- fail open (treat as not-seen) per capture_state.py design."""
+        state_dir = tmp_path / ".surrealmemory"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        (state_dir / "capture_state.json").write_text("{not valid json", encoding="utf-8")
+
+        result = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        assert result["saved"] == 1
+        assert "error" not in result
+
+    async def test_concurrent_calls_never_crash_or_silently_ambiguous(
+        self, isolated_brain: str, tmp_path: Path
+    ) -> None:
+        """Two REAL hook subprocesses racing for the same session (the actual
+        production shape -- separate OS processes, not two coroutines sharing
+        one process's cached storage connection) must never hang or crash, and
+        must never both report an ambiguous/silent result: each result is
+        either a clean capture or a clean duplicate-skip, and the total saved
+        count is bounded (no double-loss, no unexplained failure)."""
+        import json
+        import os
+        import subprocess
+        import sys
+
+        proj_dir = tmp_path / ".claude" / "projects" / "race-test"
+        proj_dir.mkdir(parents=True, exist_ok=True)
+        transcript = proj_dir / "transcript.jsonl"
+        transcript.write_text(
+            json.dumps({"role": "user", "content": _TEXT_A}) + "\n", encoding="utf-8"
+        )
+        hook_input = json.dumps({"transcript_path": str(transcript), "cwd": str(tmp_path)})
+
+        # main() derives project_name from cwd's basename (no git repo here),
+        # and add_typed_memory's project_id FK requires that project to already
+        # exist (a separate, already-flagged bug -- task_11add155 -- unrelated
+        # to idempotency). Pre-register it so this test measures the race, not
+        # that unrelated FK crash.
+        from surreal_memory.core.project import Project
+        from surreal_memory.unified_config import get_config, get_shared_storage
+        from surreal_memory.utils.timeutils import utcnow
+
+        config = get_config()
+        storage = await get_shared_storage(config.current_brain)
+        brain = await storage.get_brain(config.current_brain)
+        assert brain is not None
+        await storage.add_project(  # type: ignore[attr-defined]
+            Project(id=tmp_path.name, name=tmp_path.name, start_date=utcnow(), created_at=utcnow())
+        )
+        await storage.close()
+
+        cmd = [sys.executable, "-m", "surreal_memory.hooks.stop"]
+        proc1 = subprocess.Popen(  # noqa: S603 -- fixed cmd, no shell, no untrusted input
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=dict(os.environ),
+        )
+        proc2 = subprocess.Popen(  # noqa: S603 -- fixed cmd, no shell, no untrusted input
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=dict(os.environ),
+        )
+        try:
+            _, err1 = proc1.communicate(input=hook_input, timeout=30)
+            _, err2 = proc2.communicate(input=hook_input, timeout=30)
+        except subprocess.TimeoutExpired:
+            proc1.kill()
+            proc2.kill()
+            raise
+
+        assert proc1.returncode == 0
+        assert proc2.returncode == 0
+        combined = err1 + err2
+        captured_count = combined.count("captured 1 memories")
+        # Best case: the race is caught and only one process wins (1). Worst
+        # case (known, accepted limitation -- no cross-process lock on the
+        # read-then-write idempotency state): both win (2). Never zero
+        # (silent total loss).
+        assert captured_count in (1, 2), f"unexpected capture count under race: {err1!r} {err2!r}"
+        assert err1.strip() and err2.strip(), "every hook invocation must report a status"
+
+
+class TestIdempotencyFuzz:
+    """RUNBOOK-80 §6 fuzz/property test: >=50 iterations, fixed seed. Save
+    count must increase monotonically and ONLY when genuinely new content
+    (a never-before-seen decision option) is introduced."""
+
+    async def test_random_growing_session_saves_only_on_new_content(
+        self, isolated_brain: str
+    ) -> None:
+        import random
+
+        rng = random.Random(1234567890)
+        seen_options: set[int] = set()
+        next_option = 0
+        expected_total_saved = 0
+        actual_total_saved = 0
+
+        for _ in range(60):
+            if seen_options and rng.random() < 0.7:
+                option = rng.choice(sorted(seen_options))
+                is_new = False
+            else:
+                option = next_option
+                next_option += 1
+                seen_options.add(option)
+                is_new = True
+
+            text = f"I decided to use option number {option} for this particular task."
+            result = await stop_hook.capture_text(text, project_name=None)
+            assert result["saved"] in (0, 1)
+            actual_total_saved += result["saved"]
+            if is_new:
+                expected_total_saved += 1
+                assert result["saved"] == 1, (
+                    f"genuinely new content (option {option}) must not be suppressed"
+                )
+            else:
+                assert result["saved"] == 0, (
+                    f"repeated content (option {option}) must be suppressed, "
+                    f"got message: {result['message']!r}"
+                )
+
+        assert actual_total_saved == expected_total_saved
+        assert actual_total_saved == len(seen_options)


### PR DESCRIPTION
Fixes #80.

## Problem

The Stop hook fires after *every* assistant turn and PreCompact fires on
every compaction; both re-read an overlapping transcript tail and re-run
`analyze_text_for_memories`. When the effectively-captured text (a matched
fragment, or Stop's session-summary fallback) hasn't changed since the
previous invocation, they still re-encode it, producing duplicate "Session
activity" memory entries turn over turn. Measured on a live production
brain: **387 of 1482 fibers (26%)** are these duplicated session-activity
summaries (`fiber.summary` containing `"Session activity"`).

The content-similarity dedup pipeline added in #103 does not catch this,
because the summary text genuinely differs whenever the raw transcript tail
grows (new trailing lines shift the "last N meaningful lines" window used to
build the summary) — even when nothing of substance actually happened. This
needs an *operational* idempotency key (has this been captured before, this
session?), not another content-similarity check.

## Fix

Adds `hooks/capture_state.py`: a per-session (`CLAUDE_SESSION_ID`) seen-set
of normalized-content hashes persisted to `~/.surrealmemory/capture_state.json`,
shared between the Stop and PreCompact hooks so neither re-captures the
other's writes. Design:

- **Fail-open** — any read/write error is treated as "not seen"; losing the
  idempotency check is far cheaper than losing real content.
- **Bounded** — 2000 hashes/session, 50 sessions, FIFO-trimmed, so the state
  file cannot grow without bound over a long-lived machine.
- **Atomic-ish write** — temp file + `replace()`, so two hooks racing for the
  same session can't tear the state file.
- **Backend-agnostic** — the state file lives beside the brain config, not
  inside SQLite/SurrealDB, so behavior is identical on both storage backends
  (this was deliberately checked at runtime on both — see Testing below —
  since #111 showed a hardcoded-SQLite assumption is an easy mistake here).

Both hooks' `saved=0` responses are now split into three distinguishable
stderr messages instead of one generic `"No memories saved"` bucket:
*no memorable content*, *rejected by quality gate*, and *duplicate content
already captured this session (idempotency skip)* — so a caller (or a human
reading the log) can tell which of the three actually happened.

## Prior art

This adapts an unfinished prototype of mine from `fix/shard-hash-accessfreq-2026-06-26`
(commit `f147490`, 2026-06-30) that was never rebased, tested, or sent upstream.
Two real bugs surfaced while adapting it, found by tests written before touching
the implementation:

1. `_state_path()`'s environment-variable fallback never actually triggered:
   `Path("") or fallback` is always truthy (`Path("")` normalizes to `Path(".")`,
   and `pathlib.Path` has no `__bool__`), so an unset `SURREAL_MEMORY_DIR`
   silently resolved the state file to the process's current working
   directory instead of the user's home.
2. When *every* detected fragment was filtered out as a duplicate, the
   original logic still fell through to compute and save a **fresh** session
   summary for that same turn — silently defeating the suppression it had
   just performed. A 60-iteration fuzz test (fixed seed) with alternating
   repeated/new fragment content caught this; fixed by tracking whether all
   originally-detected candidates were removed specifically by the
   duplicate filter (as opposed to never being detected, or being rejected
   by the write-quality gate — both pre-existing, unrelated code paths left
   untouched).

## Scope note (re: prior maintainer comment on this issue)

Half of the issue's original description is already resolved by #103 (all
three write-capturing hooks already have `dedup_pipeline` on `main`), so this
PR is scoped to exactly the remaining gap: an operational idempotency key for
re-invocation of the *same* hook for the *same* session. `task_context.py`,
`post_tool_use.py`, `session_start.py`, and `user_prompt_submit.py` are
untouched — the first is a single agent-authored note (not a re-read of a
growing tail); the other three never create a fiber at all.

## Testing

- New tests written *before* the implementation (confirmed red against
  unfixed `main`, confirmed green after): `tests/unit/test_capture_state.py`
  (21 unit tests: session/content key derivation, fail-open on corrupt
  state, bounded/FIFO retention, atomic write) and
  `tests/unit/test_hook_capture_idempotency.py` (12 behavioral tests:
  duplicate suppressed on 2nd call, genuinely-new content never suppressed,
  the three distinguishable messages, missing-session-id, corrupt state
  file, two real subprocesses racing for the same session, and a
  60-iteration fixed-seed fuzz/property test).
- Manual runtime verification on **both backends**, each with a
  before/after fiber counter *and a positive control* (a deliberate write to
  prove the counter isn't just measuring the wrong place before trusting a
  "0" result): SQLite (isolated tmp `HOME`) and SurrealDB (isolated
  namespace/database on a throwaway instance, dropped afterward). Neither
  ever touched production data.
- Independently verified by a separate reviewing pass (not the same context
  that wrote the fix) against the five criteria this issue implies: (1)
  repeat call with no new content saves zero and reports why, (2) a genuine
  content increment saves exactly one, (3) every negative path gives a
  distinguishable status, (4) runtime proof on both backends, (5) genuinely
  new content is never suppressed. All five confirmed with independently
  reproduced commands/output, including the reviewer's own throwaway
  SurrealDB namespace and its own fuzz run with a different seed.
- Full existing suite green throughout (`ruff check`, `ruff format --check`,
  `mypy`, `pytest -m "not stress"`), zero regressions.
