### PR TITLE
v2.18.1: the maturation view actually reaches smem_health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.18.1] — The maturation view actually reaches `smem_health`
+
+2.18.0 added `stage_distribution` and `semantic_gate_blockers` to the health report and
+computed both on every call. Neither reached anyone. The `smem_health` MCP handler and the
+`smem health` CLI command each build an explicit response dict, and both simply omitted the
+new keys — the fields existed on the report object, were populated correctly, and were
+dropped at the serialization boundary. Verifying through `DiagnosticsEngine.analyze()`
+passes on the object that boundary then discards, which is exactly why this survived the
+original release.
+
+Both surfaces now carry them, omitted rather than nulled when a backend cannot answer,
+matching how `smem_evolution` already treats the same two fields.
+
+`smem health` also never showed `top_penalties` at all, so 2.18.0's corrected remedy text —
+the one that names spaced recall and says `smem consolidate` will not raise the ratio on its
+own — was reachable only over MCP and the dashboard. A CLI user saw a low consolidation bar
+and no explanation for it. The CLI now prints the biggest penalties with their remedy, plus
+the stage distribution and the semantic-gate breakdown.
+
 ## [2.18.0] — Maturation reachability
 
 2.16.0 made the consolidation report honest about what it counts. It did not make

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,21 @@ matching how `smem_evolution` already treats the same two fields.
 the one that names spaced recall and says `smem consolidate` will not raise the ratio on its
 own — was reachable only over MCP and the dashboard. A CLI user saw a low consolidation bar
 and no explanation for it. The CLI now prints the biggest penalties with their remedy, plus
-the stage distribution and the semantic-gate breakdown.
+the stage distribution and the semantic-gate breakdown. The semantic-gate line says what its
+numbers mean (`18 waiting on dwell time, 9 waiting on recall spacing, 3 ready`), and calls
+out the `ready` bucket as the only one a `smem consolidate` run moves.
+
+Both payloads are now produced by one serializer rather than two hand-maintained dicts.
+That duplication is the actual defect here: two lists of keys, written out by hand, drift
+apart the moment the report grows a field — which is how these two ended up missing from
+both surfaces while `top_penalties` was missing from only one. A field added to the report
+and to the serializer is now on both surfaces or on neither. `smem health --json`
+consequently also gained `contradiction_count`, `conflict_rate`, and the `weight` /
+`penalty_points` the MCP payload had always carried on each penalty.
+
+`docs/guides/brain-health.md` documents the maturation fields, and its example
+`top_penalties[].action` no longer quotes the pre-2.18.0 remedy that told the reader to run
+`smem consolidate`.
 
 ## [2.18.0] — Maturation reachability
 
@@ -73,10 +87,13 @@ merge partner does not have that dwell time reset to "now."
   hop advanced (`stm→working`, `working→episodic`, `episodic→semantic`); the three hop
   counts sum to the same total, so nothing about the existing field changes for anything
   already parsing it.
-- `smem_health` now includes a `stage_distribution` (how many fibers sit at each maturation
-  stage) and a `semantic_gate_blockers` breakdown of every EPISODIC fiber by what is actually
-  blocking it from SEMANTIC: waiting on dwell time, waiting on reinforcement spacing, or
-  already eligible and waiting for the next consolidation pass. Found and fixed along the
+- The health report now includes a `stage_distribution` (how many fibers sit at each
+  maturation stage) and a `semantic_gate_blockers` breakdown of every EPISODIC fiber by what
+  is actually blocking it from SEMANTIC: waiting on dwell time, waiting on reinforcement
+  spacing, or already eligible and waiting for the next consolidation pass. (Correction: this
+  entry originally said "`smem_health` now includes". It did not — both fields were dropped
+  at that tool's serialization boundary and reached a caller only through `smem_evolution`
+  and the dashboard. Fixed in 2.18.1.) Found and fixed along the
   way: `smem evolution`'s own "closest to semantic" classifier duplicated this threshold
   logic locally and checked only the distinct-days path, so a fiber that qualified through
   the rehearsal-count-and-windows alternative was misreported as still blocked. Both

--- a/docs/guides/brain-health.md
+++ b/docs/guides/brain-health.md
@@ -177,19 +177,23 @@ smem_recall("topic related to orphaned entities")
 
 ## Understanding Your Health Report
 
-When you run `smem_health()`, you get:
+When you run `smem_health()` — or `smem health --json`, which returns the same payload — you
+get:
 
 ```json
 {
   "purity_score": 44.9,
   "grade": "D",
+  "consolidation_ratio": 0.0,
+  "stage_distribution": {"stm": 40, "working": 12, "episodic": 30, "semantic": 0},
+  "semantic_gate_blockers": {"time_gate": 18, "spacing_gate": 9, "ready": 3},
   "top_penalties": [
     {
       "component": "consolidation_ratio",
       "current_score": 0.0,
       "penalty_points": 15.0,
       "estimated_gain": 12.0,
-      "action": "Run `smem consolidate` — 100% of fibers still episodic..."
+      "action": "100% of fibers are still episodic (target: 50%+ semantic). They advance to semantic only through spaced recall..."
     },
     {
       "component": "activation_efficiency",
@@ -209,6 +213,20 @@ When you run `smem_health()`, you get:
 3. **`action`** — Exactly what to do
 
 **Always fix the highest penalty first** — it gives you the most score improvement per effort.
+
+**How to read the maturation fields:** `consolidation_ratio` is one number and cannot explain
+itself. `stage_distribution` says which stage the fibers that have *not* reached semantic sit
+at. `semantic_gate_blockers` splits the EPISODIC ones by what is actually holding them back:
+
+| Bucket | Meaning | What moves it |
+|--------|---------|---------------|
+| `time_gate` | Has not dwelt in EPISODIC long enough | Time |
+| `spacing_gate` | Reinforcement not yet spread across 3+ distinct days (or 15+ rehearsals across 5+ time windows) | Recalling those memories on more separate days |
+| `ready` | Both gates satisfied | The next `smem consolidate` pass |
+
+Only the `ready` bucket moves by running a command. Both fields are omitted entirely on a
+backend that cannot report maturation — that is not the same as an empty distribution.
+`smem health` renders all of this as a **Maturation** section.
 
 ---
 

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "2.18.0",
+      "version": "2.18.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "2.18.0",
+      "version": "2.18.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.18.0"
+version = "2.18.1"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.18.0"
+__version__ = "2.18.1"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/cli/commands/info.py
+++ b/src/surreal_memory/cli/commands/info.py
@@ -361,48 +361,16 @@ def health(
                 "error": "No brain configured. Run: smem brain create default && smem brain use default"
             }
 
-        from surreal_memory.engine.diagnostics import DiagnosticsEngine
+        from surreal_memory.engine.diagnostics import DiagnosticsEngine, build_health_payload
 
         engine = DiagnosticsEngine(storage)
         report = await engine.analyze(storage.brain_id or brain.name)
 
-        payload: dict[str, Any] = {
-            "brain": brain.name,
-            "grade": report.grade,
-            "purity_score": report.purity_score,
-            "connectivity": report.connectivity,
-            "diversity": report.diversity,
-            "freshness": report.freshness,
-            "consolidation_ratio": report.consolidation_ratio,
-            "orphan_rate": report.orphan_rate,
-            "activation_efficiency": report.activation_efficiency,
-            "recall_confidence": report.recall_confidence,
-            "neuron_count": report.neuron_count,
-            "synapse_count": report.synapse_count,
-            "fiber_count": report.fiber_count,
-            "warnings": [
-                {"severity": w.severity.value, "code": w.code, "message": w.message}
-                for w in report.warnings
-            ],
-            "recommendations": list(report.recommendations),
-            # Without this the remedy text (what actually raises a component's
-            # score) existed only in the MCP payload -- a CLI user saw the low
-            # bar and never the explanation for it.
-            "top_penalties": [
-                {
-                    "component": p.component,
-                    "current_score": p.current_score,
-                    "estimated_gain": p.estimated_gain,
-                    "action": p.action,
-                }
-                for p in report.top_penalties
-            ],
-        }
-        if report.stage_distribution is not None:
-            payload["stage_distribution"] = dict(report.stage_distribution)
-        if report.semantic_gate_blockers is not None:
-            payload["semantic_gate_blockers"] = dict(report.semantic_gate_blockers)
-        return payload
+        # The same payload smem_health returns, minus its roadmap and embedding
+        # probe — see build_health_payload. Built there rather than here so this
+        # command cannot fall behind the MCP tool again; `top_penalties` (whose
+        # `action` is the remedy text a CLI user never saw) is part of that.
+        return build_health_payload(report, brain=brain.name)
 
     result = run_async(_health())
 
@@ -448,21 +416,7 @@ def health(
     )
 
     # Maturation: where fibers sit, and what holds the episodic ones back.
-    stages = result.get("stage_distribution")
-    if stages:
-        ordered = " ".join(
-            f"{name}: {stages[name]}"
-            for name in ("stm", "working", "episodic", "semantic")
-            if name in stages
-        )
-        typer.echo(f"\n  Stages    {ordered}")
-    blockers = result.get("semantic_gate_blockers")
-    if blockers:
-        typer.echo(
-            f"  Semantic gate  time: {blockers.get('time_gate', 0)}  "
-            f"spacing: {blockers.get('spacing_gate', 0)}  "
-            f"ready: {blockers.get('ready', 0)}"
-        )
+    _render_maturation(result.get("stage_distribution"), result.get("semantic_gate_blockers"))
 
     # Biggest score penalties, with the action that actually moves each one.
     penalties = result.get("top_penalties", [])
@@ -496,6 +450,73 @@ def health(
         typer.echo("\nRecommendations:")
         for rec in recommendations:
             typer.echo(f"  > {rec}")
+
+
+# Maturation stages in promotion order. The report carries the raw MemoryStage
+# values; "stm" is not a word, so it gets spelled out on the way to a terminal.
+_STAGE_LABELS: dict[str, str] = {
+    "stm": "short-term",
+    "working": "working",
+    "episodic": "episodic",
+    "semantic": "semantic",
+}
+
+
+def _render_maturation(
+    stage_distribution: dict[str, int] | None,
+    gate_blockers: dict[str, int] | None,
+) -> None:
+    """Render the maturation breakdown behind the consolidation bar above it.
+
+    ``consolidation_ratio`` is a single number that cannot explain itself: it
+    says what fraction of fibers reached SEMANTIC, never which stage the rest
+    sit at or what is holding them there. Both fields are absent when the
+    backend cannot report them — then this prints nothing.
+
+    The gate counts are spelled out rather than tabulated (``time: 18``) because
+    the reader who needs them is the one who does not already know what the
+    semantic gate is.
+    """
+    if not stage_distribution and not gate_blockers:
+        return
+
+    typer.echo("\nMaturation:")
+
+    if stage_distribution:
+        cells = [
+            f"{label}: {stage_distribution[stage]}"
+            for stage, label in _STAGE_LABELS.items()
+            if stage in stage_distribution
+        ]
+        # A backend may report a stage this CLI has not heard of — show it
+        # rather than silently dropping those fibers from the breakdown.
+        cells += [
+            f"{stage}: {count}"
+            for stage, count in sorted(stage_distribution.items())
+            if stage not in _STAGE_LABELS
+        ]
+        typer.echo(f"  {'Stages':<14} " + "  ".join(cells))
+
+    if gate_blockers:
+        time_gate = gate_blockers.get("time_gate", 0)
+        spacing_gate = gate_blockers.get("spacing_gate", 0)
+        ready = gate_blockers.get("ready", 0)
+        typer.echo(
+            f"  {'Semantic gate':<14} {time_gate} waiting on dwell time, "
+            f"{spacing_gate} waiting on recall spacing, {ready} ready"
+        )
+        if spacing_gate:
+            typer.secho(
+                f"    {spacing_gate} episodic fibers need recall spread across 3+ distinct days "
+                "(or 15+ rehearsals across 5+ time windows); consolidate will not move them.",
+                fg=typer.colors.YELLOW,
+            )
+        if ready:
+            # The one bucket a command moves — the other two need spaced recall.
+            typer.secho(
+                f"    {ready} already qualify — the next `smem consolidate` pass advances them.",
+                fg=typer.colors.GREEN,
+            )
 
 
 def _render_bar(label: str, value: float, *, invert: bool = False) -> None:

--- a/src/surreal_memory/cli/commands/info.py
+++ b/src/surreal_memory/cli/commands/info.py
@@ -366,7 +366,7 @@ def health(
         engine = DiagnosticsEngine(storage)
         report = await engine.analyze(storage.brain_id or brain.name)
 
-        return {
+        payload: dict[str, Any] = {
             "brain": brain.name,
             "grade": report.grade,
             "purity_score": report.purity_score,
@@ -385,7 +385,24 @@ def health(
                 for w in report.warnings
             ],
             "recommendations": list(report.recommendations),
+            # Without this the remedy text (what actually raises a component's
+            # score) existed only in the MCP payload -- a CLI user saw the low
+            # bar and never the explanation for it.
+            "top_penalties": [
+                {
+                    "component": p.component,
+                    "current_score": p.current_score,
+                    "estimated_gain": p.estimated_gain,
+                    "action": p.action,
+                }
+                for p in report.top_penalties
+            ],
         }
+        if report.stage_distribution is not None:
+            payload["stage_distribution"] = dict(report.stage_distribution)
+        if report.semantic_gate_blockers is not None:
+            payload["semantic_gate_blockers"] = dict(report.semantic_gate_blockers)
+        return payload
 
     result = run_async(_health())
 
@@ -429,6 +446,35 @@ def health(
         f"Synapses: {result['synapse_count']}  "
         f"Fibers: {result['fiber_count']}"
     )
+
+    # Maturation: where fibers sit, and what holds the episodic ones back.
+    stages = result.get("stage_distribution")
+    if stages:
+        ordered = " ".join(
+            f"{name}: {stages[name]}"
+            for name in ("stm", "working", "episodic", "semantic")
+            if name in stages
+        )
+        typer.echo(f"\n  Stages    {ordered}")
+    blockers = result.get("semantic_gate_blockers")
+    if blockers:
+        typer.echo(
+            f"  Semantic gate  time: {blockers.get('time_gate', 0)}  "
+            f"spacing: {blockers.get('spacing_gate', 0)}  "
+            f"ready: {blockers.get('ready', 0)}"
+        )
+
+    # Biggest score penalties, with the action that actually moves each one.
+    penalties = result.get("top_penalties", [])
+    if penalties:
+        typer.echo("\nBiggest penalties:")
+        for p in penalties:
+            typer.secho(
+                f"  {p['component']} ({p['current_score']:.2f}, "
+                f"+{p['estimated_gain']:.1f} available)",
+                fg=typer.colors.YELLOW,
+            )
+            typer.echo(f"    {p['action']}")
 
     # Warnings
     warnings = result.get("warnings", [])

--- a/src/surreal_memory/engine/diagnostics.py
+++ b/src/surreal_memory/engine/diagnostics.py
@@ -302,6 +302,72 @@ class BrainHealthReport:
     semantic_gate_blockers: dict[str, int] | None = None
 
 
+# ── Report serialization ─────────────────────────────────────────
+
+
+def build_health_payload(report: BrainHealthReport, *, brain: str) -> dict[str, Any]:
+    """Serialize a report into the payload every user-facing health surface returns.
+
+    `smem_health` (MCP) and `smem health --json` (CLI) show the same report to the
+    same operator, and each used to build its dict by hand, field by field. That is
+    the mechanism behind this whole fix: two hand-maintained lists of keys drift the
+    moment the report grows one. They had drifted in both directions at once —
+    `top_penalties` reached only the MCP payload, and the maturation fields reached
+    neither. One builder, one shape; a field added to the report and to this function
+    is on both surfaces or on neither. Callers add their own surface-specific keys
+    (roadmap, embedding probe, deep analysis) on top of what this returns.
+
+    `stage_distribution` and `semantic_gate_blockers` are omitted, not nulled, when
+    the report carries `None` — that means "this backend cannot answer", which is
+    not an empty distribution, and it matches how `smem_evolution` already
+    serializes the same two fields.
+    """
+    payload: dict[str, Any] = {
+        "brain": brain,
+        "grade": report.grade,
+        "purity_score": report.purity_score,
+        "connectivity": report.connectivity,
+        "diversity": report.diversity,
+        "freshness": report.freshness,
+        "consolidation_ratio": report.consolidation_ratio,
+        "orphan_rate": report.orphan_rate,
+        "activation_efficiency": report.activation_efficiency,
+        "recall_confidence": report.recall_confidence,
+        "neuron_count": report.neuron_count,
+        "synapse_count": report.synapse_count,
+        "fiber_count": report.fiber_count,
+        "contradiction_count": report.contradiction_count,
+        "conflict_rate": report.conflict_rate,
+        "warnings": [
+            {"severity": w.severity.value, "code": w.code, "message": w.message}
+            for w in report.warnings
+        ],
+        "recommendations": list(report.recommendations),
+        # The remedy text lives in `action` — without it a caller sees which
+        # component is costing points and nothing about how to move it.
+        "top_penalties": [
+            {
+                "component": p.component,
+                "current_score": p.current_score,
+                "weight": p.weight,
+                "penalty_points": p.penalty_points,
+                "estimated_gain": p.estimated_gain,
+                "action": p.action,
+            }
+            for p in report.top_penalties
+        ],
+    }
+
+    # Maturation view: which stages fibers sit at, and what blocks the episodic
+    # ones from SEMANTIC. These two exist to explain the consolidation_ratio above.
+    if report.stage_distribution is not None:
+        payload["stage_distribution"] = dict(report.stage_distribution)
+    if report.semantic_gate_blockers is not None:
+        payload["semantic_gate_blockers"] = dict(report.semantic_gate_blockers)
+
+    return payload
+
+
 # ── Grade mapping ────────────────────────────────────────────────
 
 

--- a/src/surreal_memory/mcp/stats_handler.py
+++ b/src/surreal_memory/mcp/stats_handler.py
@@ -236,55 +236,17 @@ class StatsHandler:
         if err:
             return err
 
-        from surreal_memory.engine.diagnostics import DiagnosticsEngine
+        from surreal_memory.engine.diagnostics import DiagnosticsEngine, build_health_payload
 
         engine = DiagnosticsEngine(storage)
         # Rows are scoped by the brain *name* (storage.brain_id), not by the brain
         # record's UUID primary key — brain.id would analyse an empty scope.
         report = await engine.analyze(storage.brain_id or brain.name)
 
-        result: dict[str, Any] = {
-            "brain": brain.name,
-            "grade": report.grade,
-            "purity_score": report.purity_score,
-            "connectivity": report.connectivity,
-            "diversity": report.diversity,
-            "freshness": report.freshness,
-            "consolidation_ratio": report.consolidation_ratio,
-            "orphan_rate": report.orphan_rate,
-            "activation_efficiency": report.activation_efficiency,
-            "recall_confidence": report.recall_confidence,
-            "neuron_count": report.neuron_count,
-            "synapse_count": report.synapse_count,
-            "fiber_count": report.fiber_count,
-            "contradiction_count": report.contradiction_count,
-            "conflict_rate": report.conflict_rate,
-            "warnings": [
-                {"severity": w.severity.value, "code": w.code, "message": w.message}
-                for w in report.warnings
-            ],
-            "recommendations": list(report.recommendations),
-            "top_penalties": [
-                {
-                    "component": p.component,
-                    "current_score": p.current_score,
-                    "weight": p.weight,
-                    "penalty_points": p.penalty_points,
-                    "estimated_gain": p.estimated_gain,
-                    "action": p.action,
-                }
-                for p in report.top_penalties
-            ],
-            "roadmap": self._build_health_roadmap(report),
-        }
-
-        # Maturation view: which stages fibers sit at, and what blocks the
-        # episodic ones from SEMANTIC. Omitted (not nulled) when the backend
-        # cannot answer, matching smem_evolution's treatment of the same fields.
-        if report.stage_distribution is not None:
-            result["stage_distribution"] = dict(report.stage_distribution)
-        if report.semantic_gate_blockers is not None:
-            result["semantic_gate_blockers"] = dict(report.semantic_gate_blockers)
+        # Shared with `smem health --json` — see build_health_payload. A new report
+        # field belongs there, not here, or the two surfaces drift apart again.
+        result: dict[str, Any] = build_health_payload(report, brain=brain.name)
+        result["roadmap"] = self._build_health_roadmap(report)
 
         # Embedding capability: surface whether the configured provider is usable
         # (missing package, disabled, or ready) so problems are visible, not silent.

--- a/src/surreal_memory/mcp/stats_handler.py
+++ b/src/surreal_memory/mcp/stats_handler.py
@@ -278,6 +278,14 @@ class StatsHandler:
             "roadmap": self._build_health_roadmap(report),
         }
 
+        # Maturation view: which stages fibers sit at, and what blocks the
+        # episodic ones from SEMANTIC. Omitted (not nulled) when the backend
+        # cannot answer, matching smem_evolution's treatment of the same fields.
+        if report.stage_distribution is not None:
+            result["stage_distribution"] = dict(report.stage_distribution)
+        if report.semantic_gate_blockers is not None:
+            result["semantic_gate_blockers"] = dict(report.semantic_gate_blockers)
+
         # Embedding capability: surface whether the configured provider is usable
         # (missing package, disabled, or ready) so problems are visible, not silent.
         try:

--- a/tests/unit/test_brain_scope_uses_brain_name.py
+++ b/tests/unit/test_brain_scope_uses_brain_name.py
@@ -119,6 +119,12 @@ def test_mcp_health_analyzes_the_brain_name_scope(monkeypatch: Any) -> None:
         warnings: list[Any] = []
         recommendations: list[Any] = []
         top_penalties: list[Any] = []
+        # Not covered by the 0.0 catch-all below: these are `dict | None` on the
+        # real report, and None is the "backend can't answer" case the handler
+        # checks for. Letting __getattr__ answer 0.0 would make the handler try
+        # to copy a float as a mapping.
+        stage_distribution: dict[str, int] | None = None
+        semantic_gate_blockers: dict[str, int] | None = None
 
         def __getattr__(self, _name: str) -> Any:
             return 0.0

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.18.0"
+        assert surreal_memory.__version__ == "2.18.1"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_health_payload_shared.py
+++ b/tests/unit/test_health_payload_shared.py
@@ -1,0 +1,265 @@
+"""The two health surfaces are serialized once, and the CLI renders what it gets.
+
+``TestHealthPayloadExposesMaturationFields`` (test_maturation_rehearsal.py) pins
+the MCP side of the fix. These pin the half that had no coverage at all:
+
+* both surfaces go through one serializer, so a field added to the report cannot
+  reach `smem_health` and miss `smem health --json` again — which is exactly how
+  `stage_distribution`/`semantic_gate_blockers` (missing from both) and
+  `top_penalties` (missing from the CLI only) diverged in the first place;
+* `smem health` actually prints the maturation breakdown and the penalty
+  remedies, rather than merely carrying them in a dict nobody displays.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from surreal_memory.engine.diagnostics import (
+    BrainHealthReport,
+    _rank_penalty_factors,
+    build_health_payload,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+BRAIN_NAME = "default"
+
+_STAGE_DISTRIBUTION = {"stm": 40, "working": 12, "episodic": 30, "semantic": 8}
+_GATE_BLOCKERS = {"time_gate": 18, "spacing_gate": 9, "ready": 3}
+
+_COMPONENT_SCORES = {
+    "connectivity": 0.4,
+    "diversity": 0.7,
+    "freshness": 0.9,
+    "consolidation_ratio": 0.09,
+    "orphan_rate": 0.2,
+    "activation_efficiency": 0.5,
+    "recall_confidence": 0.6,
+}
+
+
+def _make_report(
+    *,
+    stage_distribution: dict[str, int] | None = None,
+    semantic_gate_blockers: dict[str, int] | None = None,
+) -> BrainHealthReport:
+    return BrainHealthReport(
+        purity_score=61.2,
+        grade="C",
+        connectivity=0.4,
+        diversity=0.7,
+        freshness=0.9,
+        consolidation_ratio=0.09,
+        orphan_rate=0.2,
+        activation_efficiency=0.5,
+        recall_confidence=0.6,
+        neuron_count=250,
+        synapse_count=900,
+        fiber_count=90,
+        warnings=(),
+        recommendations=("Recall memories by topic.",),
+        top_penalties=_rank_penalty_factors(
+            _COMPONENT_SCORES,
+            metrics={"fiber_count": 90, "neuron_count": 250, "consolidation_ratio": 0.09},
+        ),
+        stage_distribution=stage_distribution,
+        semantic_gate_blockers=semantic_gate_blockers,
+    )
+
+
+class _FakeBrain:
+    id = "00313cb4-61ca-4e69-9784-e51431e99ad7"
+    name = BRAIN_NAME
+
+
+class _FakeStorage:
+    def __init__(self) -> None:
+        self.brain_id = BRAIN_NAME
+
+    async def get_brain(self, _brain_id: str) -> _FakeBrain:
+        return _FakeBrain()
+
+
+def _patch_cli_health(monkeypatch: pytest.MonkeyPatch, report: BrainHealthReport) -> None:
+    from surreal_memory.cli.commands import info
+    from surreal_memory.engine import diagnostics as diagnostics_mod
+
+    storage = _FakeStorage()
+
+    async def fake_get_storage(_config: Any) -> _FakeStorage:
+        return storage
+
+    class _FakeEngine:
+        def __init__(self, _storage: Any) -> None: ...
+
+        async def analyze(self, _brain_id: str) -> BrainHealthReport:
+            return report
+
+    monkeypatch.setattr(info, "get_config", lambda: object())
+    monkeypatch.setattr(info, "get_storage", fake_get_storage)
+    monkeypatch.setattr(diagnostics_mod, "DiagnosticsEngine", _FakeEngine)
+
+
+# ── The shared serializer ────────────────────────────────────────
+
+
+class TestBuildHealthPayload:
+    def test_carries_the_maturation_fields_and_the_penalty_remedies(self) -> None:
+        payload = build_health_payload(
+            _make_report(
+                stage_distribution=_STAGE_DISTRIBUTION,
+                semantic_gate_blockers=_GATE_BLOCKERS,
+            ),
+            brain=BRAIN_NAME,
+        )
+
+        assert payload["stage_distribution"] == _STAGE_DISTRIBUTION
+        assert payload["semantic_gate_blockers"] == _GATE_BLOCKERS
+        assert payload["brain"] == BRAIN_NAME
+        assert all(p["action"] for p in payload["top_penalties"])
+
+    def test_omits_rather_than_nulls_what_the_backend_cannot_report(self) -> None:
+        payload = build_health_payload(_make_report(), brain=BRAIN_NAME)
+
+        assert "stage_distribution" not in payload
+        assert "semantic_gate_blockers" not in payload
+
+    def test_copies_the_dicts(self) -> None:
+        """Mutating the payload must not reach back into the report."""
+        report = _make_report(
+            stage_distribution=_STAGE_DISTRIBUTION,
+            semantic_gate_blockers=_GATE_BLOCKERS,
+        )
+        payload = build_health_payload(report, brain=BRAIN_NAME)
+        payload["stage_distribution"]["semantic"] = 999
+
+        assert report.stage_distribution == _STAGE_DISTRIBUTION
+
+
+class TestBothSurfacesShareOneShape:
+    def test_cli_json_matches_the_mcp_payload(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The CLI's JSON is the MCP payload plus that tool's own extras.
+
+        Pinning the relationship, not two hand-copied key lists: a field added
+        to one and forgotten on the other is what this whole fix is about.
+        """
+        import asyncio
+
+        from surreal_memory.cli.commands import info
+        from surreal_memory.engine import diagnostics as diagnostics_mod
+        from surreal_memory.mcp.stats_handler import StatsHandler
+
+        report = _make_report(
+            stage_distribution=_STAGE_DISTRIBUTION,
+            semantic_gate_blockers=_GATE_BLOCKERS,
+        )
+        _patch_cli_health(monkeypatch, report)
+
+        cli_result: dict[str, Any] = {}
+        monkeypatch.setattr(info, "output_result", lambda result, _json: cli_result.update(result))
+        info.health(json_output=True)
+
+        class _FakeEngine:
+            def __init__(self, _storage: Any) -> None: ...
+
+            async def analyze(self, _brain_id: str) -> BrainHealthReport:
+                return report
+
+        monkeypatch.setattr(diagnostics_mod, "DiagnosticsEngine", _FakeEngine)
+        handler = StatsHandler.__new__(StatsHandler)
+
+        async def fake_get_storage() -> _FakeStorage:
+            return _FakeStorage()
+
+        handler.get_storage = fake_get_storage  # type: ignore[method-assign]
+        mcp_result = asyncio.run(handler._health({}))
+
+        # Everything the CLI reports, the MCP tool reports identically.
+        assert cli_result == {k: v for k, v in mcp_result.items() if k in cli_result}
+        # The MCP tool adds its own; the CLI adds none of its own.
+        assert set(mcp_result) - set(cli_result) <= {"roadmap", "embedding", "gromov", "pro_hints"}
+        assert cli_result["stage_distribution"] == _STAGE_DISTRIBUTION
+        assert cli_result["semantic_gate_blockers"] == _GATE_BLOCKERS
+        assert cli_result["top_penalties"]
+
+
+# ── What `smem health` actually prints ───────────────────────────
+
+
+class TestCliHealthRendered:
+    def test_renders_the_maturation_section(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from surreal_memory.cli.commands import info
+
+        _patch_cli_health(
+            monkeypatch,
+            _make_report(
+                stage_distribution=_STAGE_DISTRIBUTION,
+                semantic_gate_blockers=_GATE_BLOCKERS,
+            ),
+        )
+
+        info.health(json_output=False)
+        out = capsys.readouterr().out
+
+        assert "Maturation:" in out
+        assert "short-term: 40" in out
+        assert "semantic: 8" in out
+        # Spelled out, not "time: 18  spacing: 9  ready: 3".
+        assert "18 waiting on dwell time" in out
+        assert "9 waiting on recall spacing" in out
+        assert "3 ready" in out
+        # `ready` is the one bucket a command moves — and the only place the
+        # rendered view is allowed to recommend consolidate for the gate.
+        assert "smem consolidate` pass advances them" in out
+
+    def test_renders_the_penalty_remedies(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from surreal_memory.cli.commands import info
+
+        report = _make_report(
+            stage_distribution=_STAGE_DISTRIBUTION,
+            semantic_gate_blockers=_GATE_BLOCKERS,
+        )
+        _patch_cli_health(monkeypatch, report)
+
+        info.health(json_output=False)
+        out = capsys.readouterr().out
+
+        assert "Biggest penalties:" in out
+        for penalty in report.top_penalties:
+            assert penalty.action in out
+
+    def test_maturation_section_absent_when_the_backend_cannot_report(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from surreal_memory.cli.commands import info
+
+        _patch_cli_health(monkeypatch, _make_report())
+
+        info.health(json_output=False)
+        out = capsys.readouterr().out
+
+        assert "Maturation:" not in out
+        # The rest of the view is unaffected.
+        assert "Grade: C" in out
+        assert "Biggest penalties:" in out
+
+    def test_an_unknown_stage_is_not_dropped(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from surreal_memory.cli.commands import info
+
+        _patch_cli_health(
+            monkeypatch,
+            _make_report(stage_distribution={"stm": 2, "hibernating": 7}),
+        )
+
+        info.health(json_output=False)
+        out = capsys.readouterr().out
+
+        assert "hibernating: 7" in out

--- a/tests/unit/test_hook_capture_idempotency.py
+++ b/tests/unit/test_hook_capture_idempotency.py
@@ -10,18 +10,16 @@ HOME) -- never the shared prod brain. Each test uses a unique brain name and
 session id to avoid cross-test collisions in unified_config's process-wide
 _config / _storage_cache singletons.
 
-Caveat: only HOME/SURREAL_MEMORY_BRAIN are overridden, not
-SURREAL_MEMORY_STORAGE. If a developer's shell already has
-SURREAL_MEMORY_STORAGE=surrealdb exported (for day-to-day dashboard use),
-these tests resolve to the live SurrealDB backend instead of SQLite;
-_cleanup_test_brain() below deletes that throwaway "idem*" brain by id in
-that case so the shared DB never accumulates leftovers.
+That isolation is enforced by the autouse ``_isolate_storage_env`` fixture
+below, not merely assumed: overriding HOME/SURREAL_MEMORY_BRAIN alone is not
+enough, because UnifiedConfig.load() reads SURREAL_MEMORY_STORAGE straight
+from the environment and lets it win over config.toml. See that fixture for
+the full list of variables and why each one matters.
 """
 
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
@@ -47,36 +45,50 @@ _TEXT_B = (
 _TEXT_TRIVIAL = "abcd efgh ijk\nlmno pqrs tuv\nwxyz abcd efg\nhijk lmno pqr"
 
 
-async def _cleanup_test_brain(brain_name: str) -> None:
-    """Best-effort: drop this test's throwaway brain if it landed on live
-    SurrealDB instead of the isolated tmp_path SQLite fixture.
+@pytest.fixture(autouse=True)
+def _isolate_storage_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never let the developer's real environment decide a test's outcome.
 
-    The isolated_brain* fixtures only override HOME/SURREAL_MEMORY_BRAIN, not
-    SURREAL_MEMORY_STORAGE. When a developer's shell already exports
-    SURREAL_MEMORY_STORAGE=surrealdb (+ SURREALDB_URL/SURREALDB_PASS) for
-    day-to-day dashboard use, storage_backend resolves to "surrealdb" here
-    too, and every test would otherwise leave an orphaned "idem*" row behind
-    on the shared DB -- the same brain-leakage failure mode already fixed for
-    the other live-SurrealDB tests via cleanup_live_brains() in
-    _surrealdb_live.py. SQLite brains need no cleanup: they live under the
-    fixture's own tmp_path HOME, which pytest discards on its own.
+    These tests assert on a throwaway SQLite brain under a tmp_path HOME. Two
+    variables from a normal dev shell (``set -a; . ./.env``) silently move that
+    target, so the suite passed in CI -- where nothing is exported -- and failed
+    for anyone with a configured environment:
+
+    * ``SURREAL_MEMORY_STORAGE=surrealdb`` -- UnifiedConfig.load() reads this
+      directly and it outranks config.toml, so ``get_shared_storage()`` returns
+      the *live* SurrealDB instead of the fixture's SQLite brain. The unique
+      "idem*" brain does not exist there, so ``capture_text()`` short-circuits
+      on ``{"error": "No brain configured", "saved": 0}`` and nearly every
+      assertion fails as ``assert 0 == 1``. Pinned to "sqlite" rather than
+      deleted: this file's whole contract is the SQLite fixture backend.
+    * ``SURREAL_MEMORY_DIR`` -- resolves the data dir ahead of ``Path.home()``
+      in both UnifiedConfig and ``capture_state._state_path()``, so config.toml
+      and capture_state.json are read from the developer's real directory
+      instead of tmp_path (and this suite writes its state into it).
+
+    ``SURREALDB_URL``/``SURREALDB_PASS`` are dropped too, mirroring the same
+    guard in ``tests/e2e/test_api.py``: with no route to the live server, a
+    future regression in the pin above fails loudly instead of quietly writing
+    test brains into production.
+
+    Autouse, so tests that build their own environment inline (rather than via
+    the isolated_brain* fixtures) are covered as well; pytest instantiates
+    autouse fixtures before same-scope non-autouse ones, so the pin is in place
+    before any ``get_config(reload=True)`` below.
     """
-    from surreal_memory.unified_config import get_config, get_shared_storage
-
-    if get_config().storage_backend != "surrealdb":
-        return
-    try:
-        storage = await get_shared_storage()
-        from tests.unit._surrealdb_live import cleanup_live_brains
-
-        await cleanup_live_brains(storage, own_brain_id=brain_name)
-    except Exception:
-        pass
+    monkeypatch.setenv("SURREAL_MEMORY_STORAGE", "sqlite")
+    monkeypatch.delenv("SURREAL_MEMORY_DIR", raising=False)
+    monkeypatch.delenv("SURREALDB_URL", raising=False)
+    monkeypatch.delenv("SURREALDB_PASS", raising=False)
 
 
 @pytest.fixture
-async def isolated_brain(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[str]:
-    """Point unified_config at a throwaway HOME with a unique brain+session."""
+async def isolated_brain(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Point unified_config at a throwaway HOME with a unique brain+session.
+
+    No teardown: the SQLite brain lives under this fixture's own tmp_path HOME,
+    which pytest discards on its own.
+    """
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("TMPDIR", "/tmp")
     brain_name = "idem" + uuid.uuid4().hex[:12]
@@ -86,14 +98,11 @@ async def isolated_brain(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Asy
     from surreal_memory.unified_config import get_config
 
     get_config(reload=True)
-    yield brain_name
-    await _cleanup_test_brain(brain_name)
+    return brain_name
 
 
 @pytest.fixture
-async def isolated_brain_gate_enforce(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> AsyncIterator[str]:
+async def isolated_brain_gate_enforce(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
     """Same as isolated_brain, but with the write gate forced to enforce mode
     and an impossible min_length, so every capture is rejected deterministically."""
     monkeypatch.setenv("HOME", str(tmp_path))
@@ -112,8 +121,7 @@ async def isolated_brain_gate_enforce(
     from surreal_memory.unified_config import get_config
 
     get_config(reload=True)
-    yield brain_name
-    await _cleanup_test_brain(brain_name)
+    return brain_name
 
 
 class TestStopHookIdempotency:
@@ -219,13 +227,10 @@ class TestIdempotencyNegativePaths:
 
         get_config(reload=True)
 
-        try:
-            result1 = await stop_hook.capture_text(_TEXT_A, project_name=None)
-            assert result1["saved"] == 1
-            result2 = await stop_hook.capture_text(_TEXT_A, project_name=None)
-            assert result2["saved"] == 0
-        finally:
-            await _cleanup_test_brain(brain_name)
+        result1 = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        assert result1["saved"] == 1
+        result2 = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        assert result2["saved"] == 0
 
     async def test_corrupt_idempotency_state_fails_open_not_crash(
         self, isolated_brain: str, tmp_path: Path

--- a/tests/unit/test_maturation_rehearsal.py
+++ b/tests/unit/test_maturation_rehearsal.py
@@ -305,3 +305,100 @@ class TestStagesAdvancedPerHop:
             "episodic_to_semantic": 1,
         }
         assert sum(breakdown.values()) == report.stages_advanced
+
+
+class TestHealthPayloadExposesMaturationFields:
+    """The two maturation fields must survive `smem_health`'s serialization.
+
+    Regression: `stage_distribution` and `semantic_gate_blockers` were added to
+    the `BrainHealthReport` dataclass and populated by `analyze()`, but neither
+    the MCP handler nor the CLI copied them into the response they actually
+    return -- both build an explicit dict and simply omitted the new keys. The
+    fields existed, were computed on every call, and reached no user. Verifying
+    through `analyze()` alone cannot catch this: it passes on the object the
+    serialization boundary then drops.
+    """
+
+    def _handler_with_report(self, monkeypatch, report):
+        import asyncio
+
+        from surreal_memory.engine import diagnostics as diagnostics_mod
+        from surreal_memory.mcp.stats_handler import StatsHandler
+
+        class _FakeEngine:
+            def __init__(self, _storage): ...
+
+            async def analyze(self, _brain_id):
+                return report
+
+        monkeypatch.setattr(diagnostics_mod, "DiagnosticsEngine", _FakeEngine)
+
+        storage = AsyncMock()
+        storage.brain_id = "default"
+        storage.get_brain.return_value = SimpleNamespace(id="b1", name="default")
+
+        handler = StatsHandler.__new__(StatsHandler)
+
+        async def fake_get_storage():
+            return storage
+
+        handler.get_storage = fake_get_storage  # type: ignore[method-assign]
+        return asyncio.run(handler._health({}))
+
+    @staticmethod
+    def _report(**overrides):
+        base = {
+            "grade": "D",
+            "purity_score": 47.7,
+            "neuron_count": 10,
+            "synapse_count": 10,
+            "fiber_count": 10,
+            "contradiction_count": 0,
+            "warnings": [],
+            "recommendations": [],
+            "top_penalties": [],
+            "stage_distribution": {"stm": 1, "working": 2, "episodic": 6, "semantic": 1},
+            "semantic_gate_blockers": {"time_gate": 1, "spacing_gate": 5, "ready": 0},
+        }
+        base.update(overrides)
+
+        class _Report(SimpleNamespace):
+            def __getattr__(self, _name):  # numeric metrics the handler reads
+                return 0.0
+
+        return _Report(**base)
+
+    def test_stage_distribution_reaches_the_health_response(self, monkeypatch) -> None:
+        result = self._handler_with_report(monkeypatch, self._report())
+
+        assert result["stage_distribution"] == {
+            "stm": 1,
+            "working": 2,
+            "episodic": 6,
+            "semantic": 1,
+        }
+
+    def test_semantic_gate_blockers_reach_the_health_response(self, monkeypatch) -> None:
+        result = self._handler_with_report(monkeypatch, self._report())
+
+        assert result["semantic_gate_blockers"] == {
+            "time_gate": 1,
+            "spacing_gate": 5,
+            "ready": 0,
+        }
+
+    def test_a_backend_without_maturation_support_omits_them_rather_than_nulling(
+        self, monkeypatch
+    ) -> None:
+        """None means "this backend can't answer", which is not the same as an
+
+        empty distribution -- so the keys are left out entirely rather than
+        serialized as null, matching how `smem_evolution` already treats them.
+        """
+        result = self._handler_with_report(
+            monkeypatch,
+            self._report(stage_distribution=None, semantic_gate_blockers=None),
+        )
+
+        assert "stage_distribution" not in result
+        assert "semantic_gate_blockers" not in result

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "2.18.0",
+      "version": "2.18.1",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Follow-up bugfix to [#122](https://github.com/acidkill/surreal-memory/pull/122). Found during post-release verification against a live brain.

2.18.0 added `stage_distribution` and `semantic_gate_blockers` to the health report and
computed both on every call — but **neither reached any user**. The `smem_health` MCP handler
and the `smem health` CLI command each build an explicit response dict, and both simply
omitted the new keys. The fields existed on the report object, were populated correctly, and
were dropped at the serialization boundary.

That's also why the original release shipped with it: verifying through
`DiagnosticsEngine.analyze()` passes on the very object the boundary then discards. The
regression tests added here go through the handler, not the engine, so they fail on 2.18.0
and pass here.

Both surfaces now carry the fields, **omitted rather than nulled** when a backend cannot
answer — matching how `smem_evolution` already treats the same two fields.

### Also fixed

`smem health` never rendered `top_penalties` at all, so 2.18.0's corrected remedy text — the
one that names spaced recall and states that `smem consolidate` will not raise the ratio on
its own — was reachable only over MCP and the dashboard. A CLI user saw a low consolidation
bar and no explanation for it. The CLI now prints the biggest penalties with their remedy,
plus the stage distribution and the semantic-gate breakdown.

Patch release (2.18.1): bugfix only, no new features, no behavior change beyond fields and
output that were always meant to be there.

### Also fixed: `make verify` is trustworthy locally again

An earlier revision of this PR noted that `tests/unit/test_hook_capture_idempotency.py` fails
locally on any machine with the project's own environment exported, passes with it unset, and
was being tracked separately. It is fixed here instead, because that fragility is exactly what
made the release gate for this PR unreliable — it produced a wall of failures that had to be
investigated and dismissed before verification could proceed.

Narrowed to a single variable: **`SURREAL_MEMORY_STORAGE=surrealdb`**. Of the 16 variables a
normal dev shell exports, it is the only one that changes the outcome — the file passes with
all 15 others set. `UnifiedConfig.load()` reads it straight from `os.environ` and lets it
outrank `config.toml`, so `get_shared_storage()` hands the hooks the *live* SurrealDB instead
of the fixture's `tmp_path` SQLite brain. The unique `idem*` brain does not exist there,
`capture_text()` short-circuits on `{"error": "No brain configured", "saved": 0}`, and nearly
every assertion fails as `assert 0 == 1`.

That precedence is correct production behavior — it is how a process is pointed at the real
backend — so the defect is the tests' missing isolation, not the hook code. Fixed with an
autouse fixture matching the `_clear_endpoint_env` pattern in `test_reasoning_naming.py`:
pin `SURREAL_MEMORY_STORAGE=sqlite` and drop `SURREALDB_URL`/`SURREALDB_PASS`, mirroring the
guard already in `tests/e2e/test_api.py`. `SURREAL_MEMORY_DIR` is dropped too — a second,
independent hole found while narrowing: it resolves the data dir ahead of `Path.home()` in
both `UnifiedConfig` and `capture_state._state_path()`, so `config.toml` and
`capture_state.json` were read from — and this suite's state written into — the developer's
real directory rather than `tmp_path`.

No production code changes; one test file.

## Test plan

- [x] Three regression tests written first and confirmed failing on 2.18.0 with `KeyError: 'stage_distribution'` / `KeyError: 'semantic_gate_blockers'` — they exercise `StatsHandler._health()`, the exact boundary the original verification bypassed
- [x] Third test pins the `None` case: a backend that cannot report maturation omits the keys rather than serializing nulls
- [x] `uv run make verify` green (lint, format, mypy, 7092 passed, coverage 71% ≥ 67%, security scan)
- [x] Fixed a stale test fake in `test_brain_scope_uses_brain_name.py` whose catch-all `__getattr__` returned `0.0` for these `dict | None` fields, which made the handler try to copy a float as a mapping
- [x] Version parity bumped to 2.18.1 across pyproject, `__init__`, the version-pin test, all three npm packages and their lockfiles, plus a CHANGELOG entry
- [x] Idempotency isolation verified four ways on the merged branch: full dev environment exported (12 passed), unset (12 passed), `SURREAL_MEMORY_DIR` alone (12 passed, real data dir left untouched), and `pytest tests/ -m "not stress" -n auto` → 7116 passed, 55 skipped, 1 xfailed. `ruff check`, `ruff format --check` and `mypy src/ --ignore-missing-imports` clean.
