### PR TITLE
fix(tests): stop unit tests from writing into the real Claude Desktop config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,3 +203,54 @@ def _close_leaked_aiosqlite_connections(
         with contextlib.suppress(Exception):
             conn.stop()
         thread.join(timeout=2.0)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _isolated_home_dir(tmp_path_factory: pytest.TempPathFactory) -> Generator[None, None, None]:
+    """Never let a forgotten ``Path.home()`` patch touch a real dev machine.
+
+    Defense in depth for #110: two tests ran ``run_full_setup()`` (which calls
+    ``setup_mcp_claude_desktop()``) without patching ``Path.home``, so on any
+    machine with a real ``~/.config/Claude`` directory the test suite silently
+    rewrote the developer's actual ``claude_desktop_config.json`` with a dead
+    ``SURREALDB_URL``/placeholder password leaked from an unrelated test (see
+    ``_surrealdb_test_env`` in ``test_bulk_batch_paths.py`` /
+    ``test_batch_writers.py``). Tests that legitimately need a fake home dir
+    already patch ``Path.home`` explicitly (``test_setup_mcp.py``,
+    ``test_doctor_enhanced.py``, ``test_setup_skills.py``, ``test_surface_mcp.py``,
+    ``test_surface_path_and_decay.py``, ``test_unified_config.py``) — those
+    local patches simply nest on top of this one and are restored on exit, so
+    this fixture is a pure safety net, not a replacement for them.
+
+    Redirects via the ``HOME`` env var rather than patching the ``Path.home``
+    classmethod directly. ``pathlib.Path.home()`` on POSIX already resolves
+    through ``$HOME``, and some tests (``test_reasoning_injection.py``'s
+    ``clean_env`` fixture) rely on exactly that by doing their own
+    ``monkeypatch.setenv("HOME", ...)`` — patching the classmethod instead
+    would shadow ``$HOME`` entirely and break that idiom. Setting the env var
+    lets both patterns coexist: per-test ``monkeypatch.setenv("HOME", ...)``
+    correctly overrides this session default, and per-test
+    ``patch("...Path.home", return_value=tmp_path)`` still wins outright since
+    it replaces the callable itself.
+
+    Session-scoped because it's a safety net, not per-test isolation — the
+    built-in ``monkeypatch`` fixture only supports function scope, so the
+    session-scoped patch is applied and undone via a manually managed
+    ``pytest.MonkeyPatch()`` instance instead.
+
+    Pre-seeds ``~/.surrealmemory/config.toml`` (empty file, only ``.exists()``
+    is checked) so this looks like an already-initialized machine, same as a
+    real developer's home. Without this, ``surreal_memory.cli.main._app_callback``
+    prints "Tip: Surreal-Memory not set up yet..." to stderr on every CLI
+    invocation via a blank home dir — and since Typer's ``CliRunner`` mixes
+    stderr into ``result.output`` by default, that banner broke unrelated CLI
+    tests (``test_cli_reasoning.py``) that parse ``result.output`` as JSON.
+    """
+    fake_home = tmp_path_factory.mktemp("fake-home")
+    surrealmemory_dir = fake_home / ".surrealmemory"
+    surrealmemory_dir.mkdir(parents=True, exist_ok=True)
+    (surrealmemory_dir / "config.toml").touch()
+    mp = pytest.MonkeyPatch()
+    mp.setenv("HOME", str(fake_home))
+    yield
+    mp.undo()

--- a/tests/unit/test_batch_writers.py
+++ b/tests/unit/test_batch_writers.py
@@ -12,9 +12,10 @@ Mock/fake based — no live SurrealDB required.
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import Any
 from unittest.mock import AsyncMock
+
+import pytest
 
 from surreal_memory.core.neuron import NeuronState
 from surreal_memory.core.synapse import Direction, Synapse, SynapseType
@@ -26,16 +27,29 @@ from surreal_memory.storage.surrealdb.store import (
 from surreal_memory.utils.timeutils import utcnow
 
 
+@pytest.fixture(autouse=True)
+def _surrealdb_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate the fake SurrealDB connection env used by ``_make_storage_spy``.
+
+    Was ``os.environ.setdefault(...)``, which — unlike ``monkeypatch.setenv``
+    — mutates the real process environment and never reverts. That leaked a
+    dead ``SURREALDB_URL``/placeholder password for the rest of the pytest
+    session, which a later unpatched ``setup_mcp_claude_desktop()`` call could
+    read via ``SurrealSettings.from_env()`` and write into a real MCP config
+    file (#110).
+    """
+    monkeypatch.setenv("SURREALDB_URL", "http://127.0.0.1:65535")
+    monkeypatch.setenv("SURREALDB_USER", "root")
+    monkeypatch.setenv("SURREALDB_PASS", "x")
+    monkeypatch.setenv("SURREALDB_NS", "ns")
+    monkeypatch.setenv("SURREALDB_DB", "db")
+
+
 def _make_storage_spy() -> Any:
     """A storage instance with the transport replaced by recording spies.
 
     Constructed without connecting: only the query-building code runs.
     """
-    os.environ.setdefault("SURREALDB_URL", "http://127.0.0.1:65535")
-    os.environ.setdefault("SURREALDB_USER", "root")
-    os.environ.setdefault("SURREALDB_PASS", "x")
-    os.environ.setdefault("SURREALDB_NS", "ns")
-    os.environ.setdefault("SURREALDB_DB", "db")
     s = SurrealDBStorage()
     s._current_brain_id = "default"
     s._skip_change_log = False

--- a/tests/unit/test_bulk_batch_paths.py
+++ b/tests/unit/test_bulk_batch_paths.py
@@ -15,6 +15,8 @@ import asyncio
 from typing import Any
 from unittest.mock import AsyncMock
 
+import pytest
+
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.synapse import Synapse, SynapseType
 from surreal_memory.engine.pipeline_steps import _persist_synapses
@@ -67,18 +69,29 @@ def test_increment_keyword_df_dedups_and_noops_empty():
 # ---------------------------- synapse batch ----------------------------
 
 
+@pytest.fixture(autouse=True)
+def _surrealdb_test_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate the fake SurrealDB connection env used by ``_make_storage_spy``.
+
+    Was ``os.environ.setdefault(...)``, which — unlike ``monkeypatch.setenv``
+    — mutates the real process environment and never reverts. That leaked a
+    dead ``SURREALDB_URL``/placeholder password for the rest of the pytest
+    session, which a later unpatched ``setup_mcp_claude_desktop()`` call could
+    read via ``SurrealSettings.from_env()`` and write into a real MCP config
+    file (#110).
+    """
+    monkeypatch.setenv("SURREALDB_URL", "http://127.0.0.1:65535")
+    monkeypatch.setenv("SURREALDB_USER", "root")
+    monkeypatch.setenv("SURREALDB_PASS", "x")
+    monkeypatch.setenv("SURREALDB_NS", "ns")
+    monkeypatch.setenv("SURREALDB_DB", "db")
+
+
 def _make_storage_spy() -> Any:
     """A minimal stand-in exposing the methods add_synapses_batch touches."""
-    import os
-
     from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
     # construct without connecting (no network); we only exercise add_synapses_batch
-    os.environ.setdefault("SURREALDB_URL", "http://127.0.0.1:65535")
-    os.environ.setdefault("SURREALDB_USER", "root")
-    os.environ.setdefault("SURREALDB_PASS", "x")
-    os.environ.setdefault("SURREALDB_NS", "ns")
-    os.environ.setdefault("SURREALDB_DB", "db")
     s = SurrealDBStorage()
     s._current_brain_id = "default"  # brain_id field value (alnum+_, not record-id)
     s._skip_change_log = False

--- a/tests/unit/test_full_setup.py
+++ b/tests/unit/test_full_setup.py
@@ -191,8 +191,13 @@ class TestRunFullSetup:
         mock_detect: MagicMock,
         mock_defaults: MagicMock,
         mock_maintenance: MagicMock,
+        tmp_path: Path,
     ) -> None:
-        result = run_full_setup()
+        # run_full_setup() calls setup_mcp_claude_desktop() (unmocked, real
+        # function) for real — it must not be allowed to touch the actual
+        # developer $HOME/.config/Claude/claude_desktop_config.json (#110).
+        with patch("surreal_memory.cli.setup.Path.home", return_value=tmp_path):
+            result = run_full_setup()
         assert "results" in result
         assert result["results"]["Brain"] == "default (ready)"
         assert result["results"]["Claude Code"] == "MCP server configured"
@@ -301,9 +306,16 @@ class TestRunFullSetupSkipEmbeddings:
         mock_detect: MagicMock,
         mock_defaults: MagicMock,
         mock_maintenance: MagicMock,
+        tmp_path: Path,
     ) -> None:
         """With skip_embeddings=True, _prompt_install_embeddings is never called."""
-        with patch("surreal_memory.cli.full_setup._prompt_install_embeddings") as mock_prompt:
+        # run_full_setup() calls setup_mcp_claude_desktop() (unmocked, real
+        # function) for real — it must not be allowed to touch the actual
+        # developer $HOME/.config/Claude/claude_desktop_config.json (#110).
+        with (
+            patch("surreal_memory.cli.full_setup._prompt_install_embeddings") as mock_prompt,
+            patch("surreal_memory.cli.setup.Path.home", return_value=tmp_path),
+        ):
             result = run_full_setup(skip_embeddings=True)
             mock_prompt.assert_not_called()
             assert "skipped" in result["results"]["Embeddings"]


### PR DESCRIPTION
## Summary

Two independent defects combined to let the unit test suite silently rewrite a real developer's `~/.config/Claude/claude_desktop_config.json`:

1. `test_full_setup.py::TestRunFullSetup::test_full_flow` and `TestRunFullSetupSkipEmbeddings::test_skip_embeddings_does_not_prompt` called `run_full_setup()` with MCP setup enabled but never patched `Path.home` — unlike every test in `test_setup_mcp.py`. A guard that skips writing when `~/.config/Claude` doesn't exist kept this invisible in CI, but not on a real dev machine where the directory exists.
2. `test_bulk_batch_paths.py` and `test_batch_writers.py` used `os.environ.setdefault(...)` (a real, session-persisting mutation) instead of `monkeypatch.setenv(...)` to fake SurrealDB connection settings — leaking a dead URL and placeholder password into the rest of the pytest session, which then got written into the real config file by defect (1).

## Fix

- Patch `Path.home` in both affected `test_full_setup.py` tests, matching the existing `test_setup_mcp.py` pattern.
- Replace `os.environ.setdefault` with `monkeypatch.setenv` in both batch test files via a small autouse fixture.
- Defense in depth: a new session-scoped autouse fixture in `conftest.py` redirects `$HOME` to a throwaway `tmp_path_factory` directory for the whole test session, so no future test can reach the real home dir even if it forgets to patch `Path.home` itself. Redirects via the `HOME` env var (not overriding the `Path.home` classmethod) because `test_reasoning_injection.py`'s own `clean_env` fixture relies on `Path.home()` naturally reading `$HOME`; pre-seeds an empty `~/.surrealmemory/config.toml` so the CLI's first-run tip doesn't leak into unrelated stdout-parsing tests.

## Test plan

- [x] Reproduced the exact scenario from the issue (fake `$HOME` containing `.config/Claude`, running the three affected files) — confirmed it wrote a real-looking config before the fix, and writes nothing after
- [x] Full unit suite run 5x (2 baseline, 3 with fix) to separate signal from this suite's pre-existing flakiness under `-n auto` — same known-flaky test family in both, none touching `Path.home`/MCP setup/SurrealDB env
- [x] `ruff check` / `ruff format --check` clean; `mypy` on touched test files shows the same pre-existing error count (43) as unmodified baseline — zero new errors
- [x] Verified every other `Path.home()` reference in `tests/` is already inside an explicit per-test patch (6 files), all coexist correctly with the new fixture

Fixes #110