### PR TITLE
fix(cross-brain): make cross-brain recall backend-aware instead of hardcoded SQLite

### DIFF
--- a/src/surreal_memory/engine/cross_brain.py
+++ b/src/surreal_memory/engine/cross_brain.py
@@ -1,23 +1,22 @@
 """Cross-brain recall — parallel spreading activation across multiple brains.
 
-Resolves brain names to DB paths, opens temporary SQLiteStorage instances,
-runs SA in parallel via asyncio.gather, deduplicates results by SimHash,
-and merges by confidence.
+Resolves brain names against the active storage backend's brain listing
+(SQLite or SurrealDB), fetches backend-aware shared storage for each, runs SA
+in parallel via asyncio.gather, deduplicates results by SimHash, and merges
+by confidence.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from surreal_memory.engine.retrieval_types import DepthLevel
 from surreal_memory.utils.timeutils import utcnow
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from surreal_memory.unified_config import UnifiedConfig
     from surreal_memory.utils.geo import GeoFilter
 
@@ -47,32 +46,47 @@ class CrossBrainResult:
     fibers: list[CrossBrainFiber]
     total_neurons_activated: int = 0
     merged_context: str = ""
+    errors: dict[str, str] = field(default_factory=dict)
 
 
 async def _query_single_brain(
-    db_path: Path,
     brain_name: str,
     query: str,
     depth: DepthLevel,
     max_tokens: int,
     tags: set[str] | None = None,
     near: GeoFilter | None = None,
-) -> tuple[str, list[CrossBrainFiber], int, str]:
+) -> tuple[str, list[CrossBrainFiber], int, str, str | None]:
     """Query a single brain and return its results.
 
-    Returns:
-        Tuple of (brain_name, fibers, neurons_activated, context)
-    """
-    from surreal_memory.storage.sqlite_store import SQLiteStorage
+    Uses the backend-aware ``get_shared_storage`` accessor so this respects
+    ``config.storage_backend`` ("sqlite" or "surrealdb") instead of always
+    opening a throwaway local SQLite file — on a SurrealDB deployment that
+    file is typically empty or nonexistent, which silently made cross-brain
+    recall a no-op.
 
-    storage = SQLiteStorage(db_path)
+    The storage instance returned by ``get_shared_storage`` is cached/shared
+    (per its own docstring, "to avoid connection leaks") and may be in
+    concurrent use by the primary, non-cross-brain recall path running in
+    this same process. It is intentionally NOT closed here — its lifecycle is
+    owned by the shared-storage cache, not by an individual cross-brain
+    query; closing it here could tear down a connection another concurrent
+    caller still needs.
+
+    Returns:
+        Tuple of (brain_name, fibers, neurons_activated, context, error).
+        ``error`` is None on success (including "queried fine, zero
+        matches"); it carries a short message when the query itself raised.
+    """
+    from surreal_memory.unified_config import get_shared_storage
+
     try:
-        await storage.initialize()
+        storage = await get_shared_storage(brain_name)
 
         # Find the brain by name in the DB
         brain = await storage.find_brain_by_name(brain_name)
         if not brain:
-            return brain_name, [], 0, ""
+            return brain_name, [], 0, "", None
 
         # Rows are scoped by the brain *name*; brain.id is a UUID for brains
         # created by older versions and would select an empty scope.
@@ -104,12 +118,10 @@ async def _query_single_brain(
                     )
                 )
 
-        return brain_name, fibers, result.neurons_activated, result.context or ""
-    except Exception:
-        logger.debug("Cross-brain query failed for '%s'", brain_name, exc_info=True)
-        return brain_name, [], 0, ""
-    finally:
-        await storage.close()
+        return brain_name, fibers, result.neurons_activated, result.context or "", None
+    except Exception as exc:
+        logger.warning("Cross-brain query failed for '%s'", brain_name, exc_info=True)
+        return brain_name, [], 0, "", str(exc) or exc.__class__.__name__
 
 
 def _dedup_fibers(fibers: list[CrossBrainFiber]) -> list[CrossBrainFiber]:
@@ -155,7 +167,9 @@ async def cross_brain_recall(
     """Run recall across multiple brains in parallel.
 
     Args:
-        config: Unified configuration (for brain DB path resolution)
+        config: Unified configuration (kept for signature compatibility;
+            brain resolution itself goes through the process-wide config
+            singleton via ``list_available_brains``/``get_shared_storage``)
         brain_names: List of brain names to query (max 5)
         query: The recall query
         depth: Depth level (0-3)
@@ -164,25 +178,26 @@ async def cross_brain_recall(
     Returns:
         CrossBrainResult with merged, deduplicated results
     """
+    from surreal_memory.unified_config import list_available_brains
+
     # Cap brain count
     brain_names = brain_names[:MAX_CROSS_BRAINS]
 
-    # Resolve brain names to DB paths
-    valid_brains: list[tuple[str, Path]] = []
-    available = set(config.list_brains())
+    # Resolve valid brain names via the active storage backend's own brain
+    # listing. UnifiedConfig.list_brains() only inspects local sqlite *.db
+    # fixture files, so it returns nothing for a SurrealDB deployment (or
+    # stale leftovers from an old SQLite install) — list_available_brains()
+    # is backend-aware and queries the real SurrealDB brain table when
+    # storage_backend == "surrealdb". There is no per-brain file to check on
+    # that backend, so membership in this listing is the only validity check.
+    available = set(await list_available_brains())
 
+    valid_brain_names: list[str] = [name for name in brain_names if name in available]
     for name in brain_names:
         if name not in available:
             logger.debug("Brain '%s' not found, skipping", name)
-            continue
-        try:
-            db_path = config.get_brain_db_path(name)
-            if db_path.exists():
-                valid_brains.append((name, db_path))
-        except ValueError:
-            logger.debug("Invalid brain name '%s', skipping", name)
 
-    if not valid_brains:
+    if not valid_brain_names:
         return CrossBrainResult(
             query=query,
             brains_queried=[],
@@ -197,8 +212,8 @@ async def cross_brain_recall(
 
     # Query all brains in parallel
     tasks = [
-        _query_single_brain(db_path, name, query, depth_level, max_tokens, tags=tags, near=near)
-        for name, db_path in valid_brains
+        _query_single_brain(name, query, depth_level, max_tokens, tags=tags, near=near)
+        for name in valid_brain_names
     ]
     results = await asyncio.gather(*tasks)
 
@@ -207,13 +222,16 @@ async def cross_brain_recall(
     total_neurons = 0
     context_parts: list[str] = []
     queried: list[str] = []
+    errors: dict[str, str] = {}
 
-    for brain_name, fibers, neurons_activated, context in results:
+    for brain_name, fibers, neurons_activated, context, error in results:
         queried.append(brain_name)
         all_fibers.extend(fibers)
         total_neurons += neurons_activated
         if context:
             context_parts.append(f"[{brain_name}] {context}")
+        if error:
+            errors[brain_name] = error
 
     # Sort by confidence descending
     all_fibers.sort(key=lambda f: f.confidence, reverse=True)
@@ -230,4 +248,5 @@ async def cross_brain_recall(
         fibers=deduped,
         total_neurons_activated=total_neurons,
         merged_context=merged_context,
+        errors=errors,
     )

--- a/src/surreal_memory/mcp/recall_handler.py
+++ b/src/surreal_memory/mcp/recall_handler.py
@@ -1085,13 +1085,18 @@ class RecallHandler:
             for f in result.fibers
         ]
 
-        return {
+        response: dict[str, Any] = {
             "answer": result.merged_context,
             "brains_queried": result.brains_queried,
             "total_neurons_activated": result.total_neurons_activated,
             "fibers": fibers_out,
             "cross_brain": True,
         }
+        # Only include errors when a brain query actually failed — an empty
+        # dict here would be indistinguishable noise on every response.
+        if result.errors:
+            response["errors"] = result.errors
+        return response
 
     async def _context(self, args: dict[str, Any]) -> dict[str, Any]:
         """Get recent context.

--- a/tests/unit/test_cross_brain.py
+++ b/tests/unit/test_cross_brain.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -10,8 +11,10 @@ from surreal_memory.engine.cross_brain import (
     CrossBrainFiber,
     CrossBrainResult,
     _dedup_fibers,
+    _query_single_brain,
     cross_brain_recall,
 )
+from surreal_memory.engine.retrieval_types import DepthLevel
 
 
 class TestCrossBrainFiber:
@@ -49,6 +52,7 @@ class TestCrossBrainResult:
         )
         assert r.total_neurons_activated == 0
         assert r.merged_context == ""
+        assert r.errors == {}
 
     def test_frozen(self) -> None:
         r = CrossBrainResult(query="q", brains_queried=[], fibers=[])
@@ -99,19 +103,113 @@ class TestDedupFibers:
         assert len(result) == 2
 
 
+class TestQuerySingleBrain:
+    """Tests for _query_single_brain — the backend-aware single-brain query."""
+
+    async def test_uses_backend_aware_shared_storage_not_sqlite_file(self) -> None:
+        """Should route through get_shared_storage (backend-aware) instead of
+        unconditionally opening a throwaway SQLiteStorage file, and should
+        return the real fibers/context the pipeline produced."""
+        mock_brain = MagicMock()
+        mock_brain.name = "brain1"
+        mock_brain.config = MagicMock()
+
+        mock_storage = MagicMock()
+        mock_storage.find_brain_by_name = AsyncMock(return_value=mock_brain)
+        mock_storage.set_brain = MagicMock()
+        mock_storage.get_fiber = AsyncMock(
+            return_value=MagicMock(summary="real memory content", content_hash=0)
+        )
+
+        mock_pipeline_result = MagicMock()
+        mock_pipeline_result.fibers_matched = ["f1"]
+        mock_pipeline_result.confidence = 0.85
+        mock_pipeline_result.neurons_activated = 7
+        mock_pipeline_result.context = "actual retrieved context"
+
+        with (
+            patch(
+                "surreal_memory.unified_config.get_shared_storage",
+                new_callable=AsyncMock,
+                return_value=mock_storage,
+            ) as mock_get_shared_storage,
+            patch("surreal_memory.engine.retrieval.ReflexPipeline") as mock_pipeline_cls,
+        ):
+            mock_pipeline_cls.return_value.query = AsyncMock(return_value=mock_pipeline_result)
+
+            brain_name, fibers, neurons, context, error = await _query_single_brain(
+                "brain1", "find real content", DepthLevel.CONTEXT, 500
+            )
+
+        mock_get_shared_storage.assert_awaited_once_with("brain1")
+        assert brain_name == "brain1"
+        assert len(fibers) == 1
+        assert fibers[0].summary == "real memory content"
+        assert neurons == 7
+        assert context == "actual retrieved context"
+        assert error is None
+        # The shared/cached storage instance must not be torn down here — its
+        # lifecycle belongs to the shared-storage cache, not this one query.
+        mock_storage.close.assert_not_called()
+
+    async def test_brain_not_found_returns_empty_without_error(self) -> None:
+        """A brain absent from the resolved storage is a clean empty result,
+        not an error — distinct from an actual exception."""
+        mock_storage = MagicMock()
+        mock_storage.find_brain_by_name = AsyncMock(return_value=None)
+
+        with patch(
+            "surreal_memory.unified_config.get_shared_storage",
+            new_callable=AsyncMock,
+            return_value=mock_storage,
+        ):
+            brain_name, fibers, neurons, context, error = await _query_single_brain(
+                "ghost", "q", DepthLevel.CONTEXT, 500
+            )
+
+        assert (brain_name, fibers, neurons, context, error) == ("ghost", [], 0, "", None)
+
+    async def test_exception_returns_error_message_and_logs_at_warning(self, caplog) -> None:
+        """A real failure must surface a short error message (for
+        CrossBrainResult.errors) and log at WARNING, not DEBUG — DEBUG is
+        invisible by default and was hiding this exact class of bug."""
+        with patch(
+            "surreal_memory.unified_config.get_shared_storage",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
+            with caplog.at_level(logging.WARNING, logger="surreal_memory.engine.cross_brain"):
+                brain_name, fibers, neurons, context, error = await _query_single_brain(
+                    "brain1", "q", DepthLevel.CONTEXT, 500
+                )
+
+        assert brain_name == "brain1"
+        assert fibers == []
+        assert neurons == 0
+        assert context == ""
+        assert error == "boom"
+        matching = [r for r in caplog.records if "Cross-brain query failed" in r.message]
+        assert matching, "expected a 'Cross-brain query failed' log record"
+        assert all(r.levelno >= logging.WARNING for r in matching)
+
+
 class TestCrossBrainRecall:
     """Tests for the cross_brain_recall function."""
 
     async def test_no_valid_brains(self) -> None:
         """Empty brains list returns empty result."""
         config = MagicMock()
-        config.list_brains.return_value = []
 
-        result = await cross_brain_recall(
-            config=config,
-            brain_names=["nonexistent"],
-            query="test query",
-        )
+        with patch(
+            "surreal_memory.unified_config.list_available_brains",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await cross_brain_recall(
+                config=config,
+                brain_names=["nonexistent"],
+                query="test query",
+            )
         assert result.brains_queried == []
         assert result.fibers == []
         assert "No valid brains" in result.merged_context
@@ -119,29 +217,52 @@ class TestCrossBrainRecall:
     async def test_caps_at_five_brains(self) -> None:
         """Should cap brain names at MAX_CROSS_BRAINS (5)."""
         config = MagicMock()
-        config.list_brains.return_value = [f"brain{i}" for i in range(10)]
-        config.get_brain_db_path.return_value = MagicMock(exists=MagicMock(return_value=False))
 
-        result = await cross_brain_recall(
-            config=config,
-            brain_names=[f"brain{i}" for i in range(10)],
-            query="test",
-        )
-        # Even if all fail, we only attempt 5
+        with (
+            patch(
+                "surreal_memory.unified_config.list_available_brains",
+                new_callable=AsyncMock,
+                return_value=[f"brain{i}" for i in range(10)],
+            ),
+            patch(
+                "surreal_memory.engine.cross_brain._query_single_brain",
+                new_callable=AsyncMock,
+                return_value=("brainX", [], 0, "", None),
+            ) as mock_query,
+        ):
+            result = await cross_brain_recall(
+                config=config,
+                brain_names=[f"brain{i}" for i in range(10)],
+                query="test",
+            )
+        # Even though 10 names were passed and all 10 are "available", only 5
+        # (MAX_CROSS_BRAINS) should ever be queried.
+        assert mock_query.await_count <= 5
         assert len(result.brains_queried) <= 5
 
-    async def test_skips_nonexistent_brains(self) -> None:
-        """Should skip brains that don't exist."""
+    async def test_skips_nonexistent_brains_without_disk_check(self) -> None:
+        """Should skip brains not returned by list_available_brains, without
+        ever consulting a per-brain on-disk path (SurrealDB brains have
+        none)."""
         config = MagicMock()
-        config.list_brains.return_value = ["exists"]
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        config.get_brain_db_path.return_value = mock_path
+        config.get_brain_db_path = MagicMock(
+            side_effect=AssertionError("must not check a per-brain disk path")
+        )
+        config.list_brains = MagicMock(
+            side_effect=AssertionError("must not use the disk-file brain listing directly")
+        )
 
-        with patch(
-            "surreal_memory.engine.cross_brain._query_single_brain",
-            new_callable=AsyncMock,
-            return_value=("exists", [], 5, "some context"),
+        with (
+            patch(
+                "surreal_memory.unified_config.list_available_brains",
+                new_callable=AsyncMock,
+                return_value=["exists"],
+            ),
+            patch(
+                "surreal_memory.engine.cross_brain._query_single_brain",
+                new_callable=AsyncMock,
+                return_value=("exists", [], 5, "some context", None),
+            ) as mock_query,
         ):
             result = await cross_brain_recall(
                 config=config,
@@ -150,26 +271,32 @@ class TestCrossBrainRecall:
             )
         assert "exists" in result.brains_queried
         assert "nonexistent" not in result.brains_queried
+        mock_query.assert_awaited_once()
+        config.get_brain_db_path.assert_not_called()
+        config.list_brains.assert_not_called()
 
     async def test_merges_results_from_multiple_brains(self) -> None:
         """Results from multiple brains should be merged."""
         config = MagicMock()
-        config.list_brains.return_value = ["brain1", "brain2"]
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        config.get_brain_db_path.return_value = mock_path
 
         fiber1 = CrossBrainFiber("f1", "brain1", "memory from brain1", 0.9)
         fiber2 = CrossBrainFiber("f2", "brain2", "memory from brain2", 0.7)
 
-        async def mock_query(db_path, name, query, depth, max_tokens, tags=None, near=None):
+        async def mock_query(name, query, depth, max_tokens, tags=None, near=None):
             if name == "brain1":
-                return ("brain1", [fiber1], 10, "[brain1] context")
-            return ("brain2", [fiber2], 5, "[brain2] context")
+                return ("brain1", [fiber1], 10, "[brain1] context", None)
+            return ("brain2", [fiber2], 5, "[brain2] context", None)
 
-        with patch(
-            "surreal_memory.engine.cross_brain._query_single_brain",
-            side_effect=mock_query,
+        with (
+            patch(
+                "surreal_memory.unified_config.list_available_brains",
+                new_callable=AsyncMock,
+                return_value=["brain1", "brain2"],
+            ),
+            patch(
+                "surreal_memory.engine.cross_brain._query_single_brain",
+                side_effect=mock_query,
+            ),
         ):
             result = await cross_brain_recall(
                 config=config,
@@ -182,19 +309,23 @@ class TestCrossBrainRecall:
         assert result.total_neurons_activated == 15
         # Fibers should be sorted by confidence (0.9 first)
         assert result.fibers[0].confidence >= result.fibers[1].confidence
+        assert result.errors == {}
 
     async def test_invalid_depth_defaults_to_context(self) -> None:
         """Invalid depth should default to CONTEXT."""
         config = MagicMock()
-        config.list_brains.return_value = ["brain1"]
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        config.get_brain_db_path.return_value = mock_path
 
-        with patch(
-            "surreal_memory.engine.cross_brain._query_single_brain",
-            new_callable=AsyncMock,
-            return_value=("brain1", [], 0, ""),
+        with (
+            patch(
+                "surreal_memory.unified_config.list_available_brains",
+                new_callable=AsyncMock,
+                return_value=["brain1"],
+            ),
+            patch(
+                "surreal_memory.engine.cross_brain._query_single_brain",
+                new_callable=AsyncMock,
+                return_value=("brain1", [], 0, "", None),
+            ),
         ):
             result = await cross_brain_recall(
                 config=config,
@@ -205,31 +336,22 @@ class TestCrossBrainRecall:
         assert result.brains_queried == ["brain1"]
 
     async def test_handles_brain_query_failure(self) -> None:
-        """Should handle errors from individual brain queries gracefully."""
+        """An internally-handled brain-query failure surfaces in
+        CrossBrainResult.errors rather than raising or silently
+        disappearing into an empty result indistinguishable from success."""
         config = MagicMock()
-        config.list_brains.return_value = ["brain1"]
-        mock_path = MagicMock()
-        mock_path.exists.return_value = True
-        config.get_brain_db_path.return_value = mock_path
 
-        async def mock_query_fail(db_path, name, query, depth, max_tokens, tags=None, near=None):
-            raise RuntimeError("DB corrupted")
-
-        with patch(
-            "surreal_memory.engine.cross_brain._query_single_brain",
-            side_effect=mock_query_fail,
-        ):
-            # gather catches the exception since _query_single_brain has try/except
-            # But our mock bypasses that, so the gather will propagate
-            # Actually the function itself has try/except internally
-            # Let's test by having it return empty
-            pass
-
-        # Test with the mock that returns empty on error
-        with patch(
-            "surreal_memory.engine.cross_brain._query_single_brain",
-            new_callable=AsyncMock,
-            return_value=("brain1", [], 0, ""),
+        with (
+            patch(
+                "surreal_memory.unified_config.list_available_brains",
+                new_callable=AsyncMock,
+                return_value=["brain1"],
+            ),
+            patch(
+                "surreal_memory.engine.cross_brain._query_single_brain",
+                new_callable=AsyncMock,
+                return_value=("brain1", [], 0, "", "DB corrupted"),
+            ),
         ):
             result = await cross_brain_recall(
                 config=config,
@@ -238,6 +360,93 @@ class TestCrossBrainRecall:
             )
         assert result.brains_queried == ["brain1"]
         assert result.fibers == []
+        assert result.errors == {"brain1": "DB corrupted"}
+
+    async def test_partial_failure_reports_error_for_failed_brain_only(self) -> None:
+        """When one brain fails and another succeeds, the successful brain's
+        results still come back, and only the failed brain appears in
+        errors."""
+        config = MagicMock()
+        fiber_ok = CrossBrainFiber("f1", "brain_ok", "good memory", 0.8)
+
+        async def mock_query(name, query, depth, max_tokens, tags=None, near=None):
+            if name == "brain_ok":
+                return ("brain_ok", [fiber_ok], 4, "[brain_ok] context", None)
+            return ("brain_bad", [], 0, "", "connection refused")
+
+        with (
+            patch(
+                "surreal_memory.unified_config.list_available_brains",
+                new_callable=AsyncMock,
+                return_value=["brain_ok", "brain_bad"],
+            ),
+            patch(
+                "surreal_memory.engine.cross_brain._query_single_brain",
+                side_effect=mock_query,
+            ),
+        ):
+            result = await cross_brain_recall(
+                config=config,
+                brain_names=["brain_ok", "brain_bad"],
+                query="test",
+            )
+
+        assert len(result.fibers) == 1
+        assert result.fibers[0].fiber_id == "f1"
+        assert result.errors == {"brain_bad": "connection refused"}
+        assert "brain_ok" not in result.errors
+
+    async def test_backend_aware_recall_returns_real_results_not_empty(self) -> None:
+        """End-to-end through cross_brain_recall with storage_backend !=
+        sqlite: a brain with real matching content must return actual
+        fibers/context, not an empty 'no relevant memories' result."""
+        config = MagicMock()
+        config.storage_backend = "surrealdb"
+
+        mock_brain = MagicMock()
+        mock_brain.name = "brain1"
+        mock_brain.config = MagicMock()
+
+        mock_storage = MagicMock()
+        mock_storage.find_brain_by_name = AsyncMock(return_value=mock_brain)
+        mock_storage.set_brain = MagicMock()
+        mock_storage.get_fiber = AsyncMock(
+            return_value=MagicMock(summary="real memory content", content_hash=0)
+        )
+
+        mock_pipeline_result = MagicMock()
+        mock_pipeline_result.fibers_matched = ["f1"]
+        mock_pipeline_result.confidence = 0.85
+        mock_pipeline_result.neurons_activated = 7
+        mock_pipeline_result.context = "actual retrieved context"
+
+        with (
+            patch(
+                "surreal_memory.unified_config.list_available_brains",
+                new_callable=AsyncMock,
+                return_value=["brain1"],
+            ),
+            patch(
+                "surreal_memory.unified_config.get_shared_storage",
+                new_callable=AsyncMock,
+                return_value=mock_storage,
+            ),
+            patch("surreal_memory.engine.retrieval.ReflexPipeline") as mock_pipeline_cls,
+        ):
+            mock_pipeline_cls.return_value.query = AsyncMock(return_value=mock_pipeline_result)
+
+            result = await cross_brain_recall(
+                config=config,
+                brain_names=["brain1"],
+                query="find real content",
+            )
+
+        assert result.brains_queried == ["brain1"]
+        assert len(result.fibers) == 1
+        assert result.fibers[0].summary == "real memory content"
+        assert "actual retrieved context" in result.merged_context
+        assert result.merged_context != "No relevant memories found."
+        assert result.errors == {}
 
 
 class TestCrossBrainRecallHandler:
@@ -294,3 +503,58 @@ class TestCrossBrainRecallHandler:
         # Without brains param, should hit normal path and return error (no brain)
         result = await server._recall({"query": "test"})
         assert result == {"error": "No brain configured"}
+
+    async def test_cross_brain_recall_includes_errors_key_when_present(self) -> None:
+        """When CrossBrainResult.errors is non-empty, the response dict must
+        surface it under 'errors' so a real failure isn't indistinguishable
+        from a genuine zero-match result."""
+        from surreal_memory.mcp.tool_handlers import ToolHandler
+
+        class MockServer(ToolHandler):
+            def __init__(self):
+                self.config = MagicMock()
+                self.hooks = MagicMock()
+                self.hooks.emit = AsyncMock()
+
+        server = MockServer()
+        fake_result = CrossBrainResult(
+            query="q",
+            brains_queried=["ok", "bad"],
+            fibers=[],
+            errors={"bad": "boom"},
+        )
+        with patch(
+            "surreal_memory.engine.cross_brain.cross_brain_recall",
+            new_callable=AsyncMock,
+            return_value=fake_result,
+        ):
+            response = await server._cross_brain_recall({"query": "q"}, ["ok", "bad"])
+
+        assert response["errors"] == {"bad": "boom"}
+
+    async def test_cross_brain_recall_omits_errors_key_when_empty(self) -> None:
+        """When no brain query failed, the 'errors' key must be absent
+        entirely — not clutter every response with an empty dict."""
+        from surreal_memory.mcp.tool_handlers import ToolHandler
+
+        class MockServer(ToolHandler):
+            def __init__(self):
+                self.config = MagicMock()
+                self.hooks = MagicMock()
+                self.hooks.emit = AsyncMock()
+
+        server = MockServer()
+        fake_result = CrossBrainResult(
+            query="q",
+            brains_queried=["ok"],
+            fibers=[],
+            errors={},
+        )
+        with patch(
+            "surreal_memory.engine.cross_brain.cross_brain_recall",
+            new_callable=AsyncMock,
+            return_value=fake_result,
+        ):
+            response = await server._cross_brain_recall({"query": "q"}, ["ok"])
+
+        assert "errors" not in response


### PR DESCRIPTION
## Summary

- `cross_brain_recall()` resolved candidate brains via `UnifiedConfig.list_brains()`, which only inspects local `*.db` fixture files, and `_query_single_brain()` unconditionally opened a throwaway `SQLiteStorage` instance regardless of `config.storage_backend`.
- On a SurrealDB deployment this meant cross-brain recall queried an empty/nonexistent local SQLite file instead of the real database — and failed *silently*, returning a confident `"No relevant memories found."` indistinguishable from a genuinely empty result.
- `cross_brain_recall()` now resolves brain names via the existing backend-aware `list_available_brains()`; `_query_single_brain()` now calls the existing `get_shared_storage(name)` instead of constructing `SQLiteStorage(db_path)` directly.
- Removed `finally: await storage.close()` — `get_shared_storage` returns a cached/shared instance (module-level cache for both sqlite and surrealdb backends); closing it here could tear down a connection still in use by the concurrent primary recall path in the same process.
- Added `CrossBrainResult.errors: dict[str, str]` so a brain whose query genuinely raised is distinguishable from one that was queried successfully with zero matches; switched the swallowed exception's log level from `debug` to `warning` (debug is invisible at default level and was hiding this exact bug class). `_cross_brain_recall()` surfaces `errors` under an `"errors"` key only when non-empty.

## Test plan

- [x] `tests/unit/test_cross_brain.py`: backend-aware end-to-end recall returns real results, not a false-empty response
- [x] A brain absent from `list_available_brains()` is excluded without any on-disk path check
- [x] Partial failure: one brain raising doesn't suppress another brain's results; only the failed brain appears in `errors`
- [x] `_cross_brain_recall()` includes `"errors"` only when non-empty
- [x] `ruff check` / `ruff format --check` clean; `mypy` pre-existing repo-wide environment issue (numpy stub vs configured Python version) confirmed unrelated, reproduces identically on `origin/main`
- [x] 23/23 passed in touched file; full repo test collection (7034 tests) clean

Fixes #111