### PR TITLE
fix(storage): expiry cleanup no longer deletes pinned memories

### DIFF
--- a/src/surreal_memory/storage/sqlite_typed.py
+++ b/src/surreal_memory/storage/sqlite_typed.py
@@ -220,9 +220,17 @@ class SQLiteTypedMemoryMixin:
         brain_id = self._get_brain_id()
         limit = min(limit, 1000)
 
+        # LEFT JOIN (not JOIN): a typed_memory whose fiber was already deleted
+        # (orphan) must still be returned so the cleanup handler can reap the
+        # dangling row — only an *existing* fiber with pinned=1 protects its
+        # memory from expiry cleanup. pinned is the documented "never remove
+        # this" mechanism (already honored by consolidation/orphan-pruning);
+        # this path used to ignore it entirely (#112).
         async with conn.execute(
-            """SELECT * FROM typed_memories
-               WHERE brain_id = ? AND expires_at IS NOT NULL AND expires_at <= ?
+            """SELECT tm.* FROM typed_memories tm
+               LEFT JOIN fibers f ON f.id = tm.fiber_id AND f.brain_id = tm.brain_id
+               WHERE tm.brain_id = ? AND tm.expires_at IS NOT NULL AND tm.expires_at <= ?
+                 AND (f.pinned IS NULL OR f.pinned = 0)
                LIMIT ?""",
             (brain_id, utcnow().isoformat(), limit),
         ) as cursor:
@@ -233,9 +241,13 @@ class SQLiteTypedMemoryMixin:
         conn = self._ensure_conn()
         brain_id = self._get_brain_id()
 
+        # Mirrors get_expired_memories' pinned-fiber exclusion (#112) — see
+        # comment there for why this is a LEFT JOIN, not a JOIN.
         async with conn.execute(
-            """SELECT COUNT(*) FROM typed_memories
-               WHERE brain_id = ? AND expires_at IS NOT NULL AND expires_at <= ?""",
+            """SELECT COUNT(*) FROM typed_memories tm
+               LEFT JOIN fibers f ON f.id = tm.fiber_id AND f.brain_id = tm.brain_id
+               WHERE tm.brain_id = ? AND tm.expires_at IS NOT NULL AND tm.expires_at <= ?
+                 AND (f.pinned IS NULL OR f.pinned = 0)""",
             (brain_id, utcnow().isoformat()),
         ) as cursor:
             row = await cursor.fetchone()

--- a/src/surreal_memory/storage/surrealdb/typed_memory.py
+++ b/src/surreal_memory/storage/surrealdb/typed_memory.py
@@ -373,9 +373,25 @@ class SurrealDBTypedMemoryMixin:
     async def get_expired_memories(self, limit: int = 100) -> list[TypedMemory]:
         brain_id = self._get_brain_id()
         limit = min(limit, 1000)
+        # Exclude rows whose linked fiber is pinned=true — pinned is the
+        # documented "never remove this" mechanism (already honored by
+        # consolidation/orphan-pruning), but this path ignored it entirely
+        # (#112). typed_memory.fiber_id is the raw dash-form uuid while
+        # fiber:<id> uses the underscore form (see _to_surreal_id), so the
+        # correlated subquery re-derives it with string::replace. A typed_memory
+        # whose fiber no longer exists (orphan) has no row to correlate against,
+        # so the subquery evaluates to NONE — `NONE != true` is true, meaning
+        # orphans are still returned (and can still be reaped by the caller),
+        # matching the existing orphan-cleanup behavior this method had before.
+        # $parent is required: an unqualified `fiber_id` inside the subquery
+        # resolves against `fiber`'s own fields (which has no such field) and
+        # SurrealDB 3.2.3 raises "Incorrect arguments for function
+        # string::replace()" — verified live against a v3.2.3 instance.
         rows = await self._query(
             "SELECT * FROM typed_memory WHERE brain_id = $brain_id"
             " AND expires_at IS NOT NONE AND expires_at <= time::now()"
+            " AND (SELECT VALUE pinned FROM ONLY type::record('fiber',"
+            " string::replace($parent.fiber_id, '-', '_'))) != true"
             " LIMIT $limit",
             brain_id=brain_id,
             limit=limit,
@@ -384,9 +400,15 @@ class SurrealDBTypedMemoryMixin:
 
     async def get_expired_memory_count(self) -> int:
         brain_id = self._get_brain_id()
+        # Mirrors get_expired_memories' pinned-fiber exclusion (#112) — see
+        # comment there for the $parent.fiber_id / orphan-row rationale. Stays
+        # a single aggregate query (no N+1) to preserve the "cheap COUNT query
+        # for health pulse" contract documented on the base interface.
         rows = await self._query(
             "SELECT count() AS cnt FROM typed_memory"
             " WHERE brain_id = $brain_id AND expires_at IS NOT NONE AND expires_at <= time::now()"
+            " AND (SELECT VALUE pinned FROM ONLY type::record('fiber',"
+            " string::replace($parent.fiber_id, '-', '_'))) != true"
             " GROUP ALL",
             brain_id=brain_id,
         )

--- a/tests/unit/_surrealdb_live.py
+++ b/tests/unit/_surrealdb_live.py
@@ -42,6 +42,7 @@ LIVE_TEST_BRAIN_NAMES = frozenset(
         "u8-geo-live",  # test_surrealdb_geo_live.py
         "ub1-recordid-fix-live",  # test_surrealdb_recordid_fix_live.py
         "parity-test-surreal",  # test_get_project_memories.py
+        "pinned-expiry-test-9f3a1c",  # test_surrealdb_expiry_respects_pinned_live.py
     }
 )
 

--- a/tests/unit/test_sqlite_storage.py
+++ b/tests/unit/test_sqlite_storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import tempfile
 from datetime import timedelta
 from pathlib import Path
@@ -376,6 +377,54 @@ class TestSQLiteTypedMemories:
 
         expired = await storage.get_expired_memories()
         assert len(expired) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_expired_memories_excludes_pinned_fiber(
+        self, storage_with_fiber: tuple[SQLiteStorage, Fiber]
+    ) -> None:
+        """Regression (#112): an expired memory whose fiber is pinned must be
+        excluded from both get_expired_memories() and get_expired_memory_count()
+        — pinning is the documented "never remove this" mechanism and the
+        expiry-cleanup background task deletes whatever these two methods
+        return, with no other guard.
+        """
+        storage, fiber = storage_with_fiber
+        pinned_fiber = dataclasses.replace(fiber, pinned=True)
+        await storage.update_fiber(pinned_fiber)
+
+        typed_mem = TypedMemory(
+            fiber_id=fiber.id,
+            memory_type=MemoryType.TODO,
+            expires_at=utcnow() - timedelta(days=1),
+        )
+        await storage.add_typed_memory(typed_mem)
+
+        expired = await storage.get_expired_memories()
+        assert expired == []
+        assert await storage.get_expired_memory_count() == 0
+
+    @pytest.mark.asyncio
+    async def test_get_expired_memories_includes_unpinned_fiber(
+        self, storage_with_fiber: tuple[SQLiteStorage, Fiber]
+    ) -> None:
+        """No regression: an expired memory whose fiber is NOT pinned is still
+        returned/counted — this is the existing, correct behavior for
+        non-pinned expired memories.
+        """
+        storage, fiber = storage_with_fiber
+        assert fiber.pinned is False  # sanity: fixture fiber starts unpinned
+
+        typed_mem = TypedMemory(
+            fiber_id=fiber.id,
+            memory_type=MemoryType.TODO,
+            expires_at=utcnow() - timedelta(days=1),
+        )
+        await storage.add_typed_memory(typed_mem)
+
+        expired = await storage.get_expired_memories()
+        assert len(expired) == 1
+        assert expired[0].fiber_id == fiber.id
+        assert await storage.get_expired_memory_count() == 1
 
 
 class TestSQLiteProjects:

--- a/tests/unit/test_surrealdb_expiry_respects_pinned_live.py
+++ b/tests/unit/test_surrealdb_expiry_respects_pinned_live.py
@@ -1,0 +1,136 @@
+"""Regression (#112): expiry cleanup must never return a pinned memory.
+
+get_expired_memories()/get_expired_memory_count() used to filter only on
+expires_at, ignoring whether the memory's underlying fiber is pinned=true.
+Pinning is the documented "never remove this" mechanism (already honored by
+consolidation/orphan-pruning), but the expiry-cleanup background task
+(mcp/expiry_cleanup_handler.py) deletes whatever these two methods return —
+with no other guard, no confirmation, no dry-run — so this was silent,
+automatic data loss of exactly what the user explicitly protected.
+
+The test is skipped when SURREALDB_URL is unset so CI without docker still
+passes.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+import uuid
+from datetime import timedelta
+
+import pytest
+
+from surreal_memory.core.brain import Brain
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.memory_types import MemoryType, TypedMemory
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.utils.timeutils import utcnow
+from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
+
+SURREALDB_URL = os.getenv("SURREALDB_URL")
+
+pytestmark = pytest.mark.skipif(
+    not SURREALDB_URL,
+    reason="requires SURREALDB_URL env var pointing to a running SurrealDB",
+)
+
+
+@pytest.fixture
+async def surrealdb_storage():  # type: ignore[no-untyped-def]
+    ensure_real_surrealdb_sdk()
+    from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+    storage = SurrealDBStorage(url=SURREALDB_URL)
+    await storage.initialize()
+    brain = Brain.create(name="pinned-expiry-test-9f3a1c")
+    await storage.save_brain(brain)
+    storage.set_brain(brain.id)
+    yield storage
+    # Best-effort: drop this test's brain (and stale leftovers) from the
+    # shared DB so `smem brain list` doesn't accumulate test brains.
+    try:
+        await cleanup_live_brains(storage, own_brain_id=brain.id)
+    except Exception:
+        pass
+    try:
+        await storage.close()
+    except Exception:
+        pass
+
+
+async def _make_fiber(storage, idx: int, *, pinned: bool = False) -> Fiber:  # type: ignore[no-untyped-def]
+    """Create the neuron + fiber that a TypedMemory row references."""
+    neuron = Neuron.create(type=NeuronType.CONCEPT, content=f"pinned-expiry-{idx}")
+    await storage.add_neuron(neuron)
+    fiber = Fiber.create(
+        neuron_ids={neuron.id},
+        synapse_ids=set(),
+        anchor_neuron_id=neuron.id,
+        summary=f"fiber-{idx}",
+    )
+    await storage.add_fiber(fiber)
+    if pinned:
+        fiber = dataclasses.replace(fiber, pinned=True)
+        await storage.update_fiber(fiber)
+    return fiber
+
+
+@pytest.mark.asyncio
+async def test_get_expired_memories_excludes_pinned_fiber(surrealdb_storage) -> None:  # type: ignore[no-untyped-def]
+    """An expired memory whose fiber is pinned must be excluded from
+    get_expired_memories() and not counted by get_expired_memory_count().
+    """
+    fiber = await _make_fiber(surrealdb_storage, idx=1, pinned=True)
+    typed_mem = TypedMemory(
+        fiber_id=fiber.id,
+        memory_type=MemoryType.TODO,
+        expires_at=utcnow() - timedelta(days=1),
+    )
+    await surrealdb_storage.add_typed_memory(typed_mem)
+
+    expired = await surrealdb_storage.get_expired_memories()
+    assert fiber.id not in {m.fiber_id for m in expired}
+    assert await surrealdb_storage.get_expired_memory_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_get_expired_memories_includes_unpinned_fiber(surrealdb_storage) -> None:  # type: ignore[no-untyped-def]
+    """No regression: an expired memory whose fiber is NOT pinned is still
+    returned/counted — this is the existing, correct behavior for
+    non-pinned expired memories.
+    """
+    fiber = await _make_fiber(surrealdb_storage, idx=2, pinned=False)
+    typed_mem = TypedMemory(
+        fiber_id=fiber.id,
+        memory_type=MemoryType.TODO,
+        expires_at=utcnow() - timedelta(days=1),
+    )
+    await surrealdb_storage.add_typed_memory(typed_mem)
+
+    expired = await surrealdb_storage.get_expired_memories()
+    assert fiber.id in {m.fiber_id for m in expired}
+    assert await surrealdb_storage.get_expired_memory_count() == 1
+
+
+@pytest.mark.asyncio
+async def test_get_expired_memories_includes_orphan_typed_memory(surrealdb_storage) -> None:  # type: ignore[no-untyped-def]
+    """A typed_memory whose fiber has already been deleted (orphan — no fiber
+    row to correlate against) must still be returned/counted, preserving the
+    pre-fix orphan-cleanup behavior. Only an *existing* pinned fiber protects
+    its memory; a missing fiber has nothing to protect.
+    """
+    orphan_fiber_id = str(uuid.uuid4())
+    typed_mem = TypedMemory(
+        fiber_id=orphan_fiber_id,
+        memory_type=MemoryType.TODO,
+        expires_at=utcnow() - timedelta(days=1),
+    )
+    # SurrealDB's add_typed_memory does not verify fiber existence (unlike
+    # SQLite's), so this legitimately models a fiber deleted after its
+    # typed_memory row was created.
+    await surrealdb_storage.add_typed_memory(typed_mem)
+
+    expired = await surrealdb_storage.get_expired_memories()
+    assert orphan_fiber_id in {m.fiber_id for m in expired}
+    assert await surrealdb_storage.get_expired_memory_count() == 1


### PR DESCRIPTION
## Summary

- `get_expired_memories()` / `get_expired_memory_count()` filtered only on `expires_at`, never on whether the memory's fiber is `pinned` — pinning is the documented "never remove this" mechanism, already honored by consolidation/orphan-pruning, but not by expiry cleanup.
- This runs automatically: `MaintenanceConfig.expiry_cleanup_enabled` defaults to `True`, so a background task deletes whatever these methods return, with no confirmation or dry-run — a pinned memory past its `expires_at` was silently deleted in production.
- SQLite: `LEFT JOIN` (not `JOIN`) to `fibers` and exclude `pinned=1` rows — LEFT JOIN preserves existing behavior for typed_memory rows whose fiber was already deleted.
- SurrealDB: correlated subquery using `string::replace($parent.fiber_id, '-', '_')` to resolve the linked fiber's `pinned` flag, verified live against SurrealDB v3.2.3 including the orphan case. Both methods stay single queries (no N+1), preserving the "cheap COUNT for health pulse" contract on `get_expired_memory_count()`.

## Test plan

- [x] New regression tests on both backends: pinned+expired excluded, unpinned+expired still included (no regression)
- [x] RED→GREEN verified by reverting each fix and confirming the new tests fail, then restoring
- [x] Live SurrealDB v3.2.3 regression tests, test brain created and torn down, verified via `SELECT id, name FROM brain`
- [x] `ruff check` / `ruff format --check` / `mypy` clean on touched files
- [x] Full non-stress suite: 7094 passed (4 pre-existing, unrelated failures in `test_hook_capture_idempotency.py`, reproduced identically against clean `origin/main`)

Fixes #112