### PR TITLE
fix(reasoning): stale opus alias resolves to a prior model generation

### DIFF
--- a/src/surreal_memory/engine/reasoning_injection.py
+++ b/src/surreal_memory/engine/reasoning_injection.py
@@ -49,8 +49,8 @@ _PATTERN_FETCH_LIMIT = 20_000
 # pipeline. Full ids pass through ``normalize_model`` unchanged.
 _MODEL_ALIASES: dict[str, str] = {
     "sonnet": "claude-sonnet-5",
-    "opus": "claude-opus-4-8",
-    "opusplan": "claude-opus-4-8",
+    "opus": "claude-opus-5",
+    "opusplan": "claude-opus-5",
     "haiku": "claude-haiku-4-5",
     "fable": "claude-fable-5",
 }

--- a/tests/unit/test_reasoning_injection.py
+++ b/tests/unit/test_reasoning_injection.py
@@ -149,7 +149,20 @@ def test_resolve_from_settings_alias(clean_env: Path) -> None:
     claude_dir = clean_env / ".claude"
     claude_dir.mkdir(parents=True, exist_ok=True)
     (claude_dir / "settings.json").write_text(json.dumps({"model": "opusplan"}), encoding="utf-8")
-    assert resolve_active_model({}) == "claude-opus-4-8"
+    assert resolve_active_model({}) == "claude-opus-5"
+
+
+def test_model_aliases_track_the_current_lineup() -> None:
+    """Regression: the alias table shipped a stale 4.8-era id for months.
+
+    Injection is keyed on the model string in ``injection_map``, so a stale
+    alias here silently routes a user's short "opus" setting to the wrong
+    source model's patterns.
+    """
+    from surreal_memory.engine.reasoning_injection import _MODEL_ALIASES
+
+    assert _MODEL_ALIASES["opus"] == "claude-opus-5"
+    assert _MODEL_ALIASES["opusplan"] == "claude-opus-5"
 
 
 def test_resolve_default_when_nothing_available(clean_env: Path) -> None:


### PR DESCRIPTION
## What was wrong

`_MODEL_ALIASES` mapped the short aliases `"opus"` and `"opusplan"` to `claude-opus-4-8` — a prior model generation. This table is the last-resort step in `resolve_active_model`'s fallback chain: it only fires when a hook payload carries no `model` field and the transcript tail has no assistant turn yet to read one from, falling back to `~/.claude/settings.json`'s `model` field.

When it does fire, the resolved id feeds directly into `reasoning_training.injection_map` lookups. A stale id there means pattern-injection silently looks up a source model that no longer exists, for anyone whose `settings.json` sets a short alias rather than a full model id.

## Fix

Both aliases now resolve to `claude-opus-5`, matching the current lineup. Added a regression test (`test_model_aliases_track_the_current_lineup`) asserting the table's values directly, so this can't drift silently again.

## Test plan

- [x] `pytest tests/unit tests/integration -m "not stress"` — 7,158 passed
- [x] `ruff check` / `ruff format --check` clean on both touched files
- [x] `scripts/sync_refs.py` — PASS
- [x] Existing `test_resolve_from_settings_alias` updated to assert the corrected id; new regression test added
