### PR TITLE
fix(ci): auto-publish's GITHUB_TOKEN publish never triggered release.yml

### DIFF
--- a/.github/workflows/auto-publish-release.yml
+++ b/.github/workflows/auto-publish-release.yml
@@ -19,6 +19,7 @@ on:
 
 permissions:
   contents: write
+  actions: write  # to dispatch release.yml below
 
 jobs:
   publish-draft:
@@ -50,6 +51,7 @@ jobs:
           fi
 
       - name: Publish the matching draft release, if one exists
+        id: publish
         if: steps.version.outputs.bumped != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,8 +62,29 @@ jobs:
           if [ "$IS_DRAFT" = "true" ]; then
             echo "Publishing draft release $TAG"
             gh release edit "$TAG" --draft=false
+            echo "published=true" >> "$GITHUB_OUTPUT"
           elif [ -z "$IS_DRAFT" ]; then
             echo "No release named $TAG exists yet — nothing to publish"
+            echo "published=false" >> "$GITHUB_OUTPUT"
           else
             echo "$TAG is already published — nothing to do"
+            echo "published=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Dispatch release.yml explicitly
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ steps.version.outputs.bumped }}
+        run: |
+          set -euo pipefail
+          # Publishing the draft above pushes the real tag, but it does so via
+          # this job's own GITHUB_TOKEN — and GitHub does not let a
+          # GITHUB_TOKEN-authored event trigger ANOTHER workflow run, precisely
+          # to prevent infinite trigger chains. So `release.yml`'s
+          # `on: push: tags:` never fires from that publish, even though the
+          # tag is real. An explicit `workflow_dispatch` call is NOT subject to
+          # that same restriction, so dispatch release.yml directly against the
+          # tag ref: actions/checkout there has no ref: override, so GITHUB_REF
+          # resolves to this tag exactly as if it had been pushed normally.
+          gh workflow run release.yml --ref "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - "v*"
+  # Lets this be dispatched explicitly against a tag ref (actions/checkout with
+  # no ref: override resolves GITHUB_REF to whatever ref triggered the run, so
+  # `gh workflow run release.yml --ref vX.Y.Z` reproduces a real tag push with
+  # no changes needed below). Exists because a GITHUB_TOKEN-driven tag creation
+  # (e.g. publishing a draft release from another Action) does NOT fire
+  # `push: tags:` — GitHub's own anti-recursion rule for the default token —
+  # so auto-publish-release.yml dispatches this explicitly as a fallback.
+  workflow_dispatch: {}
 
 jobs:
   # ── Gate: validate version consistency ──────────────────────────


### PR DESCRIPTION
## What was wrong

Discovered live on v2.20.1: `auto-publish-release.yml` successfully published the draft release (tag created, page shows non-draft), but `release.yml` — the workflow that actually builds and pushes to PyPI/npm — never ran. Confirmed: PyPI's latest is still 2.20.0.

Root cause: publishing the draft (`gh release edit --draft=false`) ran under the job's own `GITHUB_TOKEN`. GitHub does not let a `GITHUB_TOKEN`-authored event trigger another workflow run — its own anti-recursion safeguard. So the tag became real, but `release.yml`'s `on: push: tags: v*` never fired.

## Fix

`release.yml` gains a `workflow_dispatch` trigger. `auto-publish-release.yml` explicitly dispatches it (`gh workflow run release.yml --ref "$TAG"`) right after a successful publish — an explicit `workflow_dispatch` call is not subject to the same restriction. Gated on `steps.publish.outputs.published == 'true'`, so it only fires when this run actually just flipped a draft to published, not against an already-published or nonexistent release/tag.

## Test plan

- [x] Both workflow files parse as valid YAML
- [x] No untrusted `github.event.*` field is interpolated directly into a `run:` shell string (same pattern as the original PR)
- [ ] Will be exercised for real by manually dispatching `release.yml --ref v2.20.1` once this merges, to complete the stuck v2.20.1 publish