### PR TITLE
fix(memory-types): context memories no longer silently expire after 7 days

### DIFF
--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -88,11 +88,11 @@ Store a memory. Auto-detects type if not specified. Error resolution: when a new
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `content` | string | Yes | — | The content to remember |
-| `type` | string (`fact`, `decision`, `preference`, `todo`, `insight`, `context`, `instruction`, `error`, `workflow`, `reference`, `boundary`) | No | — | Memory type (auto-detected if not specified) |
+| `type` | string (`fact`, `decision`, `preference`, `todo`, `insight`, `context`, `instruction`, `error`, `workflow`, `reference`, `boundary`) | No | — | Memory type (auto-detected if not specified). Some types default to a non-null expiry when expires_days is omitted: d... |
 | `tier` | string (`hot`, `warm`, `cold`) | No | — | Memory tier: hot (always in context, slow decay), warm (default, semantic match), cold (explicit recall only, fast de... |
 | `priority` | integer | No | — | Priority 0-10 (5=normal, 10=critical) |
 | `tags` | array[string] | No | — | Tags for categorization |
-| `expires_days` | integer | No | — | Days until memory expires |
+| `expires_days` | integer | No | — | Days until memory expires. If omitted, falls back to the type's default (decision=90d, todo=30d, insight=180d, workfl... |
 | `encrypted` | boolean | No | default: false | Force encrypt this memory's neuron content (default: false). When true, content is encrypted with the brain's Fernet ... |
 | `event_at` | string | No | — | ISO datetime of when the event originally occurred (e.g. '2026-03-02T08:00:00'). Defaults to current time if not prov... |
 | `trust_score` | number | No | — | Trust level 0.0-1.0. Capped by source ceiling (user_input max 0.9, ai_inference max 0.7). NULL = unscored. |

--- a/src/surreal_memory/core/memory_types.py
+++ b/src/surreal_memory/core/memory_types.py
@@ -432,7 +432,7 @@ DEFAULT_EXPIRY_DAYS: dict[MemoryType, int | None] = {
     MemoryType.PREFERENCE: None,  # Preferences persist
     MemoryType.TODO: 30,  # TODOs should be acted on
     MemoryType.INSIGHT: 180,  # Insights may become outdated
-    MemoryType.CONTEXT: 7,  # Context is usually short-term
+    MemoryType.CONTEXT: None,  # Context persists until superseded; use ephemeral=True for scratch/short-lived context
     MemoryType.INSTRUCTION: None,  # Instructions persist
     MemoryType.ERROR: 30,  # Error patterns may get fixed
     MemoryType.WORKFLOW: 365,  # Workflows change slowly

--- a/src/surreal_memory/mcp/tool_schemas.py
+++ b/src/surreal_memory/mcp/tool_schemas.py
@@ -129,7 +129,9 @@ _ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
                         "reference",
                         "boundary",
                     ],
-                    "description": "Memory type (auto-detected if not specified)",
+                    "description": "Memory type (auto-detected if not specified). Some types "
+                    "default to a non-null expiry when expires_days is omitted: decision=90d, "
+                    "todo=30d, insight=180d, workflow=365d, error=30d; others persist until superseded.",
                 },
                 "tier": {
                     "type": "string",
@@ -154,7 +156,10 @@ _ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
                 },
                 "expires_days": {
                     "type": "integer",
-                    "description": "Days until memory expires",
+                    "description": "Days until memory expires. If omitted, falls back to the "
+                    "type's default (decision=90d, todo=30d, insight=180d, workflow=365d, "
+                    "error=30d; most other types persist until superseded) — use ephemeral=true "
+                    "for short-lived scratch data instead.",
                 },
                 "encrypted": {
                     "type": "boolean",
@@ -245,7 +250,10 @@ _ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
                                     "workflow",
                                     "reference",
                                 ],
-                                "description": "Memory type (auto-detected if not specified)",
+                                "description": "Memory type (auto-detected if not specified). "
+                                "Some types default to a non-null expiry when expires_days is "
+                                "omitted: decision=90d, todo=30d, insight=180d, workflow=365d, "
+                                "error=30d; others persist until superseded.",
                             },
                             "priority": {
                                 "type": "integer",
@@ -260,7 +268,11 @@ _ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
                             },
                             "expires_days": {
                                 "type": "integer",
-                                "description": "Days until memory expires",
+                                "description": "Days until memory expires. If omitted, falls "
+                                "back to the type's default (decision=90d, todo=30d, "
+                                "insight=180d, workflow=365d, error=30d; most other types "
+                                "persist until superseded) — use ephemeral=true for short-lived "
+                                "scratch data instead.",
                             },
                             "encrypted": {
                                 "type": "boolean",

--- a/tests/unit/test_memory_types.py
+++ b/tests/unit/test_memory_types.py
@@ -255,13 +255,43 @@ class TestDefaultExpiry:
         """Test TODOs expire in 30 days."""
         assert DEFAULT_EXPIRY_DAYS[MemoryType.TODO] == 30
 
-    def test_context_expires_in_7_days(self) -> None:
-        """Test context expires in 7 days."""
-        assert DEFAULT_EXPIRY_DAYS[MemoryType.CONTEXT] == 7
+    def test_context_does_not_expire_by_default(self) -> None:
+        """Test context has no default expiry (persists until superseded).
+
+        Context previously defaulted to a 7-day expiry, which silently
+        deleted memories an agent would reasonably expect to persist
+        (issue #114). Short-lived context should use ephemeral=True
+        instead of relying on an implicit type-based expiry.
+        """
+        assert DEFAULT_EXPIRY_DAYS[MemoryType.CONTEXT] is None
 
     def test_decisions_expire_in_90_days(self) -> None:
         """Test decisions expire in 90 days."""
         assert DEFAULT_EXPIRY_DAYS[MemoryType.DECISION] == 90
+
+    def test_context_remember_path_resolves_to_no_expiry(self) -> None:
+        """Storing a context memory with no explicit expiry must not expire it.
+
+        Mirrors the default-expiry resolution used by both the CLI
+        remember command (cli/commands/memory.py) and the MCP
+        smem_remember handler:
+
+            expiry_days = expires if expires is not None else DEFAULT_EXPIRY_DAYS.get(mem_type)
+
+        Regression test for issue #114: this used to resolve to 7 days
+        and silently expire context memories.
+        """
+        expires: int | None = None
+        mem_type = MemoryType.CONTEXT
+        expiry_days = expires if expires is not None else DEFAULT_EXPIRY_DAYS.get(mem_type)
+
+        mem = TypedMemory.create(
+            fiber_id="fiber-context-114",
+            memory_type=mem_type,
+            expires_in_days=expiry_days,
+        )
+        assert mem.expires_at is None
+        assert mem.is_expired is False
 
 
 class TestSuggestMemoryType:


### PR DESCRIPTION
## Summary

- `MemoryType.CONTEXT` defaulted to a 7-day expiry (`DEFAULT_EXPIRY_DAYS`), unlike `FACT`/`PREFERENCE`/`INSTRUCTION`/`REFERENCE`, which persist indefinitely.
- "Context" reads to an LLM agent as durable state ("current deployment topology") that should persist until superseded, not scratch data with a silent one-week death sentence — and (until #112) pinning didn't even protect against this.
- Changes `CONTEXT`'s default to `None`, consistent with the other persistent-by-default types. Short-lived context already has an explicit mechanism: `ephemeral=True` on `smem_remember` (auto-expires in 24h, never synced, excluded from consolidation) — that's the correct tool for "throw this away soon", not an implicit type-based default.
- Extends the `smem_remember` / `smem_remember_batch` tool schema descriptions (`type`, `expires_days`) with a one-line note about which types still carry a non-null default expiry, so an agent choosing a type can see the risk without reading the source.

## Test plan

- [x] `DEFAULT_EXPIRY_DAYS[MemoryType.CONTEXT] is None` pinning test
- [x] Regression test asserting the remember path resolves `expires_at is None` for `type="context"` with no explicit `expires_days`
- [x] Updated a pre-existing test that encoded the old 7-day default as expected behavior
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] 86/86 passed in targeted files; 273/273 passed on a broader expiry-related keyword sweep across the whole suite

Fixes #114