### PR TITLE
v2.18.2: honest consolidation docs, and stop mandating AI attribution

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,17 @@ repos:
       - id: bandit
         args: [-c, pyproject.toml, -r, src/]
         additional_dependencies: ["bandit[toml]"]
+
+  # AGENTS.md Hard Rule #2. Documented-only enforcement has failed twice: agent
+  # trailers reached main's permanent history because the tooling adds them by
+  # default and a reviewer has to notice a footer to catch it. This does not.
+  - repo: local
+    hooks:
+      - id: no-ai-attribution
+        name: no AI attribution in commit messages
+        entry: >-
+          bash -c 'if grep -qiE "co-authored-by:.*(claude|anthropic|copilot|gpt)|generated with \[?(claude|chatgpt)|built with:.*(claude|codex|copilot)" "$1"; then
+          echo "AGENTS.md Hard Rule #2: remove the AI attribution trailer from the commit message.";
+          exit 1; fi' --
+        language: system
+        stages: [commit-msg]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,15 +24,26 @@ This rule overrides every other heuristic in this file.
 
 ---
 
-## Hard Rule #2 — Tool Transparency
+## Hard Rule #2 — No AI Attribution
 
-State which agent / tool produced the PR. In the PR description add a line such as:
+**Do not put AI attribution in commits, PR descriptions, or the CHANGELOG.** No
+`Co-Authored-By: Claude <noreply@anthropic.com>` (or any other agent) trailer, no
+`Built with: …` footer, no "Generated with …" line.
 
+If your tooling adds such a trailer by default, strip it before pushing:
+
+```bash
+git commit --amend  # delete the trailer line, save
 ```
-Built with: Claude Code (Sonnet 4.6) — verified by @your-github-handle
-```
 
-Commit trailers from your agent (`Co-Authored-By: Claude <noreply@anthropic.com>`, etc.) are welcome — keep them.
+A commit or PR describes **the change**, not the process that produced it. The GitHub
+account on the commit is the responsible human either way — that is the accountability
+record, and it is already there without a trailer. See Hard Rule #1: you own what you
+ship, regardless of what typed it.
+
+> Earlier revisions of this file asked for the opposite. That guidance is withdrawn: it
+> conflicted with the project's own release rules and repeatedly leaked agent trailers
+> into `main`'s permanent history.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.18.2] — Docs catch up with the maturation model, and the attribution rule stops contradicting itself
+
+No behavior change. Documentation and contributor-process only.
+
+### The README described consolidation as something a command does
+
+`Memory consolidation — episodic memories mature into semantic knowledge` was the entire
+description, which reads as though `smem consolidate` performs the maturation. It does not,
+and 2.18.0 removed that claim from the code's own remedy text without updating the README
+that still implied it. The entry now states the actual mechanism: maturation happens through
+spaced recall (7 days dwell plus reinforcement across 3+ distinct days, or 15+ rehearsals
+across 5+ windows), names the two `smem health` fields that show where each memory sits and
+what it is waiting on, and points at `brain.reinforcement_neuron_limit` for widening how many
+of a recall's memories get rehearsed.
+
+`distill_llm_load_cmd` (2.18.0) was missing from the reasoning-training example entirely, so
+the documented config could only unload a model it never controlled the loading of.
+
+### AGENTS.md required the attribution that CLAUDE.md forbids
+
+`AGENTS.md` Hard Rule #2 was "Tool Transparency": it instructed contributors to add a
+`Built with: …` line and to *keep* `Co-Authored-By: Claude <noreply@anthropic.com>` trailers.
+`CONTRIBUTING.md`'s quality gate listed the same trailer as a requirement. Both are now the
+opposite rule, because the repo's release process forbids AI attribution and the two
+documents were pulling contributors in opposite directions — with the versioned, visible one
+winning by default for anyone who could not see the ignored one.
+
+Because a documented rule had already failed to prevent this twice, it is now also enforced
+mechanically: a `commit-msg` pre-commit hook rejects any commit message carrying an agent
+attribution trailer.
+
 ## [2.18.1] — The maturation view actually reaches `smem_health`
 
 2.18.0 added `stage_distribution` and `semantic_gate_blockers` to the health report and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ For the operating rules (gitflow, pre-commit gate, PR template, forbidden action
 
 - Green CI: `ruff check`, `ruff format --check`, `mypy --ignore-missing-imports`, `pytest -m "not stress"`.
 - PR body has a `## Test plan` checklist describing how you (or your agent) verified the change end-to-end.
-- Commits from an agent carry a trailer naming the tool (e.g. `Co-Authored-By: Claude <noreply@anthropic.com>`).
+- Commits and PR descriptions carry **no AI attribution** — no `Co-Authored-By: Claude <noreply@anthropic.com>` trailer, no "Built with" or "Generated with" footer. Strip them if your tooling adds them (see [AGENTS.md](AGENTS.md) Hard Rule #2). Your account on the commit is the accountability record.
 - At least one human reviewer approves the merge.
 
 ### AI-Slop Policy (3-Strike Rule)

--- a/README.md
+++ b/README.md
@@ -210,18 +210,19 @@ Sync uses **Merkle delta** — only diffs travel, not the full brain.
 - **Fast bulk training** — `smem train` batches DB writes (one round-trip per N synapses via `add_synapses_batch`) and the `find_neurons` brain_id index is now used, so large docs stay cheap per chunk even on big brains (previously 7–15 s/chunk on a 68k-neuron brain; ~10× fewer DB ops/chunk). Shows live `tqdm` progress.
 - **Import adapters** — migrate from ChromaDB, Mem0, Cognee, Graphiti, LlamaIndex
 - **Reasoning training** (opt-in) — mine a model's own `thinking` from `~/.claude` transcripts, distill it into reusable reasoning-pattern fibers, and inject the learned strategies into other models' sessions (dashboard + `smem reasoning` CLI + `smem_reasoning` MCP tool). Off by default; traces are redacted before storage.
-- **LLM pattern naming** (opt-in, local-only) — by default a distilled pattern is named after its own mechanics (`debugging: restate-goal, gather-evidence, verify`) and described by a raw slice of the medoid trace. Point `distill_use_llm` at a **loopback** OpenAI-compatible endpoint and a local model rewrites the title, description and strategy into something readable, leaving identity and statistics untouched. A non-loopback endpoint is refused outright — reasoning traces never leave the machine — and any failure falls back to the mechanical naming. `distill_llm_unload_cmd` unloads the model once the run ends, so it does not sit in VRAM between runs:
+- **LLM pattern naming** (opt-in, local-only) — by default a distilled pattern is named after its own mechanics (`debugging: restate-goal, gather-evidence, verify`) and described by a raw slice of the medoid trace. Point `distill_use_llm` at a **loopback** OpenAI-compatible endpoint and a local model rewrites the title, description and strategy into something readable, leaving identity and statistics untouched. A non-loopback endpoint is refused outright — reasoning traces never leave the machine — and any failure falls back to the mechanical naming. `distill_llm_load_cmd` loads the model once before the first request, so you control *how* it loads (context size, GPU layers, no vision projector) instead of accepting whatever the endpoint does implicitly; `distill_llm_unload_cmd` releases it when the run ends, so it does not sit in VRAM between runs. Both are argv lists run without a shell, `{model}` is substituted, and either one being absent or failing degrades silently to the old behavior:
 
   ```toml
   [reasoning_training]
   distill_use_llm = true
   distill_llm_model = "<a chat model your server serves>"
   distill_llm_endpoint = "http://127.0.0.1:PORT/v1"   # loopback only
+  distill_llm_load_cmd = ["<your-launcher>", "load", "{model}", "--n-gpu-layers", "99"]
   distill_llm_unload_cmd = ["<your-launcher>", "stop", "{model}"]
   ```
 
 #### Lifecycle & Storage
-- **Memory consolidation** — episodic memories mature into semantic knowledge
+- **Memory consolidation** — episodic memories mature into semantic knowledge through **spaced recall**, not through a command. A fiber reaches `semantic` after 7 days in `episodic` *plus* reinforcement spread across 3+ distinct days (or 15+ rehearsals across 5+ time windows) — recalling a memory is what advances it; `smem consolidate` cannot move it on its own. `smem health` shows where every memory sits (`stage_distribution`) and what each one is still waiting on (`semantic_gate_blockers`: dwell time, recall spacing, or already eligible), so a flat `consolidation_ratio` is diagnosable instead of mysterious. Recall rehearses the memories it actually surfaced — raise `brain.reinforcement_neuron_limit` (default 15) to widen that reach at the cost of some recall latency.
 - **Compression tiers** — full → summary → essence → ghost → metadata
 - **Brain versioning** — snapshot, rollback, diff, transplant memories between brains
 

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "2.18.1",
+      "version": "2.18.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "2.18.1",
+      "version": "2.18.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.18.1"
+version = "2.18.2"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.18.1"
+__version__ = "2.18.2"
 
 __all__ = [
     "__version__",

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.18.1"
+        assert surreal_memory.__version__ == "2.18.2"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "2.18.1",
+      "version": "2.18.2",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
Documentation and contributor-process only — no behavior change. Version bumped because the
README is the PyPI long description, so correcting it requires a release to reach the page
people actually read.

## The README still described consolidation as something a command does

Its entire description was:

> **Memory consolidation** — episodic memories mature into semantic knowledge

which reads as though `smem consolidate` performs the maturation. It does not. 2.18.0 removed
exactly that false claim from the code's own remedy text — and left the README implying it,
so the docs kept telling people the thing the release had just stopped telling them.

It now names the real mechanism (spaced recall: 7 days dwell **plus** reinforcement across 3+
distinct days, or 15+ rehearsals across 5+ windows), the two `smem health` fields that make a
flat `consolidation_ratio` diagnosable rather than mysterious (`stage_distribution`,
`semantic_gate_blockers`), and `brain.reinforcement_neuron_limit` for widening how much of a
recall gets rehearsed.

`distill_llm_load_cmd` (shipped in 2.18.0) was missing from the reasoning-training example
entirely, so the documented configuration could only *unload* a model whose loading it never
controlled.

## Test plan

- [x] `uv run make verify` — exit 0: lint, format, mypy, 7100 passed, coverage 71.22% ≥ 67%, security scan clean
- [x] Pre-commit hook verified against both cases: a message with `Co-authored-by: Claude …` exits 1 with the rule reference; a clean message exits 0
- [x] Version parity bumped to 2.18.2 across pyproject, `__init__`, the version-pin test, all three npm packages and their lockfiles
- [x] Diff audited for attribution: the only matches are the prohibition text and the hook's own detection pattern