### PR TITLE
fix(consolidation): apply age/access guard to orphan neurons before pruning

### DIFF
--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -708,31 +708,43 @@ class ConsolidationEngine:
                 is_orphan = (
                     neuron.id not in connected_neuron_ids and neuron.id not in fiber_neuron_ids
                 )
-                if is_orphan:
-                    report.neurons_pruned += 1
-                    orphan_ids.append(neuron.id)
-                    continue
 
-                # Dead neuron: has connections but never accessed, old enough.
-                # Never applies to fiber members: reinforce() (retrieval.py) only
-                # bumps access_frequency for the top-10 highest-activation neurons
-                # per recall, so most neurons that are genuinely part of an
-                # actively-recalled fiber still read access_frequency == 0 forever.
-                # Without this guard, "dead" pruning deletes real memory content
-                # (measured live: 57150/63380 neuron_states were fiber members with
+                # Fiber members are never "dead neuron" candidates: reinforce()
+                # (retrieval.py) only bumps access_frequency for the top-10
+                # highest-activation neurons per recall, so most neurons that are
+                # genuinely part of an actively-recalled fiber still read
+                # access_frequency == 0 forever. Without this guard, "dead"
+                # pruning deletes real memory content (measured live:
+                # 57150/63380 neuron_states were fiber members with
                 # access_frequency == 0 — nearly the whole brain was wrongly
-                # eligible). Only a neuron with NO fiber membership at all (already
-                # excluded from is_orphan above only because it still has a direct
-                # synapse connection) is a genuine dead-neuron candidate.
+                # eligible). A fiber member can never be an orphan either (that
+                # requires NOT being in fiber_neuron_ids), so this skip is safe
+                # for both branches.
                 if neuron.id in fiber_neuron_ids:
                     continue
+
+                # Same never-accessed + old-enough predicate now gates BOTH the
+                # orphan branch and the dead-neuron branch (#113). Previously the
+                # orphan branch short-circuited straight to pruning — a neuron
+                # written moments ago, before consolidation had any chance to
+                # link it, was immediately deleted just for being momentarily
+                # unconnected. Hoisting this guard above the orphan short-circuit
+                # mirrors how the pinned guard was hoisted above both branches in
+                # #17: a merely-young or recently-accessed orphan is left alone
+                # and re-evaluated on the next consolidation pass instead of
+                # being deleted outright.
                 state = states.get(neuron.id)
                 freq = state.access_frequency if state else 0
                 if freq > 0:
                     continue
                 age_days = (reference_time - neuron.created_at).total_seconds() / 86400
-                if age_days >= dead_neuron_days:
-                    report.neurons_pruned += 1
+                if age_days < dead_neuron_days:
+                    continue
+
+                report.neurons_pruned += 1
+                if is_orphan:
+                    orphan_ids.append(neuron.id)
+                else:
                     dead_ids.append(neuron.id)
 
             offset += len(batch)

--- a/tests/unit/test_invariants.py
+++ b/tests/unit/test_invariants.py
@@ -12,6 +12,9 @@ Three categories:
 
 from __future__ import annotations
 
+from dataclasses import replace as dc_replace
+from datetime import timedelta
+
 import pytest
 import pytest_asyncio
 
@@ -26,6 +29,7 @@ from surreal_memory.engine.consolidation import (
 )
 from surreal_memory.engine.diagnostics import DiagnosticsEngine
 from surreal_memory.storage.memory_store import InMemoryStorage
+from surreal_memory.utils.timeutils import utcnow
 
 # ── Shared fixtures ──────────────────────────────────────────────
 
@@ -40,12 +44,20 @@ async def mixed_storage() -> InMemoryStorage:
     - n-both: in both synapse and fiber
     - n-anchor: fiber anchor, has synapse
     - n-orphan-1, n-orphan-2: truly orphaned (no synapse, no fiber)
+
+    The two orphans are backdated well past the default #113 age guard
+    (``BrainConfig.prune_dead_neuron_days`` = 14 days) so they remain
+    genuinely stale, eligible orphans for the tests below — a freshly
+    created (age ~0) orphan would no longer be immediately prune-eligible
+    after #113, which is the exact behavior this fixture's tests intend to
+    exercise (connectivity-based orphan detection, not the age gate itself).
     """
     store = InMemoryStorage()
     brain = Brain.create(name="mixed", config=BrainConfig(), owner_id="test")
     await store.save_brain(brain)
     store.set_brain(brain.id)
 
+    old_enough = utcnow() - timedelta(days=30)
     neurons = [
         Neuron.create(type=NeuronType.ENTITY, content="syn-a", neuron_id="n-syn-a"),
         Neuron.create(type=NeuronType.ENTITY, content="syn-b", neuron_id="n-syn-b"),
@@ -54,8 +66,14 @@ async def mixed_storage() -> InMemoryStorage:
         Neuron.create(type=NeuronType.SPATIAL, content="fib-c", neuron_id="n-fib-c"),
         Neuron.create(type=NeuronType.CONCEPT, content="both", neuron_id="n-both"),
         Neuron.create(type=NeuronType.ACTION, content="anchor", neuron_id="n-anchor"),
-        Neuron.create(type=NeuronType.ENTITY, content="orphan-1", neuron_id="n-orphan-1"),
-        Neuron.create(type=NeuronType.ENTITY, content="orphan-2", neuron_id="n-orphan-2"),
+        dc_replace(
+            Neuron.create(type=NeuronType.ENTITY, content="orphan-1", neuron_id="n-orphan-1"),
+            created_at=old_enough,
+        ),
+        dc_replace(
+            Neuron.create(type=NeuronType.ENTITY, content="orphan-2", neuron_id="n-orphan-2"),
+            created_at=old_enough,
+        ),
     ]
     for n in neurons:
         await store.add_neuron(n)

--- a/tests/unit/test_recall_quality.py
+++ b/tests/unit/test_recall_quality.py
@@ -187,7 +187,16 @@ class TestDeadNeuronPruning:
 
     @pytest.mark.asyncio
     async def test_young_neurons_not_pruned(self) -> None:
-        """Neurons younger than 14 days should NOT be pruned even with 0 access."""
+        """Neurons younger than 14 days should NOT be pruned even with 0 access.
+
+        Regression (#113): the orphan branch used to short-circuit straight to
+        deletion without checking age/access at all, so a young orphan (no
+        synapses, no fibers) was pruned immediately — before consolidation had
+        any chance to link it into the graph. The same never-accessed +
+        old-enough guard used for dead-neuron pruning now applies to the
+        orphan branch too, so a young orphan survives and is re-evaluated on
+        the next consolidation pass instead.
+        """
         from surreal_memory.engine.consolidation import ConsolidationConfig, ConsolidationEngine
 
         young_neuron = self._make_neuron("young", 5)
@@ -207,9 +216,10 @@ class TestDeadNeuronPruning:
         engine = ConsolidationEngine(storage, config)
         report = await engine.run(strategies=["prune"])
 
-        # Young neuron IS an orphan (no synapses, no fibers) so it gets pruned as orphan
-        # But it would NOT be pruned as "dead" — the orphan check catches it first
-        assert report.neurons_pruned >= 1
+        # Young neuron IS an orphan (no synapses, no fibers) but it is neither
+        # old enough nor previously accessed, so it must survive this pass.
+        assert report.neurons_pruned == 0
+        storage.delete_neurons_batch.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_accessed_neurons_not_pruned(self) -> None:
@@ -282,6 +292,132 @@ class TestDeadNeuronPruning:
         report = await engine.run(strategies=["prune"])
 
         assert report.neurons_pruned == 0
+
+
+# ---------------------------------------------------------------------------
+# Orphan neuron pruning respects the same age/access guard as dead-neuron
+# pruning (#113)
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanPruneAgeGuard:
+    """Regression tests for #113.
+
+    The orphan branch in ``ConsolidationEngine._prune`` used to short-circuit
+    straight to deletion for ANY unconnected neuron, without ever checking
+    age or access — unlike the dead-neuron branch just below it, which always
+    required never-accessed + old-enough. That meant a neuron written moments
+    ago, before consolidation had any chance to link it into the graph, was
+    pruned on the very next consolidation pass. The fix hoists the same
+    never-accessed + old-enough predicate above the orphan short-circuit,
+    mirroring how the pinned guard was hoisted above both branches in #17.
+    """
+
+    def _make_neuron(self, neuron_id: str, days_old: float) -> Neuron:
+        return Neuron(
+            id=neuron_id,
+            type=NeuronType.CONCEPT,
+            content=f"test content {neuron_id}",
+            created_at=utcnow() - timedelta(days=days_old),
+        )
+
+    def _make_state(self, neuron_id: str, freq: int = 0) -> NeuronState:
+        return NeuronState(neuron_id=neuron_id, access_frequency=freq)
+
+    def _make_storage(
+        self,
+        neuron: Neuron,
+        *,
+        freq: int = 0,
+        pinned_ids: set[str] | None = None,
+    ) -> AsyncMock:
+        """Storage double for a single orphan candidate: no synapses, no
+        fibers — i.e. unconditionally an orphan per the ``is_orphan`` check.
+        """
+        state = self._make_state(neuron.id, freq=freq)
+        storage = AsyncMock()
+        storage.current_brain_id = "test"
+        storage.get_synapses = AsyncMock(return_value=[])
+        storage.get_fibers = AsyncMock(return_value=[])
+        storage.get_pinned_neuron_ids = AsyncMock(return_value=pinned_ids or set())
+        storage.find_neurons = AsyncMock(side_effect=[[neuron], []])
+        storage.get_neuron_states_batch = AsyncMock(return_value={neuron.id: state})
+        storage.get_all_neuron_states = AsyncMock(return_value=[state])
+        storage.delete_neurons_batch = AsyncMock()
+        return storage
+
+    @pytest.mark.asyncio
+    async def test_freshly_created_orphan_survives(self) -> None:
+        """A neuron created just now, with no synapses/fiber and freq=0, must
+        NOT be pruned this pass — it hasn't had a chance to be linked into
+        the graph yet.
+        """
+        from surreal_memory.engine.consolidation import ConsolidationConfig, ConsolidationEngine
+
+        neuron = self._make_neuron("fresh-orphan", days_old=0.0)
+        storage = self._make_storage(neuron, freq=0)
+
+        config = ConsolidationConfig()
+        engine = ConsolidationEngine(storage, config)
+        report = await engine.run(strategies=["prune"])
+
+        assert report.neurons_pruned == 0
+        storage.delete_neurons_batch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stale_orphan_still_pruned(self) -> None:
+        """A genuinely stale orphan (old enough, never accessed) must still be
+        pruned — this preserves today's correct behavior and must not
+        regress.
+        """
+        from surreal_memory.engine.consolidation import ConsolidationConfig, ConsolidationEngine
+
+        neuron = self._make_neuron("stale-orphan", days_old=30.0)
+        storage = self._make_storage(neuron, freq=0)
+
+        config = ConsolidationConfig()
+        engine = ConsolidationEngine(storage, config)
+        report = await engine.run(strategies=["prune"])
+
+        assert report.neurons_pruned == 1
+        storage.delete_neurons_batch.assert_called_once()
+        deleted_ids = storage.delete_neurons_batch.call_args[0][0]
+        assert "stale-orphan" in deleted_ids
+
+    @pytest.mark.asyncio
+    async def test_accessed_orphan_survives_even_if_old(self) -> None:
+        """An old orphan that has been accessed (access_frequency > 0) must
+        NOT be pruned — parity with the dead-neuron branch's
+        never-prune-if-accessed rule.
+        """
+        from surreal_memory.engine.consolidation import ConsolidationConfig, ConsolidationEngine
+
+        neuron = self._make_neuron("accessed-orphan", days_old=30.0)
+        storage = self._make_storage(neuron, freq=3)
+
+        config = ConsolidationConfig()
+        engine = ConsolidationEngine(storage, config)
+        report = await engine.run(strategies=["prune"])
+
+        assert report.neurons_pruned == 0
+        storage.delete_neurons_batch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pinned_orphan_survives_regardless_of_age(self) -> None:
+        """A pinned orphan must survive regardless of age — don't regress the
+        #17 fix, which hoisted the pinned guard above both prune branches.
+        """
+        from surreal_memory.engine.consolidation import ConsolidationConfig, ConsolidationEngine
+
+        neuron = self._make_neuron("pinned-orphan", days_old=30.0)
+        storage = self._make_storage(neuron, freq=0, pinned_ids={"pinned-orphan"})
+
+        config = ConsolidationConfig()
+        engine = ConsolidationEngine(storage, config)
+        report = await engine.run(strategies=["prune"])
+
+        assert report.neurons_pruned == 0
+        storage.delete_neurons_batch.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `_prune()` protected dead neurons (no synapses, in a fiber) with a never-accessed + old-enough guard, but the orphan branch just above it short-circuited straight to deletion for ANY unconnected neuron.
- A neuron written moments ago, before consolidation had any chance to link it into the graph, was pruned on the very next consolidation pass — disproportionately hitting exactly the memories that matter most: novel, not-yet-connected facts.
- Hoists the same never-accessed + old-enough predicate above the orphan short-circuit, mirroring how the pinned guard was hoisted above both branches in #17. A merely-young or recently-accessed orphan now survives and is re-evaluated next pass; genuinely stale orphans are still pruned as before. Fiber-member exclusion and pinned-guard ordering for dead-neuron detection are unchanged.
- Updates two pre-existing tests whose fixtures relied on the old short-circuit (freshly-created orphans expected to be pruned immediately) — this was intentional behavior change per the issue, not a regression.

## Test plan

- [x] New `TestOrphanPruneAgeGuard` suite: fresh-orphan survival, stale-orphan pruning, accessed-orphan survival, pinned-orphan survival regardless of age
- [x] Fixed `test_invariants.py`'s `mixed_storage` fixture and `test_recall_quality.py`'s `test_young_neurons_not_pruned`, both of which encoded the bug as expected behavior
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] Full `tests/unit` + `tests/integration` suite: 6987 passed (remaining failures are pre-existing live-SurrealDB connectivity flakiness under concurrent load, unrelated to this change)
- [x] Live-DB brain state verified clean after test run (`smem brain list` → only `default`)

Fixes #113