### PR TITLE
2.20.0: the configured embedder is used, and a validated endpoint is the one connected to

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "2.19.0"
+    "version": "2.20.0"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "2.19.0",
+      "version": "2.20.0",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.20.0] — The embedding path stops being outperformed by its own fallback
 
+### Community — Spanish README (#127)
+
+Thanks to [WebBrain](https://github.com/webbrain-one) for this release's first outside
+contribution: a full Spanish translation, `README.es-ES.md`, alongside the original.
+
 ### Pattern clustering used a threshold that was never calibrated
 
 Distillation groups traces into patterns by cosine similarity when an embedder is available, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,75 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.20.0] — The embedding path stops being outperformed by its own fallback
+
+### Pattern clustering used a threshold that was never calibrated
+
+Distillation groups traces into patterns by cosine similarity when an embedder is available, and
+falls back to move-set Jaccard when one is not. The cosine threshold was a module constant — and
+because `_get_embedder()` read the environment instead of the configured embedder, it could return
+nothing on a correctly configured machine, so the embedding branch never ran there and the constant
+was never exercised against a real embedding model.
+
+Embedding models do not share a similarity scale. Measured against a local bge-m3 corpus, the
+shipped constant sat **above the 99th percentile** of pairwise trace similarity in every category:
+the largest categories produced no clusters at all, and the embedding path yielded roughly a fifth
+of what the move-set fallback it is meant to supersede produced over the same traces. Mining
+reported patterns learned while whole categories stayed empty, which reads as "not enough material"
+rather than as a threshold defect.
+
+The threshold is now `reasoning_training.cluster_cosine` (default `0.75`, clamped to `0.05`–`1.0`),
+so it travels with the configured embedder instead of being frozen in the module. The floor exists
+because single-linkage clustering collapses into a single component as the threshold approaches the
+corpus baseline — a very low value yields fewer patterns, not more.
+
+If a brain's category coverage looks stuck, re-run distillation after checking this value; a raised
+`pattern_targets` cannot help when nothing clusters in the first place.
+
+```toml
+[reasoning_training]
+cluster_cosine = 0.75
+```
+
+A non-finite value in that field is rejected rather than clamped: `NaN` propagates through the
+bounds check into the FLOOR, which would merge every trace into a single cluster instead of falling
+back to a usable threshold.
+
+### The embedder ignored its own configuration
+
+`_get_embedder()` probed the environment rather than reading `[embedding]`, so a configured local
+provider was skipped whenever an unrelated cloud API key happened to be present, and classification
+silently degraded to keyword matching. It now reads the configuration first and delegates to the
+canonical provider factory, falling back to environment probing only when embedding is disabled.
+
+`[embedding] endpoint` joins the reranker's equivalent knob, so a local OpenAI-compatible embedding
+server can be pinned in `config.toml` instead of only through an environment variable.
+
+### A validated endpoint was not the endpoint that got connected to
+
+The loopback gate is meant to guarantee that reasoning traces — private user data — never leave the
+machine. For two providers the value it checked had no causal connection to the URL the HTTP client
+actually opened, so the gate passed while requests went to a remote host:
+
+- **openrouter**: the endpoint was loopback-checked, but the provider was then built through the
+  factory, which supplies no `base_url` and falls back to a hardcoded remote default. No attacker
+  required — just the documented configuration surface.
+- **openai**: `[embedding] endpoint` is read from `config.toml` first, but the client resolved its
+  own base URL from the environment variable alone. A loopback endpoint set only in the config file
+  — exactly what that field is for — passed the check and then fell back to the hosted default.
+- **ollama**: short-circuit evaluation meant the check was never called for this provider at all,
+  and its base URL comes from `OLLAMA_BASE_URL`, which nothing validated.
+
+The endpoint that clears the gate is now passed explicitly as the client's `base_url`, in both the
+configured and the auto-detect paths, and the ollama gate tests the URL that provider really opens.
+The factory delegation that re-resolved the endpoint independently is gone.
+
+### Loopback validation accepted hostnames that only looked local
+
+The check guarding local-only endpoints tested for a `127.` prefix, which accepts
+`127.0.0.1.attacker.example` — a remote host. It now parses the host and asks the address itself
+whether it is a loopback address.
+
 ## [2.19.0] — Learned reasoning patterns can be rebuilt, and pattern reads follow the request's brain
 
 ### Losing pattern fibers was permanent

--- a/README.md
+++ b/README.md
@@ -222,6 +222,13 @@ Sync uses **Merkle delta** — only diffs travel, not the full brain.
   distill_llm_unload_cmd = ["<your-launcher>", "stop", "{model}"]
   ```
 
+- **Clustering threshold travels with the embedder** — two traces become one pattern when their embeddings exceed `cluster_cosine` (default `0.75`). Embedding models do not share a similarity scale, so a value borrowed from another model can sit above the *99th percentile* of your corpus and cluster nothing at all, silently leaving the move-set fallback to outperform the embedding path it is meant to back up. If mining reports patterns learned but categories stay empty, compare the threshold against your own pairwise distribution before raising `pattern_targets`:
+
+  ```toml
+  [reasoning_training]
+  cluster_cosine = 0.75   # lower = more merging; too low collapses everything into one cluster
+  ```
+
 #### Lifecycle & Storage
 - **Memory consolidation** — episodic memories mature into semantic knowledge through **spaced recall**, not through a command. A fiber reaches `semantic` after 7 days in `episodic` *plus* reinforcement spread across 3+ distinct days (or 15+ rehearsals across 5+ time windows) — recalling a memory is what advances it; `smem consolidate` cannot move it on its own. `smem health` shows where every memory sits (`stage_distribution`) and what each one is still waiting on (`semantic_gate_blockers`: dwell time, recall spacing, or already eligible), so a flat `consolidation_ratio` is diagnosable instead of mysterious. Recall rehearses the memories it actually surfaced — raise `brain.reinforcement_neuron_limit` (default 15) to widen that reach at the cost of some recall latency.
 - **Compression tiers** — full → summary → essence → ghost → metadata
@@ -263,8 +270,28 @@ smem setup embeddings            # choose "Sentence Transformers"
 | **Gemini** (recommended) | `gemini-embedding-001` | `GEMINI_API_KEY` | 3072-dim, multilingual, free tier |
 | Local (sentence-transformers) | `all-MiniLM-L6-v2` · `paraphrase-multilingual-MiniLM-L12-v2` | — | offline, no key, ~440MB download |
 | Ollama | `nomic-embed-text` · `bge-m3` | — | local server (`ollama serve`) |
+| **Local OpenAI-compatible** (e.g. llamastash) | `bge-m3` | — | any server exposing `/v1/embeddings`; pairs with `bge-reranker-v2-m3` on the same host |
 | OpenAI | `text-embedding-3-small` | `OPENAI_API_KEY` | paid |
 | OpenRouter | `openai/text-embedding-3-small` | `OPENROUTER_API_KEY` | OpenAI-compatible |
+
+**Running bge-m3 on your own OpenAI-compatible server** (llama.cpp, llamastash, vLLM …) — this is
+the local pairing for the `bge-reranker-v2-m3` cross-encoder described under Reranking, so both
+halves of retrieval stay on one host and nothing leaves the machine:
+
+```toml
+[embedding]
+enabled = true
+provider = "openai"          # the wire format, not the vendor
+model = "bge-m3-FP16"        # whatever name your server serves it under
+dimension = 1024             # bge-m3 is 1024-dim; drives the HNSW index
+endpoint = "http://127.0.0.1:11435/v1"
+```
+
+`endpoint` may also come from `SURREAL_MEMORY_EMBEDDING_ENDPOINT`; the config key wins, matching
+`[reranker] endpoint`. Only a loopback host is accepted for reasoning-trace work — a remote base is
+refused with a warning rather than silently downgrading, because those traces never leave the machine.
+The endpoint that passes that check is the one handed to the client as its base URL, so "the check
+passed" means the requests really went there — a provider's own hosted default cannot override it.
 
 Set the provider to `auto` to pick the best available option at runtime
 (order: Ollama → local sentence-transformers → Gemini → OpenAI → OpenRouter).
@@ -459,7 +486,7 @@ with `RunnableWithMessageHistory`.
 git clone https://github.com/acidkill/surreal-memory
 cd surreal-memory && pip install -e ".[dev]"
 smem doctor --dev        # Verify contributor setup
-pytest tests/ -v          # 7200+ tests
+pytest tests/ -v          # 7,267 tests
 ruff check src/ tests/    # Lint
 make verify               # Full CI gate
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,6 +12,8 @@ backends, and `storage_backend` still defaults to `sqlite` (SQLite schema v40) f
 have not pointed at a SurrealDB instance. Earlier revisions of this line conflated the two schema
 numbers and called SQLite a fixture; both claims contradicted the code.
 **Architecture**: Spreading activation reflex engine, biological memory model, MCP standard.
+**Community**: Thanks to [WebBrain](https://github.com/webbrain-one) for the project's first
+outside contribution — a full Spanish translation, `README.es-ES.md` (#127).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,13 @@
 > Every item passes the VISION.md 4-question test + brain test.
 > ZERO LLM dependency — pure algorithmic, regex, graph-based.
 
-**Current state**: v2.0.0 — 58 MCP tools, 7200+ tests, schema v40, SurrealDB backend (SQLite/InMemory retained only as test fixtures), neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
+**Current state**: v2.20.0 — 58 MCP tools, 7,267 tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
+
+**Storage**: SurrealDB is the recommended backend and the one the project is built around —
+SurrealDB schema v9. SQLite and InMemory are not test-only fixtures; they are real, selectable
+backends, and `storage_backend` still defaults to `sqlite` (SQLite schema v40) for installs that
+have not pointed at a SurrealDB instance. Earlier revisions of this line conflated the two schema
+numbers and called SQLite a fixture; both claims contradicted the code.
 **Architecture**: Spreading activation reflex engine, biological memory model, MCP standard.
 
 ---

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -467,30 +467,43 @@ smem doctor  # Shows current schema version + any issues
 
 This is **completely normal for new brains**. Consolidation measures how many memories have matured from episodic (raw) to semantic (pattern) stage. A new brain has no matured memories yet.
 
-**When to worry**: If your brain is older than 1 week with 50+ memories and consolidation is still 0%, run:
+**When to worry**: if your brain is older than a week with 50+ memories and consolidation is still
+0%, the question is whether anything is *eligible* — maturation is driven by spaced recall, so a
+memory advances by being recalled across several distinct days, not by running a command. Check
+what each memory is waiting on:
+
+```bash
+smem health          # stage_distribution + semantic_gate_blockers
+```
+
+If memories show as eligible but the ratio has not moved, promote them:
 
 ```bash
 smem consolidate --strategy mature
 ```
 
-Or in Claude Code, just say: "consolidate my memories".
+If they are still waiting on dwell time or recall spacing, that command has nothing to promote —
+keep using the brain instead.
 
 **Expected progression**: After 1-2 weeks of active use → 20-40%. After a month → 50%+. A brand new brain at 0% is not a bug — it just means no memories have been recalled enough times to qualify for maturation.
 
 ### Q: How does consolidation work? When should I run it?
 
-Consolidation maintains brain health through three strategies:
+Consolidation maintains brain health. The strategies you will reach for most:
 
 | Strategy | What it does | When to use |
 |----------|-------------|-------------|
-| `mature` | Advances episodic memories to semantic stage | Weekly — promotes stable patterns |
+| `mature` | Promotes memories that have ALREADY met the spaced-recall bar | Weekly — it advances what is eligible, it does not create eligibility |
 | `merge` | Combines overlapping fibers, prunes weak synapses | When brain grows large (1000+ fibers) |
-| `full` | All strategies + topic summarization | Monthly deep cleanup |
+| `all` | Every strategy in one pass | Monthly deep cleanup |
+
+`--strategy full` does not exist; `all` is the name for "run everything". Run
+`smem consolidate --help` for the current list.
 
 ```bash
 # Recommended schedule
 smem consolidate --strategy mature     # Weekly
-smem consolidate --strategy full       # Monthly
+smem consolidate --strategy all        # Monthly
 
 # Check what would be affected first
 smem brain health
@@ -543,7 +556,7 @@ Surreal-Memory is designed for **AI agent memory** — not as a general-purpose 
 
 | Aspect | Status |
 |--------|--------|
-| **Test suite** | 7200+ tests, 67%+ coverage enforced by CI |
+| **Test suite** | 7200+ tests; CI gate 65% coverage, release gate 67% |
 | **Security** | Input validation, ReDoS protection, activation queue caps, sensitive content detection |
 | **Stability** | 51+ releases, used daily by the maintainers in production AI workflows |
 | **Scalability** | Tested up to 5,000 neurons with sub-ms latency; designed for agent-scale data, not big data |
@@ -567,7 +580,7 @@ Surreal-Memory is designed for **AI agent memory** — not as a general-purpose 
 
 ### Q: How does Surreal-Memory handle concurrent access from multiple agents?
 
-Surreal-Memory stores every brain in **SurrealDB**, which handles concurrency at the storage engine:
+On the recommended **SurrealDB** backend, concurrency is handled by the storage engine:
 
 - **Multiple concurrent readers** — agents can query the same brain simultaneously
 - **Concurrent writers** — SurrealDB serializes conflicting writes through its own transaction engine, so there is no external file lock to manage

--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -565,28 +565,6 @@ memory = TypedMemory.create(
 memories = await storage.get_project_memories(project.id)
 ```
 
-## Export & Import
-
-```python
-from surreal_memory.sharing import BrainExporter
-
-exporter = BrainExporter()
-
-# Export
-snapshot = await exporter.export(storage, brain.id)
-json_data = exporter.to_json(snapshot)
-
-# Save to file
-with open("brain.json", "w") as f:
-    f.write(json_data)
-
-# Import
-from surreal_memory.sharing import BrainImporter
-
-importer = BrainImporter()
-await importer.import_brain(storage, snapshot, "new-brain-id")
-```
-
 ## Complete Example
 
 ```python

--- a/docs/api/server.md
+++ b/docs/api/server.md
@@ -417,14 +417,6 @@ Serve the React dashboard (SPA). Pages: Overview, Health, Graph, Timeline, Evolu
 
 Built with React 19 + TailwindCSS 4 + shadcn/ui + Recharts + Sigma.js. Warm cream light theme.
 
-#### GET /ui-legacy
-
-Serve the legacy vis.js graph visualization (backward compat).
-
-#### GET /dashboard-legacy
-
-Serve the legacy Alpine.js dashboard (backward compat).
-
 ---
 
 ## Dashboard API

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -345,7 +345,8 @@ own SurrealDB instance (or Docker Compose service).
 ```
 
 This local layout applies only when `storage_backend = "sqlite"` (or InMemory, which
-persists nothing). When `storage_backend = "surrealdb"` (the production default), brain
+persists nothing). When `storage_backend = "surrealdb"` (the recommended production backend; the
+built-in default value is `"sqlite"`), brain
 data lives inside the SurrealDB instance itself — e.g. the `surrealdb_data` Docker volume
 used by `docker-compose.surrealdb.yml` — not under `~/.surrealmemory/brains/`.
 

--- a/docs/concepts/memory-types.md
+++ b/docs/concepts/memory-types.md
@@ -7,14 +7,14 @@ Surreal-Memory supports typed memories for better organization and automatic lif
 | Type | Description | Default Expiry | Use Case |
 |------|-------------|----------------|----------|
 | `fact` | Objective information | Never | API endpoints, configuration values |
-| `decision` | Choices made | Never | Architectural decisions, tool choices |
+| `decision` | Choices made | 90 days | Architectural decisions, tool choices |
 | `preference` | User preferences | Never | Coding style, naming conventions |
 | `todo` | Action items | 30 days | Tasks, reminders, follow-ups |
-| `insight` | Learned patterns | Never | Debugging tricks, optimization tips |
-| `context` | Situational info | 7 days | Meeting notes, temporary context |
+| `insight` | Learned patterns | 180 days | Debugging tricks, optimization tips |
+| `context` | Situational info | Never | Meeting notes, temporary context |
 | `instruction` | User guidelines | Never | Project rules, conventions |
-| `error` | Error patterns | Never | Bug fixes, error solutions |
-| `workflow` | Process patterns | Never | Deployment steps, review processes |
+| `error` | Error patterns | 30 days | Bug fixes, error solutions |
+| `workflow` | Process patterns | 365 days | Deployment steps, review processes |
 | `reference` | External references | Never | Documentation links, resources |
 | `tool` | Tool/CLI usage patterns | 90 days | CLI flags, commands, invocation tips |
 | `boundary` | Safety rules | Never | "Never use eval()", "Always confirm before X" |
@@ -135,7 +135,7 @@ smem remember "DECISION: PostgreSQL over MongoDB. REASON: Strong consistency nee
 
 **Behavior:**
 
-- Never expires
+- Expires after 90 days by default
 - Searchable by decision keywords
 - Critical for understanding project history
 
@@ -181,7 +181,7 @@ smem remember "Always check for null before array access" --type insight
 
 **Behavior:**
 
-- Never expires
+- Expires after 180 days by default
 - High value for similar problem-solving
 - Good for documenting "lessons learned"
 
@@ -196,7 +196,7 @@ smem remember "Sprint 5 focus: performance" --type context --expires 14
 
 **Behavior:**
 
-- Expires in 7 days by default
+- Never expires by default
 - Lower retrieval priority for older queries
 - Good for session-specific context
 
@@ -231,7 +231,7 @@ smem remember "ERROR: CORS blocked request. SOLUTION: Add origin to allowed list
 
 **Behavior:**
 
-- Never expires
+- Expires after 30 days by default
 - Highly relevant for debugging queries
 - Pairs well with tags for categorization
 
@@ -245,7 +245,7 @@ smem remember "Deploy process: 1. Run tests 2. Build 3. Push to staging 4. Verif
 
 **Behavior:**
 
-- Never expires
+- Expires after 365 days by default
 - Good for recurring processes
 - Can be broken into steps
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -80,7 +80,8 @@ make verify
 
 ## Environment Variables
 
-<!-- AUTO-GENERATED from .env.example — do not edit this table manually -->
+<!-- Maintained by hand. No script generates this table; when you add an env var to
+     the code, add it here and to .env.example in the same change. -->
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `SURREAL_MEMORY_STORAGE` | No | `sqlite` | Storage backend: `sqlite`/`memory` (test fixtures) or `surrealdb` (production backend) |
@@ -99,10 +100,11 @@ make verify
 | `SURREAL_MEMORY_HUB_URL` | Sync only | — | Cloudflare sync hub URL |
 | `SURREAL_MEMORY_API_KEY` | Sync only | — | Sync hub API key |
 | `SURREAL_MEMORY_DEVICE_ID` | No | — | Device identifier for sync |
-| `SURREAL_MEMORY_SYNC_ENABLED` | No | `true` | Enable sync |
-| `SURREAL_MEMORY_SYNC_AUTO` | No | `true` | Auto-sync on changes |
+| `SURREAL_MEMORY_SYNC_ENABLED` | No | `false` | Enable sync |
+| `SURREAL_MEMORY_SYNC_AUTO` | No | `false` | Auto-sync on changes |
 | `SURREAL_MEMORY_EMBEDDING_ENABLED` | No | `false` | Enable vector embeddings |
-| `SURREAL_MEMORY_EMBEDDING_PROVIDER` | Embeddings only | — | `gemini`, `openai`, `openrouter` |
+| `SURREAL_MEMORY_EMBEDDING_PROVIDER` | Embeddings only | `sentence_transformer` | `sentence_transformer`, `openai`, `openrouter`, `gemini`, `ollama`, `bge_m3`, `auto` |
+| `SURREAL_MEMORY_EMBEDDING_ENDPOINT` | No | — | Base URL of a local OpenAI-compatible embedding server (e.g. llamastash bge-m3 at `http://127.0.0.1:11435/v1`). Config key `[embedding] endpoint` wins over this. |
 | `SURREAL_MEMORY_EMBEDDING_MODEL` | No | — | Model name for embeddings |
 | `GEMINI_API_KEY` | Gemini only | — | Google Gemini API key |
 | `OPENAI_API_KEY` | OpenAI only | — | OpenAI API key |

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -3,7 +3,7 @@
 Guide to using the Surreal-Memory CLI with examples and common workflows.
 
 !!! info "See also"
-    For a complete auto-generated reference of all 66 commands, see the [CLI Reference](cli-reference.md).
+    For a complete auto-generated reference of all 82 commands, see the [CLI Reference](cli-reference.md).
     For MCP tool usage in Claude Code, see the [MCP Tools Reference](../api/mcp-tools.md).
 
 ## Core Commands

--- a/docs/guides/brain-health.md
+++ b/docs/guides/brain-health.md
@@ -100,7 +100,9 @@ EPISODIC → WORKING → SEMANTIC
 **How memories consolidate:**
 
 1. **Natural maturation**: Memories recalled multiple times over days mature automatically
-2. **Manual consolidation**: Run `smem consolidate --strategy mature`
+2. **Recall the memories you care about.** Maturation is driven by spaced recall, not by a
+   command: `smem consolidate --strategy mature` only promotes fibers that have ALREADY met the
+   dwell-and-spacing bar. Running it on a brain with nothing eligible advances nothing.
 3. **Time**: The system periodically checks for memories ready to advance
 
 **How to improve:**
@@ -240,7 +242,7 @@ backend that cannot report maturation — that is not the same as an empty distr
 
 ### Week 2-3: Growth (D → C)
 
-- [ ] Run `smem consolidate --strategy mature` to advance memory stages
+- [ ] Recall actively for a week, then run `smem consolidate --strategy mature` to promote whatever became eligible
 - [ ] Use varied language (causal, temporal, relational) for diversity
 - [ ] Start sessions with `smem_recap()` to maintain freshness
 - [ ] Resolve any memory conflicts: `smem_conflicts(action="list")`
@@ -258,7 +260,7 @@ backend that cannot report maturation — that is not the same as an empty distr
 
 ### "Consolidation is 0% — is something broken?"
 
-No. New brains always start at 0%. Memories must be recalled multiple times over several days before they're eligible for maturation. Run `smem consolidate --strategy mature` after your first week of active use.
+No. New brains always start at 0%. Memories must be recalled multiple times over several days before they are eligible for maturation — recall is what advances them. Once that has happened, `smem consolidate --strategy mature` promotes the ones that qualify; run before then it has nothing to promote.
 
 ### "25% orphan neurons — should I worry?"
 

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -621,7 +621,7 @@ Surreal-Memory is lightweight — it won't slow down your editor.
 
 ## Available Tools
 
-**3 tools you need. 53 the agent handles automatically.**
+**3 tools you need. 55 the agent handles automatically.**
 
 58 tools are available, but most users only interact with three:
 
@@ -701,6 +701,29 @@ These tools fire automatically via MCP instructions and hooks — you don't need
 | `smem_sync_status` | Show pending changes, devices, last sync |
 | `smem_sync_config` | Configure hub URL, auto-sync, conflict strategy |
 | `smem_telegram_backup` | Send brain backup to Telegram |
+
+### Not listed above
+
+These were absent from this page while it was presented as the complete tool list. Descriptions
+come from each tool's own schema.
+
+| Tool | Description |
+|------|-------------|
+| `smem_budget` | Token budget analysis for recall — estimate, analyze, or optimize context window usage |
+| `smem_consolidate` | Run memory consolidation on the current brain |
+| `smem_lifecycle` | Memory lifecycle management — view lifecycle states and manage compression resistance |
+| `smem_provenance` | Trace provenance / verify / approve a memory neuron, or query retrieval traces |
+| `smem_reasoning` | Reasoning training: status, mine, patterns, or config |
+| `smem_refine` | Refine an instruction or workflow memory — update its content, record a failure mode, or add a  |
+| `smem_remember_batch` | Store multiple memories in a single call |
+| `smem_report_outcome` | Report execution outcome for an instruction or workflow memory |
+| `smem_show` | Get full verbatim content + metadata + synapses for a specific memory by ID |
+| `smem_source` | Manage memory sources (provenance) |
+| `smem_surface` | Knowledge Surface management — generate or inspect the |
+| `smem_tier` | Auto-tier management — promote/demote memories between HOT/WARM/COLD based on access patterns |
+| `smem_uncertainty` | How much can you trust this brain's memories? Uncertainty diagnostics — contradictions, low-evi |
+| `smem_visualize` | Generate charts from memory data |
+| `smem_watch` | Watch directories for file changes and auto-ingest into memory |
 
 ---
 

--- a/docs/guides/pro-quickstart.md
+++ b/docs/guides/pro-quickstart.md
@@ -65,7 +65,9 @@ namespace = "surreal_memory"
 database = "default"
 ```
 
-**Restart your MCP server** (or CLI session). > SurrealDB is the default and only first-class backend since the SurrealDB-only
+**Restart your MCP server** (or CLI session).
+
+> SurrealDB is the recommended and only first-class backend since the SurrealDB-only
 > release. SQLite remains solely as a lightweight test fixture; the legacy
 > SQLite↔SurrealDB migration / backend-switch flow was removed.
 

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -153,7 +153,7 @@
       <div>
         <div class="inline-flex items-center gap-2 bg-nm-green/10 text-nm-green text-sm font-medium px-3 py-1 rounded-full mb-6 border border-nm-green/20">
           <span class="w-2 h-2 bg-nm-green rounded-full"></span>
-          v1.6.0 — 20 MCP tools, 1649 tests
+          v2.19.0 — 58 MCP tools, 7200+ tests
         </div>
         <h1 class="font-heading text-4xl md:text-5xl lg:text-6xl font-bold leading-tight mb-6">
           Memory for<br>
@@ -361,7 +361,7 @@
             </svg>
           </div>
           <h3 class="font-heading font-semibold text-lg mb-2">Typed Relationships</h3>
-          <p class="text-nm-muted text-sm leading-relaxed">20 synapse types: CAUSED_BY, LEADS_TO, IS_A, CONTAINS, CO_OCCURS. Not just "related".</p>
+          <p class="text-nm-muted text-sm leading-relaxed">41 synapse types: CAUSED_BY, LEADS_TO, IS_A, CONTAINS, CO_OCCURS. Not just "related".</p>
         </div>
 
         <div class="bg-nm-surface border border-nm-border rounded-xl p-6 hover:border-nm-green/40 transition-colors duration-200 cursor-default">

--- a/docs/landing/pro.md
+++ b/docs/landing/pro.md
@@ -16,7 +16,7 @@ pip install surreal-memory[surrealdb]
 
 | Backend | Type | Best For |
 |---------|------|----------|
-| **SurrealDB** (default) | Document + Graph + Vector | Full-featured: semantic search, graph queries, vector indexing in one engine |
+| **SurrealDB** (recommended) | Document + Graph + Vector | Full-featured: semantic search, graph queries, vector indexing in one engine |
 | SQLite | Relational + FTS5 | Lightweight local-only setups, no external database |
 
 SurrealDB is the recommended backend. It provides native vector search (HNSW), graph traversal, and document storage in a single process -- no extra services to run.
@@ -93,7 +93,7 @@ Score per sentence = primary_similarity * 0.6 + max(reference_similarities) * 0.
 
 #### Consolidation
 
-14 consolidation strategies plus smart merge:
+20 consolidation strategies plus smart merge:
 
 | Strategy | Complexity | Best For |
 |----------|-----------|----------|
@@ -125,7 +125,7 @@ Deploy with the provided Worker template. No managed service dependency.
 
 | Interface | Description |
 |-----------|-------------|
-| **MCP Server** | 50+ tools for Claude, GPT, and other agents. Recall, store, consolidate, query. |
+| **MCP Server** | 58 tools for Claude, GPT, and other agents. Recall, store, consolidate, query. |
 | **Web Dashboard** | Browser-based brain inspector. Visualize neurons, fibers, and graph topology. |
 | **VS Code Extension** | Inline memory panel. Recall context without leaving the editor. |
 | **CLI** | Full control from the terminal. `smem recall`, `smem store`, `smem merge`, etc. |
@@ -167,21 +167,19 @@ Surreal-Memory vs. alternatives:
 
 ## MCP Tools
 
-50+ tools registered automatically. Key tools by category:
+58 tools registered automatically. Key tools by category:
 
 **Recall:**
 - `smem_recall` -- query memories with configurable depth and confidence
-- `smem_cone_query` -- semantic search with adjustable precision cone
 - `smem_suggest` -- autocomplete from brain neurons
 
 **Storage:**
 - `smem_remember` -- store facts, decisions, insights, todos
 - `smem_auto` -- auto-capture memories from text
-- `smem_delete` / `smem_delete_observations` -- remove specific data
+- `smem_forget` -- remove specific memories
 
 **Lifecycle:**
-- `smem_tier_info` -- view and manage storage tier distribution
-- `smem_pro_merge` -- smart consolidation with dry-run preview
+- `smem_tier` -- view and manage storage tier distribution
 - `smem_consolidate` -- trigger consolidation strategies
 
 **Sync:**

--- a/docs/promo/devto-article.md
+++ b/docs/promo/devto-article.md
@@ -157,7 +157,7 @@ If you need a lightweight SQLite-backed version, the upstream project is the rig
 ## Numbers
 
 - **58 MCP tools** — 3-tool core, 53 fire automatically or on demand
-- **5,500+ unit tests**, 67%+ CI coverage
+- **7200+ unit tests**, 67%+ CI coverage
 - **15 memory types**: fact, decision, error, insight, preference, workflow, todo, and more
 - **41 synapse types**: `CAUSED_BY`, `LEADS_TO`, `RESOLVED_BY`, `CONTRADICTS`, and 37 more
 - **$0.00 per query** — no API keys needed for core encode + recall

--- a/docs/promo/discord-anthropic.md
+++ b/docs/promo/discord-anthropic.md
@@ -24,7 +24,7 @@ smem-mcp  # starts the MCP server
 - All Pro-tier features free via the bundled community plugin (cone/HNSW vector search, smart merge, directional compression) — no license keys, no paywalls
 - 15 memory types · single-file portable brain · JSON export/import · multi-device sync via your own Cloudflare account
 
-**MIT · Python 3.11+ · 5,500+ unit tests**
+**MIT · Python 3.11+ · 7200+ unit tests**
 
 GitHub: https://github.com/acidkill/surreal-memory
 

--- a/docs/promo/hackernews.md
+++ b/docs/promo/hackernews.md
@@ -12,7 +12,7 @@ Core idea: memories are stored as typed neurons connected by 41 typed synapses (
 
 No embedding API calls needed for core recall — it's pure algorithmic graph traversal. Embeddings are optional for semantic (vector) search (supports Ollama, sentence-transformers, Gemini, OpenAI). Core encode + recall costs $0.00 per query.
 
-Backed by SurrealDB's multi-model engine (document + graph + vector HNSW in one database — no separate vector store). 58 MCP tools, 5,500+ tests, 67%+ CI coverage, Python 3.11+, MIT.
+Backed by SurrealDB's multi-model engine (document + graph + vector HNSW in one database — no separate vector store). 58 MCP tools, 7200+ tests, 67%+ CI coverage, Python 3.11+, MIT.
 
 All Pro-tier features (HNSW vector search, smart merge, 5-tier compression, sleep consolidation) are free via the bundled community plugin — no license keys.
 

--- a/docs/promo/reddit-claudeai.md
+++ b/docs/promo/reddit-claudeai.md
@@ -49,7 +49,7 @@ Works with Claude Code, Cursor, Windsurf, VS Code, Cline, Zed, and Gemini CLI.
 
 ## Numbers
 
-- **58 MCP tools** · **5,500+ unit tests** · **67%+ CI coverage**
+- **58 MCP tools** · **7200+ unit tests** · **67%+ CI coverage**
 - **$0.00/query** — no API calls for core encode + recall
 - 15 memory types · 41 synapse types
 - Python 3.11+ · async · MIT license

--- a/docs/promo/reddit-localllama.md
+++ b/docs/promo/reddit-localllama.md
@@ -30,7 +30,7 @@ This gives you multi-hop causal reasoning. "Why did the outage happen?" traces: 
 - **Lifecycle**: Ebbinghaus decay, Hebbian reinforcement, sleep consolidation (ENRICH/PRUNE/MERGE/DREAM), 5-tier compression
 - **MCP server**: 58 tools (3-tool core: smem_remember, smem_recall, smem_health), stdio + HTTP, works with Claude Code, Cursor, Windsurf, Cline, Zed, Gemini CLI
 - **Pro features**: cone/HNSW vector search, smart merge, directional compression — all FREE via the bundled community plugin, no license keys
-- **Tests**: 5,500+ unit tests, 67%+ CI coverage, mypy + ruff + pytest
+- **Tests**: 7200+ unit tests, 67%+ CI coverage, mypy + ruff + pytest
 
 ## Why local/offline users care
 

--- a/docs/promo/vs-neural-memory.md
+++ b/docs/promo/vs-neural-memory.md
@@ -15,7 +15,7 @@ This page explains what was inherited and what changed so you can make an inform
 - 41 explicit synapse types (`CAUSED_BY`, `LEADS_TO`, `RESOLVED_BY`, `CONTRADICTS`, …) for causal reasoning
 - 15 memory types (`fact`, `decision`, `error`, `insight`, `preference`, `workflow`, `todo`, …)
 - Memory lifecycle: decay (Ebbinghaus curve), Hebbian reinforcement, sleep-consolidation phases
-- The 56-tool MCP surface — including the 3-tool core (`smem_remember`, `smem_recall`, `smem_health`)
+- The 58-tool MCP surface — including the 3-tool core (`smem_remember`, `smem_recall`, `smem_health`)
 
 ---
 

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "2.19.0",
+      "version": "2.20.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "2.19.0",
-  "description": "TypeScript client for the Surreal-Memory REST API — typed access to brains, neurons, synapses, fibers, recall, and sync.",
+  "version": "2.20.0",
+  "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/integrations/surreal-memory/SKILL.md
+++ b/integrations/surreal-memory/SKILL.md
@@ -230,7 +230,7 @@ Automatically extracts: 1 decision, 1 fact, 1 TODO.
 
 - **Zero LLM dependency** — Pure algorithmic: regex, graph traversal, Hebbian learning
 - **Spreading activation** — Associative recall through neural graph, not keyword/vector search
-- **20 synapse types** — Temporal (BEFORE/AFTER), causal (CAUSED_BY/LEADS_TO), semantic (IS_A/HAS_PROPERTY), emotional (FELT/EVOKES), conflict (CONTRADICTS)
+- **41 synapse types** — Temporal (BEFORE/AFTER), causal (CAUSED_BY/LEADS_TO), semantic (IS_A/HAS_PROPERTY), emotional (FELT/EVOKES), conflict (CONTRADICTS)
 - **Memory lifecycle** — Short-term → Working → Episodic → Semantic with Ebbinghaus decay
 - **Contradiction detection** — Auto-detects conflicting memories, deprioritizes outdated ones
 - **Hebbian learning** — "Neurons that fire together wire together" — memory improves with use

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "2.19.0",
+      "version": "2.20.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "surrealmemory",
-  "version": "2.19.0",
-  "description": "Surreal-Memory plugin for OpenClaw — graph-based persistent memory for AI agents with SurrealDB backend",
+  "version": "2.20.0",
+  "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,18 @@ plugins:
             heading_level: 2
 
 exclude_docs: |
-  llm-wiki/
+  # Outbound copy drafts (platform-specific, pasted elsewhere — not site pages).
+  promo/devto-article.md
+  promo/discord-anthropic.md
+  promo/hackernews.md
+  promo/reddit-claudeai.md
+  promo/reddit-localllama.md
+  # Internal engineering artifacts, not end-user docs.
+  lessons-learned.md
+  plans/
+  # Superseded snapshots that carry their own HISTORICAL banner.
+  ARCHITECTURE_V1_EXTENDED.md
+  architecture/architect-260302-0506-kb-retrieval-analysis.md
 
 markdown_extensions:
   - pymdownx.highlight:
@@ -105,6 +116,7 @@ nav:
     - OpenClaw Plugin: guides/openclaw-plugin.md
     - Cognitive Reasoning: guides/cognitive-reasoning.md
     - Schema v21 Migration: guides/schema-v21-migration.md
+    - Memory Layer Unification: guides/memory-layer-unification.md
     - Learning Habits: guides/learning-habits.md
     - Safety & Security: guides/safety.md
     - Companion Setup: guides/companion-setup.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "2.19.0"
+version = "2.20.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/scripts/sync_refs.py
+++ b/scripts/sync_refs.py
@@ -29,6 +29,10 @@ SKIP_FILES = {
     "docs/changelog.md",
     "AUDIT-REPORT.md",
     "docs/guides/schema-v21-migration.md",  # Historical migration — references old schema versions
+    # Dated posts record what was true when they were written. "1,299 tests" in a
+    # post stamped February 2026 is a fact about February, not drift to correct.
+    "docs/blog/honest-comparison-2026.md",
+    "docs/blog/why-i-built-surrealmemory.md",
 }
 
 # Paths to skip entirely (not shipped docs)
@@ -38,7 +42,34 @@ SKIP_DIRS = {
     ".git",
     "coverage",
     "__pycache__",
+    # Run evidence, not shipped documentation. It is gitignored, and it QUOTES
+    # stale forms on purpose as examples of what the scanner used to miss —
+    # "correcting" those quotes would destroy the very thing they record.
+    "qa",
+    ".goal",
 }
+
+# Lines that legitimately carry a NUMBER THAT IS NOT OURS, or not ours *now*.
+# Without these the checker "fixes" true statements:
+#   - README Acknowledgments credits the upstream project's own tool count.
+#   - ROADMAP's "What We've Built" table is version-tagged history (a `v1.0` row
+#     describes v1.0, not today).
+HISTORICAL_LINE_MARKERS = (
+    "entirely their work",  # README § Acknowledgments — upstream's count
+    "| v1.0",  # ROADMAP "What We've Built" rows carry their own Version column
+    # (also catches "| v1.0-v2.29" — the substring match covers the ranged form)
+    "| v2.0 |",
+    # There are TWO schema counters — sqlite_schema.py (the truth this script
+    # reads) and surrealdb/schema.py. A line that says which backend it means
+    # is not stale just because the other backend's number differs.
+    "SurrealDB schema v",
+)
+
+
+def _is_historical_line(line: str) -> bool:
+    """True when a line states a number about the past or about another project."""
+    return any(marker in line for marker in HISTORICAL_LINE_MARKERS)
+
 
 PASS = "\033[92m PASS \033[0m"
 FAIL = "\033[91m FAIL \033[0m"
@@ -63,6 +94,10 @@ class TruthValues:
     mcp_tool_count: int = 0
     test_count_approx: int = 0  # Rounded to nearest 100
     schema_version: int = 0
+    memory_type_count: int = 0
+    synapse_type_count: int = 0
+    strategy_count: int = 0
+    cli_command_count: int = 0
     version: str = ""
     errors: list[str] = field(default_factory=list)
 
@@ -117,6 +152,24 @@ def derive_truth() -> TruthValues:
     else:
         truth.errors.append("pyproject.toml not found")
 
+    try:
+        from surreal_memory.core.memory_types import MemoryType
+        from surreal_memory.core.synapse import SynapseType
+        from surreal_memory.engine.consolidation import ConsolidationStrategy
+
+        truth.memory_type_count = len(list(MemoryType))
+        truth.synapse_type_count = len(list(SynapseType))
+        # "ALL" is an aggregate switch, not a strategy anyone runs on its own.
+        truth.strategy_count = len([s for s in ConsolidationStrategy if s.name != "ALL"])
+    except Exception:
+        truth.errors.append("enum counts unavailable (memory/synapse/strategy)")
+
+    cli_ref = ROOT / "docs/getting-started/cli-reference.md"
+    if cli_ref.exists():
+        m = re.search(r"\*\*(\d+) commands\*\*", cli_ref.read_text(encoding="utf-8"))
+        if m:
+            truth.cli_command_count = int(m.group(1))
+
     return truth
 
 
@@ -148,8 +201,17 @@ def scan_stale_refs(truth: TruthValues) -> list[RefFinding]:
         # Match any number followed by " tools" or " MCP tools" (but not in code blocks)
         patterns.append(
             (
-                re.compile(r"\b(\d+)(\s+(?:MCP\s+)?tools)\b"),
+                re.compile(r"\b(\d+)\+?(\s+(?:MCP\s+)?tools)\b"),
                 "tool_count",
+                str(truth.mcp_tool_count),
+            )
+        )
+        # Hyphenated form: "the 53-tool MCP interface". The plain pattern needs a
+        # space and a plural, so this shape drifted unnoticed across releases.
+        patterns.append(
+            (
+                re.compile(r"\b(\d+)(-tool\b)"),
+                "tool_count_hyphenated",
                 str(truth.mcp_tool_count),
             )
         )
@@ -168,6 +230,15 @@ def scan_stale_refs(truth: TruthValues) -> list[RefFinding]:
             (
                 re.compile(r"\b(\d{4})\+?\s+tests\b"),
                 "test_count",
+                f"{truth.test_count_approx}+",
+            )
+        )
+        # Comma-grouped counts have no four consecutive digits, so the pattern
+        # above never fired on "5,500+ tests" or "1,299 tests".
+        patterns.append(
+            (
+                re.compile(r"\b(\d{1,3},\d{3})\+?\s+tests\b"),
+                "test_count_comma",
                 f"{truth.test_count_approx}+",
             )
         )
@@ -199,6 +270,10 @@ def scan_stale_refs(truth: TruthValues) -> list[RefFinding]:
         for line_num, line in enumerate(lines, 1):
             # Skip code blocks
             if line.strip().startswith("```") or line.strip().startswith("`"):
+                continue
+
+            # Skip lines whose number is historical or belongs to another project
+            if _is_historical_line(line):
                 continue
 
             for pattern, ref_type, truth_val in patterns:
@@ -238,6 +313,36 @@ def scan_stale_refs(truth: TruthValues) -> list[RefFinding]:
                     elif ref_type == "test_count":
                         old_num = match.group(1)
                         if int(old_num) < truth.test_count_approx:
+                            old_text = match.group(0)
+                            new_text = f"{truth.test_count_approx}+ tests"
+                            findings.append(
+                                RefFinding(
+                                    file=rel_path,
+                                    line_num=line_num,
+                                    old_text=old_text,
+                                    new_text=new_text,
+                                    ref_type=ref_type,
+                                )
+                            )
+
+                    elif ref_type == "tool_count_hyphenated":
+                        old_num = match.group(1)
+                        if int(old_num) != truth.mcp_tool_count and 20 <= int(old_num) <= 200:
+                            old_text = match.group(0)
+                            new_text = f"{truth.mcp_tool_count}-tool"
+                            findings.append(
+                                RefFinding(
+                                    file=rel_path,
+                                    line_num=line_num,
+                                    old_text=old_text,
+                                    new_text=new_text,
+                                    ref_type=ref_type,
+                                )
+                            )
+
+                    elif ref_type == "test_count_comma":
+                        old_num = int(match.group(1).replace(",", ""))
+                        if old_num < truth.test_count_approx:
                             old_text = match.group(0)
                             new_text = f"{truth.test_count_approx}+ tests"
                             findings.append(

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "2.19.0"
+__version__ = "2.20.0"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/reasoning_distiller.py
+++ b/src/surreal_memory/engine/reasoning_distiller.py
@@ -33,7 +33,7 @@ from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.synapse import Direction, Synapse, SynapseType
 from surreal_memory.engine.clustering import UnionFind
-from surreal_memory.engine.reasoning_naming import build_namer
+from surreal_memory.engine.reasoning_naming import _is_loopback, build_namer
 from surreal_memory.engine.reasoning_progress import PHASE_DISTILLING, MiningProgress
 
 if TYPE_CHECKING:
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_CLUSTER_COSINE = 0.83
+_CLUSTER_COSINE = 0.75  # fallback only; reasoning_training.cluster_cosine wins
 _CATEGORY_COS_THRESHOLD = 0.35
 _MOVE_JACCARD = 0.6
 _CLASSIFY_CHARS = 500
@@ -277,14 +277,21 @@ def _medoid_index(vectors: list[list[float]]) -> int:
 def _cluster(
     vectors: list[list[float]] | None,
     moves: list[list[str]],
+    cosine_threshold: float = _CLUSTER_COSINE,
 ) -> list[list[int]]:
-    """Cluster items by cosine (vectors) or move-set Jaccard (fallback)."""
+    """Cluster items by cosine (vectors) or move-set Jaccard (fallback).
+
+    ``cosine_threshold`` belongs to the configured embedder, not to this
+    module: two models embedding the same pair of traces disagree on the
+    absolute cosine, so a value tuned for one silently clusters nothing under
+    another.
+    """
     n = len(moves)
     uf = UnionFind(n)
     for i in range(n):
         for j in range(i + 1, n):
             if vectors is not None:
-                if _cosine(vectors[i], vectors[j]) >= _CLUSTER_COSINE:
+                if _cosine(vectors[i], vectors[j]) >= cosine_threshold:
                     uf.union(i, j)
             else:
                 a, b = set(moves[i]), set(moves[j])
@@ -405,14 +412,101 @@ async def _materialize_pattern(
     return True
 
 
-def _get_embedder() -> EmbeddingProvider | None:
+_LOCAL_SAFE_PROVIDERS: tuple[str, ...] = ("openai", "openrouter", "bge_m3")
+_OLLAMA_DEFAULT_BASE = "http://localhost:11434"
+
+
+def _warn_remote_endpoint(endpoint: str) -> None:
+    """Say the embedder was refused, rather than degrading silently.
+
+    A silent fallback to keyword classification is indistinguishable from
+    "embeddings are off" from the outside, which is how a misconfigured
+    endpoint went unnoticed long enough to freeze category coverage.
+    """
+    logger.warning(
+        "reasoning distiller: embedding endpoint %r is not loopback — "
+        "reasoning traces never leave this machine, so classification "
+        "falls back to keywords. Point SURREAL_MEMORY_EMBEDDING_ENDPOINT "
+        "or [embedding] endpoint at a local server to enable it.",
+        endpoint or "<unset>",
+    )
+
+
+def _endpoint_is_loopback(endpoint: str) -> bool:
+    """True when *endpoint* is a URL whose host is genuinely loopback.
+
+    ``_is_loopback`` takes a HOST, not a URL — parsing is the caller's job (see
+    ``resolve_llm_endpoint``), so handing it a full URL always answers False.
+    The host test itself lives there and is shared, so both the distill-LLM and
+    the embedder reach a remote endpoint under exactly one rule.
+    """
+    from urllib.parse import urlsplit
+
+    if not endpoint.strip():
+        return False
+    try:
+        return _is_loopback(urlsplit(endpoint.strip()).hostname)
+    except ValueError:
+        return False
+
+
+def _get_embedder(config: UnifiedConfig | None = None) -> EmbeddingProvider | None:
     """Best-effort LOCAL embedding provider; None if unavailable (fail-soft).
 
-    Mirrors the stop-hook pattern: only a local Ollama or a loopback
-    OpenAI-compatible endpoint (llamastash bge-m3) is used, so distillation stays
-    local + fast and never blocks on a remote/heavy provider. Any failure -> None
-    and the caller falls back to keyword classification + move-set clustering.
+    Only a local Ollama or a loopback OpenAI-compatible endpoint (llamastash
+    bge-m3) is used, so distillation stays local + fast and never blocks on a
+    remote/heavy provider. Any failure -> None and the caller falls back to
+    keyword classification + move-set clustering.
+
+    The CONFIGURED provider wins when embeddings are enabled. Deciding by
+    environment probe alone meant an unrelated GEMINI_API_KEY export shadowed a
+    correctly configured loopback endpoint: the probe answered "gemini", which
+    this function cannot build, so it returned None and every trace was
+    classified by keyword while a working bge-m3 sat idle. Delegating to the
+    canonical factory also picks up the configured model name and the shared
+    provider cache, neither of which the hand-rolled construction had.
     """
+    if config is not None and config.embedding.enabled:
+        provider = (config.embedding.provider or "").strip().lower()
+        endpoint = config.embedding.resolved_endpoint()
+        if provider == "auto":
+            provider = ""  # fall through to the probe below
+        elif provider == "ollama":
+            # Ollama's own base URL, NOT the embedding endpoint: it is the value
+            # this provider actually connects to, so it is the one that has to
+            # clear the gate. Checking anything else would validate a string
+            # that never reaches the socket.
+            ollama_base = endpoint or os.environ.get("OLLAMA_BASE_URL", _OLLAMA_DEFAULT_BASE)
+            if not _endpoint_is_loopback(ollama_base):
+                _warn_remote_endpoint(ollama_base)
+                return None
+            try:
+                from surreal_memory.engine.embedding.ollama_embedding import OllamaEmbedding
+
+                return OllamaEmbedding(model=config.embedding.model, base_url=ollama_base)
+            except Exception:
+                logger.debug("reasoning distiller: ollama embedder could not be built")
+                return None
+        elif provider in _LOCAL_SAFE_PROVIDERS and _endpoint_is_loopback(endpoint):
+            try:
+                from surreal_memory.engine.embedding.openai_embedding import OpenAIEmbedding
+
+                # base_url is passed EXPLICITLY so the endpoint that cleared the
+                # gate is the endpoint the client connects to. Delegating to the
+                # provider factory instead re-resolved it independently: an
+                # openrouter provider carries a hardcoded remote default, and an
+                # openai one reads only the env var, so a loopback endpoint set
+                # in config.toml passed the check while traces went to the cloud.
+                return OpenAIEmbedding(model=config.embedding.model, base_url=endpoint)
+            except Exception:
+                logger.debug(
+                    "reasoning distiller: configured provider %r could not be built", provider
+                )
+                return None
+        elif provider in _LOCAL_SAFE_PROVIDERS:
+            _warn_remote_endpoint(endpoint)
+            return None
+
     try:
         from surreal_memory.engine.semantic_discovery import _auto_detect_provider
 
@@ -423,15 +517,20 @@ def _get_embedder() -> EmbeddingProvider | None:
 
     try:
         endpoint = os.environ.get("SURREAL_MEMORY_EMBEDDING_ENDPOINT", "")
-        is_local = any(host in endpoint for host in ("127.0.0.1", "localhost", "::1"))
         if provider_name == "ollama":
+            # Same rule as the configured path: gate the URL this provider will
+            # really open, which is OLLAMA_BASE_URL, not the embedding endpoint.
+            ollama_base = os.environ.get("OLLAMA_BASE_URL", _OLLAMA_DEFAULT_BASE)
+            if not _endpoint_is_loopback(ollama_base):
+                _warn_remote_endpoint(ollama_base)
+                return None
             from surreal_memory.engine.embedding.ollama_embedding import OllamaEmbedding
 
-            return OllamaEmbedding(model=model_name)
-        if provider_name in ("openai", "openrouter") and is_local:
+            return OllamaEmbedding(model=model_name, base_url=ollama_base)
+        if provider_name in ("openai", "openrouter") and _endpoint_is_loopback(endpoint):
             from surreal_memory.engine.embedding.openai_embedding import OpenAIEmbedding
 
-            return OpenAIEmbedding(model=model_name)
+            return OpenAIEmbedding(model=model_name, base_url=endpoint)
     except Exception:
         logger.debug("reasoning distiller: embedding provider construction failed", exc_info=True)
     return None
@@ -523,7 +622,7 @@ async def _process_model_batch(
         sub_moves = [moves_list[i] for i in idxs]
         sub_traces = [traces[i] for i in idxs]
         capped_mid_category = False
-        for local_cluster in _cluster(sub_vectors, sub_moves):
+        for local_cluster in _cluster(sub_vectors, sub_moves, rt.cluster_cosine):
             if len(local_cluster) < rt.min_cluster_support:
                 continue
             if created >= budget:
@@ -575,7 +674,7 @@ async def distill_reasoning_patterns(
     advances.
     """
     rt = config.reasoning_training
-    embedder = embedder or _get_embedder()
+    embedder = embedder or _get_embedder(config)
     seeds = await _seed_centroids(embedder, rt.categories) if embedder is not None else None
     # None unless distill_use_llm is on AND a local endpoint and model are set.
     # acquire() explicitly loads the chat model when distill_llm_load_cmd is

--- a/src/surreal_memory/engine/reasoning_naming.py
+++ b/src/surreal_memory/engine/reasoning_naming.py
@@ -57,6 +57,7 @@ import json
 import logging
 import os
 import re
+from ipaddress import ip_address
 from typing import TYPE_CHECKING, Any, Protocol
 from urllib.parse import urlsplit
 
@@ -159,10 +160,22 @@ class RunCommand(Protocol):
 
 
 def _is_loopback(host: str | None) -> bool:
+    """True only when *host* really is a loopback address or ``localhost``.
+
+    The prefix test this replaced (``host.startswith("127.")``) accepted
+    ``127.0.0.1.attacker.example`` — a hostname anyone can register and point
+    anywhere. That matters here because this check is what keeps reasoning
+    traces and prompts on the machine: passing it is what allows a remote
+    endpoint to receive them. Parsing the address decides it, and a name that
+    is not a literal IP is loopback only if it is exactly ``localhost``.
+    """
     if not host:
         return False
     host = host.strip().strip("[]").lower()
-    return host in _LOOPBACK_NAMES or host.startswith("127.")
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return host in _LOOPBACK_NAMES
 
 
 def resolve_llm_endpoint(configured: str = "") -> str | None:

--- a/src/surreal_memory/hooks/stop.py
+++ b/src/surreal_memory/hooks/stop.py
@@ -252,8 +252,19 @@ async def _embedding_dedup(
         from surreal_memory.engine.embedding.provider import EmbeddingProvider
 
         embed_provider: EmbeddingProvider
-        endpoint = os.environ.get("SURREAL_MEMORY_EMBEDDING_ENDPOINT", "")
-        is_local_endpoint = any(h in endpoint for h in ("127.0.0.1", "localhost", "::1"))
+        # Same resolution the distiller uses: the configured endpoint wins, the
+        # env var is the fallback, and the host is parsed rather than
+        # substring-matched — "127.0.0.1.attacker.example" contains the loopback
+        # literal but is not loopback.
+        from surreal_memory.engine.reasoning_distiller import _endpoint_is_loopback
+
+        try:
+            from surreal_memory.unified_config import get_config
+
+            endpoint = get_config().embedding.resolved_endpoint()
+        except Exception:
+            endpoint = os.environ.get("SURREAL_MEMORY_EMBEDDING_ENDPOINT", "")
+        is_local_endpoint = _endpoint_is_loopback(endpoint)
         if provider_name == "ollama":
             from surreal_memory.engine.embedding.ollama_embedding import OllamaEmbedding
 

--- a/src/surreal_memory/server/routes/dashboard_api.py
+++ b/src/surreal_memory/server/routes/dashboard_api.py
@@ -1212,6 +1212,10 @@ async def test_embedding_connection() -> dict[str, Any]:
             from surreal_memory.engine.embedding.ollama_embedding import OllamaEmbedding
 
             provider = OllamaEmbedding(model=model_name)
+        elif provider_name in ("bge_m3", "bge-m3"):
+            from surreal_memory.engine.embedding.bge_m3_embedding import BGEM3Embedding
+
+            provider = BGEM3Embedding(model=model_name)
         else:
             return {"status": "error", "error": f"Unknown embedding provider: {provider_name!r}"}
 

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -124,6 +124,12 @@ class EmbeddingSettings:
     # (e.g. a local OpenAI-compatible server serving bge-m3 → 1024); it drives
     # the SurrealDB HNSW index dimension so the index always matches the vectors.
     dimension: int = 0
+    # Base URL of an OpenAI-compatible embedding server (e.g. llamastash serving
+    # bge-m3 at "http://127.0.0.1:11435/v1"). Mirrors RerankerConfig.endpoint so the
+    # two halves of a local embed+rerank pair are configured the same way; before
+    # this existed the endpoint could only be given as an env var, which no
+    # config-driven consumer could see. Config wins, env is the fallback.
+    endpoint: str = ""
 
     _VALID_PROVIDERS: ClassVar[tuple[str, ...]] = (
         "sentence_transformer",
@@ -155,6 +161,7 @@ class EmbeddingSettings:
             "model": self.model,
             "similarity_threshold": self.similarity_threshold,
             "dimension": self.dimension,
+            "endpoint": self.endpoint,
         }
 
     @classmethod
@@ -165,6 +172,20 @@ class EmbeddingSettings:
             model=str(data.get("model", "all-MiniLM-L6-v2")),
             similarity_threshold=float(data.get("similarity_threshold", 0.7)),
             dimension=int(data.get("dimension", 0) or 0),
+            endpoint=str(data.get("endpoint", "") or "").strip(),
+        )
+
+    def resolved_endpoint(self) -> str:
+        """Endpoint in effect: the configured value, else the env override.
+
+        Same precedence as the reranker (config first, env fallback), so a
+        machine-wide export cannot silently override an explicit per-brain
+        setting while still working for setups that only export the env var.
+        """
+        import os
+
+        return (
+            self.endpoint.strip() or os.environ.get("SURREAL_MEMORY_EMBEDDING_ENDPOINT", "").strip()
         )
 
 
@@ -193,6 +214,13 @@ def _load_embedding_settings(data: dict[str, Any]) -> EmbeddingSettings:
         SURREAL_MEMORY_EMBEDDING_DIMENSION            -> dimension
 
     Only env vars that are actually set (non-empty) override the file values.
+
+    ``endpoint`` is deliberately NOT in that list. It follows the reranker's
+    precedence instead — config first, env as the fallback — resolved at read
+    time by :meth:`EmbeddingSettings.resolved_endpoint`. Overriding it here too
+    would make the config value unreachable whenever the env var is exported
+    machine-wide, which is exactly the case an explicit per-brain endpoint
+    exists to serve.
     """
     base = EmbeddingSettings.from_dict(data)
 
@@ -239,6 +267,7 @@ def _load_embedding_settings(data: dict[str, Any]) -> EmbeddingSettings:
         model=model,
         similarity_threshold=similarity_threshold,
         dimension=dimension,
+        endpoint=base.endpoint,
     )
 
 
@@ -1172,6 +1201,13 @@ class ReasoningTrainingConfig:
     retention_days: int = 90
     max_traces_total: int = 20_000
     min_cluster_support: int = 3
+    # Cosine above which two traces are treated as the same pattern. Embedding
+    # models do not share a similarity scale, so this travels with the
+    # configured embedder: under bge-m3 the median pairwise cosine of real
+    # traces sits near 0.46 and the 99th percentile near 0.62, so a threshold
+    # in the high 0.8s clusters almost nothing and the move-set fallback
+    # silently outperforms the embedding path it is supposed to back up.
+    cluster_cosine: float = 0.75
     min_confidence: float = 0.2
     min_patterns_per_category: int = 3
     injection_max_patterns: int = 5
@@ -1215,6 +1251,7 @@ class ReasoningTrainingConfig:
             "retention_days": self.retention_days,
             "max_traces_total": self.max_traces_total,
             "min_cluster_support": self.min_cluster_support,
+            "cluster_cosine": self.cluster_cosine,
             "min_confidence": self.min_confidence,
             "min_patterns_per_category": self.min_patterns_per_category,
             "injection_max_patterns": self.injection_max_patterns,
@@ -1266,6 +1303,21 @@ class ReasoningTrainingConfig:
             min_confidence = max(0.0, min(float(data.get("min_confidence", 0.2)), 1.0))
         except (ValueError, TypeError):
             min_confidence = 0.2
+
+        # Floor at 0.05: single-linkage clustering collapses into one giant
+        # component once the threshold drops near the corpus baseline, which
+        # yields FEWER patterns, not more, so a near-zero value is never what
+        # an operator meant.
+        try:
+            raw_cosine = float(data.get("cluster_cosine", 0.75))
+            # NaN must not reach the clamp: min()/max() propagate it into the
+            # FLOOR, which would merge every trace into one cluster instead of
+            # falling back to a sane threshold.
+            if raw_cosine != raw_cosine:
+                raise ValueError("cluster_cosine is NaN")
+            cluster_cosine = max(0.05, min(raw_cosine, 1.0))
+        except (ValueError, TypeError):
+            cluster_cosine = 0.75
 
         # Per-model pattern targets: {model: 0..100}. Keys must be model-name
         # shaped (bad keys skipped, not fatal — this loads from disk); values
@@ -1333,6 +1385,7 @@ class ReasoningTrainingConfig:
             retention_days=_int("retention_days", 90, 1, 100_000),
             max_traces_total=_int("max_traces_total", 20_000, 1, 100_000_000),
             min_cluster_support=_int("min_cluster_support", 3, 1, 100_000),
+            cluster_cosine=cluster_cosine,
             min_confidence=min_confidence,
             min_patterns_per_category=_int("min_patterns_per_category", 3, 1, 100_000),
             injection_max_patterns=_int("injection_max_patterns", 5, 1, 1000),
@@ -1918,6 +1971,7 @@ class UnifiedConfig:
             f"retention_days = {rt.retention_days}",
             f"max_traces_total = {rt.max_traces_total}",
             f"min_cluster_support = {rt.min_cluster_support}",
+            f"cluster_cosine = {rt.cluster_cosine}",
             f"min_confidence = {rt.min_confidence}",
             f"min_patterns_per_category = {rt.min_patterns_per_category}",
             f"injection_max_patterns = {rt.injection_max_patterns}",
@@ -1984,6 +2038,7 @@ class UnifiedConfig:
             f'model = "{self.embedding.model}"',
             f"similarity_threshold = {self.embedding.similarity_threshold}",
             f"dimension = {self.embedding.dimension}",
+            f'endpoint = "{_sanitize_toml_url(self.embedding.endpoint)}"',
             "",
             "# Auto-capture settings for MCP server",
             "[auto]",

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "2.19.0"
+        assert surreal_memory.__version__ == "2.20.0"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_reasoning_distiller.py
+++ b/tests/unit/test_reasoning_distiller.py
@@ -16,6 +16,7 @@ import pytest
 from surreal_memory.engine.reasoning_distiller import (
     DistillResult,
     _classify_by_keywords,
+    _cluster,
     distill_reasoning_patterns,
     reasoning_coverage,
     segment_moves,
@@ -29,7 +30,9 @@ BRAIN = "b1"
 @pytest.fixture
 def no_embedder(monkeypatch: pytest.MonkeyPatch) -> None:
     """Force the fail-soft (no embedding provider) path — keyword + Jaccard."""
-    monkeypatch.setattr("surreal_memory.engine.reasoning_distiller._get_embedder", lambda: None)
+    monkeypatch.setattr(
+        "surreal_memory.engine.reasoning_distiller._get_embedder", lambda *_a, **_k: None
+    )
 
 
 def _ucfg(tmp_path: Path, **rt_kw: object) -> UnifiedConfig:
@@ -615,3 +618,257 @@ async def test_reset_cannot_recover_traces_the_retention_prune_removed(
 
     assert await storage.get_reasoning_trace_models(BRAIN) == []
     assert await storage.reset_reasoning_traces_processed(BRAIN) == 0
+
+
+# ── embedder selection: config wins over the environment probe ────────────────
+
+
+class TestEndpointIsLoopback:
+    """The check that decides whether reasoning text may leave this machine.
+
+    A prefix or substring test passes hostnames an attacker can register, so
+    these cases are the point of the helper, not decoration.
+    """
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "http://127.0.0.1:11435/v1",
+            "http://localhost:11435/v1",
+            "http://[::1]:11435/v1",
+            "http://127.1.2.3:8080/v1",
+        ],
+    )
+    def test_accepts_real_loopback(self, endpoint: str) -> None:
+        from surreal_memory.engine.reasoning_distiller import _endpoint_is_loopback
+
+        assert _endpoint_is_loopback(endpoint) is True
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://127.0.0.1.attacker.example/v1",  # starts with "127."
+            "https://localhost.evil.example/v1",  # starts with "localhost"
+            "https://not-127.0.0.1.example/v1",  # contains the literal
+            "https://api.openai.com/v1",
+            "",
+            "   ",
+        ],
+    )
+    def test_refuses_everything_else(self, endpoint: str) -> None:
+        from surreal_memory.engine.reasoning_distiller import _endpoint_is_loopback
+
+        assert _endpoint_is_loopback(endpoint) is False
+
+
+class TestGetEmbedderUsesConfig:
+    """Selection logic had no coverage at all, which is why the defect survived.
+
+    The `no_embedder` fixture blanks `_get_embedder` for most of this module, so
+    nothing ever exercised the real function.
+    """
+
+    @staticmethod
+    def _cfg(tmp_path: Path, **kw: object) -> UnifiedConfig:
+        from surreal_memory.unified_config import EmbeddingSettings
+
+        base: dict[str, object] = {
+            "enabled": True,
+            "provider": "openai",
+            "model": "bge-m3-FP16",
+            "dimension": 1024,
+            "endpoint": "http://127.0.0.1:11435/v1",
+        }
+        base.update(kw)
+        return UnifiedConfig(
+            data_dir=tmp_path / ".surrealmemory",
+            current_brain="default",
+            embedding=EmbeddingSettings(**base),  # type: ignore[arg-type]
+        )
+
+    def test_configured_loopback_provider_is_built(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # An unrelated GEMINI_API_KEY used to win the environment probe and
+        # shadow this configuration entirely.
+        monkeypatch.setenv("GEMINI_API_KEY", "irrelevant-but-present")
+        # The provider factory must NOT be consulted: it re-resolves the base
+        # URL on its own, which is how a validated loopback endpoint ended up
+        # pointing at a remote host.
+        monkeypatch.setattr(
+            "surreal_memory.engine.semantic_discovery._create_provider",
+            lambda *_a, **_k: pytest.fail("provider factory must not be used"),
+        )
+        from surreal_memory.engine.reasoning_distiller import _get_embedder
+
+        embedder = _get_embedder(self._cfg(tmp_path))
+
+        assert embedder is not None
+        assert "127.0.0.1" in (getattr(embedder, "_base_url", "") or "")
+
+    def test_remote_endpoint_is_refused_not_silently_degraded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", raising=False)
+        from surreal_memory.engine.reasoning_distiller import _get_embedder
+
+        cfg = self._cfg(tmp_path, endpoint="https://api.openai.com/v1")
+        assert _get_embedder(cfg) is None
+
+    def test_hostname_that_merely_looks_local_is_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", raising=False)
+        from surreal_memory.engine.reasoning_distiller import _get_embedder
+
+        cfg = self._cfg(tmp_path, endpoint="https://127.0.0.1.attacker.example/v1")
+        assert _get_embedder(cfg) is None
+
+    def test_disabled_embedding_falls_back_to_the_probe(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Fail-soft contract: embeddings off must not start reading config.
+        monkeypatch.setattr(
+            "surreal_memory.engine.semantic_discovery._auto_detect_provider",
+            lambda: (_ for _ in ()).throw(RuntimeError("no provider")),
+        )
+        from surreal_memory.engine.reasoning_distiller import _get_embedder
+
+        assert _get_embedder(self._cfg(tmp_path, enabled=False)) is None
+
+    def test_no_config_keeps_the_old_behaviour(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "surreal_memory.engine.semantic_discovery._auto_detect_provider",
+            lambda: (_ for _ in ()).throw(RuntimeError("no provider")),
+        )
+        from surreal_memory.engine.reasoning_distiller import _get_embedder
+
+        assert _get_embedder() is None
+
+
+class TestClusterCosineIsConfigurable:
+    """The clustering threshold belongs to the embedder, not to the module.
+
+    A constant tuned for one embedding model clusters nothing under another:
+    the value that shipped sat above the 99th percentile of real bge-m3 trace
+    similarity, so the embedding path produced strictly fewer patterns than the
+    move-set fallback it is meant to supersede.
+    """
+
+    @staticmethod
+    def _pair(cosine_like: float) -> list[list[float]]:
+        """Two unit vectors whose cosine is exactly ``cosine_like``."""
+        import math
+
+        angle = math.acos(cosine_like)
+        return [[1.0, 0.0], [math.cos(angle), math.sin(angle)]]
+
+    def test_pair_clusters_below_threshold_and_splits_above_it(self) -> None:
+        vectors = self._pair(0.80)
+        moves = [[], []]
+
+        lenient = _cluster(vectors, moves, 0.75)
+        strict = _cluster(vectors, moves, 0.83)
+
+        assert [len(c) for c in lenient] == [2], "0.80 similarity must cluster at 0.75"
+        assert sorted(len(c) for c in strict) == [1, 1], "0.80 must not cluster at 0.83"
+
+    def test_default_threshold_is_taken_from_config_not_the_module(self) -> None:
+        rt = ReasoningTrainingConfig()
+
+        assert rt.cluster_cosine == 0.75
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (0.9, 0.9),
+            (5.0, 1.0),  # clamped
+            (0.0, 0.05),  # floored: single-linkage collapses into one blob
+            ("not-a-number", 0.75),  # falls back rather than raising
+            (float("nan"), 0.75),  # NaN must not propagate into the floor
+            (float("inf"), 1.0),
+            (None, 0.75),
+        ],
+    )
+    def test_loader_clamps_and_survives_junk(self, raw: object, expected: float) -> None:
+        rt = ReasoningTrainingConfig.from_dict({"cluster_cosine": raw})
+
+        assert rt.cluster_cosine == expected
+
+    def test_survives_a_config_round_trip(self) -> None:
+        original = ReasoningTrainingConfig(cluster_cosine=0.62)
+
+        restored = ReasoningTrainingConfig.from_dict(original.to_dict())
+
+        assert restored.cluster_cosine == 0.62
+
+
+class TestValidatedEndpointIsTheUsedEndpoint:
+    """The endpoint that clears the loopback gate must be the one connected to.
+
+    Checking one value and connecting to another makes the gate decorative:
+    reasoning traces are private user data, and "the check passed" has to imply
+    "the data stayed on this machine".
+    """
+
+    @staticmethod
+    def _config(tmp_path: Path, provider: str, endpoint: str) -> UnifiedConfig:
+        from surreal_memory.unified_config import EmbeddingSettings
+
+        return UnifiedConfig(
+            data_dir=tmp_path / ".surrealmemory",
+            current_brain="default",
+            embedding=EmbeddingSettings(
+                enabled=True,
+                provider=provider,
+                model="bge-m3-FP16",
+                dimension=1024,
+                endpoint=endpoint,
+            ),
+        )
+
+    def test_openrouter_cannot_reach_its_hardcoded_remote_default(self, tmp_path: Path) -> None:
+        from surreal_memory.engine.reasoning_distiller import _get_embedder
+
+        embedder = _get_embedder(self._config(tmp_path, "openrouter", "http://127.0.0.1:11435/v1"))
+
+        assert embedder is not None
+        base = getattr(embedder, "_base_url", None)
+        assert base is not None and "openrouter.ai" not in base
+        assert "127.0.0.1" in base
+
+    def test_config_only_loopback_endpoint_reaches_the_client(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A loopback endpoint set ONLY in config.toml must be used, not just checked."""
+        from surreal_memory.engine.reasoning_distiller import _get_embedder
+
+        monkeypatch.delenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", raising=False)
+
+        embedder = _get_embedder(self._config(tmp_path, "openai", "http://127.0.0.1:11435/v1"))
+
+        assert embedder is not None
+        assert "127.0.0.1" in (getattr(embedder, "_base_url", "") or "")
+
+    def test_ollama_is_refused_when_its_own_base_url_is_remote(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from surreal_memory.engine.reasoning_distiller import _get_embedder
+
+        # Isolate the OLLAMA_BASE_URL path: with no embedding endpoint set,
+        # ollama's own base URL is what the client will open.
+        monkeypatch.delenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", raising=False)
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://attacker.example:11434")
+
+        assert _get_embedder(self._config(tmp_path, "ollama", "")) is None
+
+    def test_ollama_is_allowed_on_a_loopback_base_url(self, tmp_path: Path, monkeypatch) -> None:
+        from surreal_memory.engine.reasoning_distiller import _get_embedder
+
+        monkeypatch.delenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", raising=False)
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
+
+        embedder = _get_embedder(self._config(tmp_path, "ollama", ""))
+
+        assert embedder is not None
+        assert "127.0.0.1" in (getattr(embedder, "_base_url", "") or "")

--- a/tests/unit/test_reasoning_distiller.py
+++ b/tests/unit/test_reasoning_distiller.py
@@ -701,10 +701,16 @@ class TestGetEmbedderUsesConfig:
         )
         from surreal_memory.engine.reasoning_distiller import _get_embedder
 
-        embedder = _get_embedder(self._cfg(tmp_path))
+        # The real client is an optional extra; record the construction instead
+        # of requiring it, so this runs everywhere.
+        seen: dict[str, object] = {}
+        monkeypatch.setattr(
+            "surreal_memory.engine.embedding.openai_embedding.OpenAIEmbedding",
+            lambda model="", base_url=None: seen.update(base_url=base_url) or object(),
+        )
 
-        assert embedder is not None
-        assert "127.0.0.1" in (getattr(embedder, "_base_url", "") or "")
+        assert _get_embedder(self._cfg(tmp_path)) is not None
+        assert seen["base_url"] == "http://127.0.0.1:11435/v1"
 
     def test_remote_endpoint_is_refused_not_silently_degraded(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -812,6 +818,28 @@ class TestValidatedEndpointIsTheUsedEndpoint:
     """
 
     @staticmethod
+    def _record_openai(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+        """Capture the kwargs the embedder is constructed with.
+
+        The real client is an OPTIONAL extra, so building it would make these
+        tests pass only where it happens to be installed — and these guard a
+        security property, so they must run everywhere. The contract under test
+        is this module's, not the SDK's: which base_url does it hand over.
+        """
+        seen: dict[str, object] = {}
+
+        class _Recorder:
+            def __init__(self, model: str = "", base_url: str | None = None) -> None:
+                seen["model"] = model
+                seen["base_url"] = base_url
+                self._base_url = base_url
+
+        monkeypatch.setattr(
+            "surreal_memory.engine.embedding.openai_embedding.OpenAIEmbedding", _Recorder
+        )
+        return seen
+
+    @staticmethod
     def _config(tmp_path: Path, provider: str, endpoint: str) -> UnifiedConfig:
         from surreal_memory.unified_config import EmbeddingSettings
 
@@ -827,15 +855,17 @@ class TestValidatedEndpointIsTheUsedEndpoint:
             ),
         )
 
-    def test_openrouter_cannot_reach_its_hardcoded_remote_default(self, tmp_path: Path) -> None:
+    def test_openrouter_cannot_reach_its_hardcoded_remote_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         from surreal_memory.engine.reasoning_distiller import _get_embedder
 
-        embedder = _get_embedder(self._config(tmp_path, "openrouter", "http://127.0.0.1:11435/v1"))
+        seen = self._record_openai(monkeypatch)
 
-        assert embedder is not None
-        base = getattr(embedder, "_base_url", None)
-        assert base is not None and "openrouter.ai" not in base
-        assert "127.0.0.1" in base
+        assert _get_embedder(self._config(tmp_path, "openrouter", "http://127.0.0.1:11435/v1"))
+
+        assert seen["base_url"] == "http://127.0.0.1:11435/v1"
+        assert "openrouter.ai" not in str(seen["base_url"])
 
     def test_config_only_loopback_endpoint_reaches_the_client(
         self, tmp_path: Path, monkeypatch
@@ -844,11 +874,11 @@ class TestValidatedEndpointIsTheUsedEndpoint:
         from surreal_memory.engine.reasoning_distiller import _get_embedder
 
         monkeypatch.delenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", raising=False)
+        seen = self._record_openai(monkeypatch)
 
-        embedder = _get_embedder(self._config(tmp_path, "openai", "http://127.0.0.1:11435/v1"))
+        assert _get_embedder(self._config(tmp_path, "openai", "http://127.0.0.1:11435/v1"))
 
-        assert embedder is not None
-        assert "127.0.0.1" in (getattr(embedder, "_base_url", "") or "")
+        assert seen["base_url"] == "http://127.0.0.1:11435/v1"
 
     def test_ollama_is_refused_when_its_own_base_url_is_remote(
         self, tmp_path: Path, monkeypatch

--- a/tests/unit/test_unified_config.py
+++ b/tests/unit/test_unified_config.py
@@ -10,6 +10,7 @@ from surreal_memory.cli.config import _sync_brain_to_toml
 from surreal_memory.unified_config import (
     _MIN_LEGACY_DB_BYTES,
     MAX_PATTERN_TARGET,
+    EmbeddingSettings,
     ReasoningTrainingConfig,
     UnifiedConfig,
     _migrate_legacy_db,
@@ -792,3 +793,39 @@ class TestPatternTargetCeiling:
         # with a few thousand staged traces can yield, so it silently capped
         # coverage instead of guarding against misconfiguration.
         assert MAX_PATTERN_TARGET >= 1000
+
+
+class TestEmbeddingEndpoint:
+    """Parity with the reranker: the endpoint is configurable, not env-only.
+
+    Before this field existed the endpoint could only be exported as an env var,
+    so nothing that resolved from config could see it — which is how a correctly
+    configured local server ended up unused.
+    """
+
+    def test_endpoint_round_trips_through_dict(self) -> None:
+        cfg = EmbeddingSettings.from_dict(
+            {"enabled": True, "provider": "openai", "endpoint": "http://127.0.0.1:11435/v1"}
+        )
+        assert cfg.endpoint == "http://127.0.0.1:11435/v1"
+        assert cfg.to_dict()["endpoint"] == "http://127.0.0.1:11435/v1"
+
+    def test_endpoint_defaults_to_empty(self) -> None:
+        assert EmbeddingSettings.from_dict({}).endpoint == ""
+
+    def test_config_wins_over_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Same precedence as the reranker. A machine-wide export must not
+        # silently override an explicit per-brain endpoint.
+        monkeypatch.setenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", "http://127.0.0.1:9999/v1")
+        cfg = EmbeddingSettings(endpoint="http://127.0.0.1:11435/v1")
+        assert cfg.resolved_endpoint() == "http://127.0.0.1:11435/v1"
+
+    def test_env_is_the_fallback_when_config_is_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", "http://127.0.0.1:11435/v1")
+        assert EmbeddingSettings().resolved_endpoint() == "http://127.0.0.1:11435/v1"
+
+    def test_no_endpoint_anywhere_resolves_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SURREAL_MEMORY_EMBEDDING_ENDPOINT", raising=False)
+        assert EmbeddingSettings().resolved_endpoint() == ""

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "2.19.0",
+      "version": "2.20.0",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## What was wrong

`_get_embedder()` probed the environment instead of reading `[embedding]`. An unrelated cloud API key was enough to shadow a correctly configured local provider: the probe answered with something this function cannot build, so it returned `None`, and every reasoning trace was classified by keyword while a working embedder sat idle. Because that path never ran, everything downstream of it had never been exercised either — which is where the rest of this PR comes from.

## Three endpoint defects, found by an independent security review

The loopback gate exists so reasoning traces — private user data — never leave the machine. It was not holding.

**The host test accepted anything starting with `127.`**, so `127.0.0.1.attacker.example` passed. It now parses the host and asks the address itself whether it is loopback.

**For `openrouter` and `openai`, the value that cleared the gate had no causal connection to the URL the client opened.** The gate delegated to the provider factory, which re-resolves `base_url` independently — and `OpenRouterEmbedding` carries a hardcoded remote default, while `OpenAIEmbedding` reads only the environment variable. A loopback endpoint set in `config.toml`, exactly what the new `[embedding] endpoint` field is for, passed the check while requests went to a hosted API. No attacker required.

**`ollama` skipped the check entirely** through `or` short-circuiting, and its base URL comes from `OLLAMA_BASE_URL`, which nothing validated.

`base_url` is now passed explicitly, in both the configured and auto-detect paths, so "the check passed" means the request went there. The ollama gate tests the URL that provider actually opens.

## Pattern clustering was calibrated for nothing

The cosine threshold was a module constant that, because of the defect above, had never executed against a real embedding model. Embedding models do not share a similarity scale, and measured against a real corpus this one sat **above the 99th percentile** of pairwise trace similarity in *every* category — the two largest categories produced no clusters at all, and the embedding path yielded roughly a fifth of what its own move-set fallback produced over the same traces. Mining reported patterns learned while categories stayed empty, which reads as "not enough material" rather than as a threshold defect.

It is now `reasoning_training.cluster_cosine` (default `0.75`), chosen as the strictest value at which the embedding path does not regress against the fallback it supersedes — calibration against a reference, not a number tuned until a metric looked good. A non-finite value falls back instead of clamping into the floor, where `NaN` would have merged every trace into one cluster.

## Documentation

Tier 1, provably wrong and user-visible: memory-type expiry tables (five wrong values in each of two files), a documented `--strategy` with no enum member, five MCP tools plus `BrainExporter`/`BrainImporter` and two legacy endpoints that do not exist, and maturation advice pointing at a command that cannot move a memory.

Tier 2, every count re-derived from source at write time: MCP tool count (three different figures, none right, plus an arithmetic line that did not add up), test counts across eight files, enum counts, the env table labelled AUTO-GENERATED that no script generates, a default-backend story that contradicted itself inside two separate files, and coverage thresholds differing across seven files. `ROADMAP.md` claimed a version several minors old and paired the SQLite schema number with a sentence about the SurrealDB backend while calling SQLite a test-only fixture — it is the configured default.

`sync_refs.py` gains the forms it used to walk past, plus historical-line markers so dated posts are not "corrected" into falsehoods.

## Test plan

- [x] `ruff check` / `ruff format --check` clean on `src/ tests/`
- [x] `pytest` — 7,157 passed, 33 skipped, 1 xfailed
- [x] `scripts/sync_refs.py` — PASS, and still fails on a deliberately stale probe file
- [x] New tests: threshold is configurable and changes clustering outcomes; clamp/junk/`NaN`/`inf` cases; four regression tests asserting the validated endpoint is the one connected to
- [x] Exercised against a live SurrealDB brain and a local bge-m3 server

## Notes for reviewers

Two of the fixes here exist because the implementer did not review their own work: the endpoint-binding defect was introduced in this branch and survived two rounds of self-verification before an independent security review found it. The `sync_refs.py` handler-branch gap is the same shape — it reported PASS while doing nothing, and only a deliberately stale probe file exposed it.

`.claude-plugin/*.json` and `integrations/surrealmemory/openclaw.plugin.json` are checked by `pre_ship` but are not on the version-parity checklist in the contributor docs, which is how two previous releases left them behind.
