### PR TITLE
fix: make migrating off the SQLite backend lossless, and deprecate it

### DIFF
--- a/docs/guides/migrating-to-3.0.md
+++ b/docs/guides/migrating-to-3.0.md
@@ -1,0 +1,134 @@
+# Migrating off the SQLite backend
+
+The SQLite storage backend is deprecated as of 2.21.0 and **removed in 3.0.0**.
+SurrealDB has been the production backend since 2.0.0; SQLite remained the
+default only because it needed no server.
+
+This guide moves an existing SQLite brain to SurrealDB. It takes a few minutes
+and never touches your `.db` files, so you can go back at any time.
+
+## Am I affected?
+
+```bash
+smem doctor
+```
+
+The **Storage backend** check reports which backend resolves. If it says
+`sqlite — deprecated, removed in 3.0.0`, this guide is for you. If it says
+`surrealdb`, you are already migrated and 3.0.0 changes nothing for you.
+
+Anything that sets `SURREAL_MEMORY_STORAGE=surrealdb` — the Docker compose
+files, `smem setup`, and the MCP configs written by `smem mcp-config` — is
+already on the new backend.
+
+## Migrate
+
+### 1. Back up the current brain
+
+```bash
+smem export backup.json
+```
+
+Repeat per brain if you have several (`smem brain list` shows them):
+
+```bash
+smem export work.json --brain work
+```
+
+Keep these files until step 4 confirms the data arrived.
+
+### 2. Start SurrealDB
+
+```bash
+docker compose -f docker-compose.surrealdb.yml up -d
+```
+
+### 3. Point surreal-memory at it
+
+Set these in your environment (or `.env`):
+
+```bash
+SURREAL_MEMORY_STORAGE=surrealdb
+SURREALDB_URL=http://localhost:8000
+SURREALDB_PASS=<your password>
+```
+
+Equivalent in `~/.surrealmemory/config.toml`:
+
+```toml
+storage_backend = "surrealdb"
+```
+
+Restart anything long-running — the MCP server, `smem serve`, your editor
+extension. A running process keeps the backend it started with.
+
+### 4. Import and verify
+
+```bash
+smem import backup.json
+smem stats
+smem recall "something you know is in there"
+```
+
+Compare `smem stats` against what the SQLite brain reported before the switch.
+
+## What a snapshot carries
+
+| Carried | Not carried |
+|---|---|
+| Neurons, synapses, fibers | Retrieval calibration (gate EMA, retriever weights, graph density) |
+| Typed memories — type, priority, tags, trust score, expiry, tier, validity window, supersession | Drift clusters and tag co-occurrence counts |
+| Projects | Sync cursors and device registrations |
+| Brain configuration | Document-training progress (re-running `smem train` re-scans) |
+| | Change-log history |
+
+Everything in the right column is derived state: consolidation, recall and the
+next training run rebuild it. Nothing you explicitly remembered is in it.
+
+!!! note "Typed memories and projects need 2.21.0 or newer"
+
+    Older versions did not put typed memories or projects into a SurrealDB
+    snapshot, so a snapshot **exported** by 2.20.x or earlier from a SurrealDB
+    brain carries only the graph. Export with 2.21.0+ on both ends.
+
+## Trying it without a database
+
+If you only want to evaluate surreal-memory, skip SurrealDB entirely:
+
+```bash
+SURREAL_MEMORY_STORAGE=memory smem remember "test note"
+```
+
+Nothing is written to disk and everything is discarded when the process exits.
+This is for experiments, not for keeping memories.
+
+## Going back
+
+3.0.0 never reads, writes or deletes `~/.surrealmemory/brains/*.db`. If you need
+the old backend, install the 2.x line again and it picks up right where it left
+off:
+
+```bash
+pipx install 'surreal-memory==2.*' --force
+```
+
+Anything you wrote to SurrealDB in the meantime stays there — export it first if
+you want to bring it back with you.
+
+## Troubleshooting
+
+**`smem` reports the backend was removed.** You are on 3.0.0 with
+`storage_backend = "sqlite"` still configured. Set
+`SURREAL_MEMORY_STORAGE=surrealdb` (or `memory`), or downgrade to 2.x to reach
+your existing `.db` file.
+
+**Connection refused.** SurrealDB is not running or is on a different port —
+check `docker compose -f docker-compose.surrealdb.yml ps` and that
+`SURREALDB_URL` matches.
+
+**Authentication failed.** `SURREALDB_PASS` does not match the password the
+container was started with. `smem doctor --fix` writes a consistent set.
+
+**The dashboard and the CLI disagree.** One of them is still on the old backend.
+This is the failure the deprecation warning calls out: check `smem doctor` in
+the same environment as each process.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
     - Agent Memory Governance: guides/agent-memory-governance.md
     - OpenClaw Plugin: guides/openclaw-plugin.md
     - Cognitive Reasoning: guides/cognitive-reasoning.md
+    - Migrating to 3.0: guides/migrating-to-3.0.md
     - Schema v21 Migration: guides/schema-v21-migration.md
     - Memory Layer Unification: guides/memory-layer-unification.md
     - Learning Habits: guides/learning-habits.md

--- a/src/surreal_memory/cli/doctor.py
+++ b/src/surreal_memory/cli/doctor.py
@@ -36,6 +36,7 @@ TIER_DEV = "dev"  # contributor/source checkout diagnostics
 _CHECK_TIERS: dict[str, str] = {
     "Python version": TIER_CORE,
     "Configuration": TIER_CORE,
+    "Storage backend": TIER_CORE,
     "Brain database": TIER_CORE,
     "Dependencies": TIER_CORE,
     "Schema version": TIER_CORE,
@@ -78,6 +79,7 @@ def run_doctor(
 
     checks.append(_check_python_version())
     checks.append(_check_config())
+    checks.append(_check_storage_backend())
     checks.append(_check_brain())
     checks.append(_check_dependencies())
     checks.append(_check_embedding_provider())
@@ -321,6 +323,42 @@ def _check_config() -> dict[str, Any]:
             "detail": "parse error — run: smem init --force",
             "fix": "Run: smem init --force",
         }
+
+
+def _check_storage_backend() -> dict[str, Any]:
+    """Report the active backend, warning when it is one that 3.0.0 drops."""
+    try:
+        from surreal_memory.unified_config import get_config
+
+        backend = get_config(reload=True).storage_backend
+    except Exception as e:
+        return {
+            "name": "Storage backend",
+            "status": FAIL,
+            "detail": f"could not resolve backend: {e}",
+            "fix": "Run: smem init --force",
+        }
+
+    if backend == "surrealdb":
+        return {"name": "Storage backend", "status": OK, "detail": "surrealdb"}
+
+    if backend == "memory":
+        return {
+            "name": "Storage backend",
+            "status": WARN,
+            "detail": "memory — nothing is persisted; every memory is lost on exit",
+            "fix": "Set SURREAL_MEMORY_STORAGE=surrealdb for a durable store",
+        }
+
+    return {
+        "name": "Storage backend",
+        "status": WARN,
+        "detail": "sqlite — deprecated, removed in 3.0.0",
+        "fix": (
+            "Migrate: smem export backup.json → set SURREAL_MEMORY_STORAGE=surrealdb "
+            "→ smem import backup.json (see docs/guides/migrating-to-3.0.md)"
+        ),
+    }
 
 
 def _check_brain() -> dict[str, Any]:

--- a/src/surreal_memory/core/memory_types.py
+++ b/src/surreal_memory/core/memory_types.py
@@ -147,6 +147,17 @@ class Provenance:
             last_confirmed=utcnow(),
         )
 
+    def to_dict(self) -> dict[str, object]:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "source": self.source,
+            "confidence": self.confidence.value,
+            "verified": self.verified,
+            "verified_at": self.verified_at.isoformat() if self.verified_at else None,
+            "created_by": self.created_by,
+            "last_confirmed": self.last_confirmed.isoformat() if self.last_confirmed else None,
+        }
+
 
 # Trust score ceilings per source — agents can lower but not exceed system ceiling.
 _TRUST_CEILINGS: dict[str, float] = {
@@ -225,6 +236,81 @@ class TypedMemory:
     valid_from: datetime | None = None
     valid_until: datetime | None = None
     superseded_by: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for brain export/import.
+
+        Key names match what the SQLite backend has always written into a
+        BrainSnapshot, so snapshots stay readable across backends and versions.
+        """
+
+        def _iso(value: datetime | None) -> str | None:
+            return value.isoformat() if value else None
+
+        return {
+            "fiber_id": self.fiber_id,
+            "memory_type": self.memory_type.value,
+            "priority": self.priority.value,
+            "provenance": self.provenance.to_dict(),
+            "expires_at": _iso(self.expires_at),
+            "project_id": self.project_id,
+            "tags": sorted(self.tags),
+            "metadata": dict(self.metadata),
+            "created_at": _iso(self.created_at),
+            "trust_score": self.trust_score,
+            "source": self.source,
+            "tier": self.tier,
+            "valid_from": _iso(self.valid_from),
+            "valid_until": _iso(self.valid_until),
+            "superseded_by": self.superseded_by,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TypedMemory:
+        """Rebuild from a to_dict() payload.
+
+        Tolerant by design: snapshots written by older versions lack the newer
+        fields, and every value is optional except fiber_id and memory_type.
+        """
+
+        def _dt(value: Any) -> datetime | None:
+            if not value:
+                return None
+            if isinstance(value, datetime):
+                return value
+            try:
+                return datetime.fromisoformat(str(value))
+            except ValueError:
+                return None
+
+        prov_data = data.get("provenance") or {}
+        provenance = Provenance(
+            source=prov_data.get("source", "import"),
+            confidence=Confidence(prov_data.get("confidence", Confidence.MEDIUM.value)),
+            verified=bool(prov_data.get("verified", False)),
+            verified_at=_dt(prov_data.get("verified_at")),
+            created_by=prov_data.get("created_by", "import"),
+            last_confirmed=_dt(prov_data.get("last_confirmed")),
+        )
+
+        trust_raw = data.get("trust_score")
+        return cls(
+            fiber_id=str(data["fiber_id"]),
+            memory_type=MemoryType(data["memory_type"]),
+            priority=Priority(data.get("priority", Priority.NORMAL.value)),
+            provenance=provenance,
+            expires_at=_dt(data.get("expires_at")),
+            project_id=data.get("project_id"),
+            tags=frozenset(data.get("tags") or []),
+            metadata=dict(data.get("metadata") or {}),
+            created_at=_dt(data.get("created_at")) or utcnow(),
+            trust_score=float(trust_raw) if trust_raw is not None else None,
+            source=data.get("source"),
+            tier=str(data.get("tier") or MemoryTier.WARM),
+            valid_from=_dt(data.get("valid_from")),
+            valid_until=_dt(data.get("valid_until")),
+            superseded_by=data.get("superseded_by"),
+        )
 
     @classmethod
     def create(

--- a/src/surreal_memory/engine/doc_trainer.py
+++ b/src/surreal_memory/engine/doc_trainer.py
@@ -238,7 +238,7 @@ class DocTrainer:
             return False
 
         try:
-            from surreal_memory.storage.sqlite_training_files import compute_file_hash
+            from surreal_memory.utils.file_hash import compute_file_hash
 
             file_hash = compute_file_hash(file_path)
             record = await self._storage.get_training_file_by_hash(file_hash)
@@ -257,7 +257,7 @@ class DocTrainer:
             return
 
         try:
-            from surreal_memory.storage.sqlite_training_files import compute_file_hash
+            from surreal_memory.utils.file_hash import compute_file_hash
 
             file_hash = compute_file_hash(file_path)
             await self._storage.upsert_training_file(

--- a/src/surreal_memory/server/app.py
+++ b/src/surreal_memory/server/app.py
@@ -29,7 +29,6 @@ from surreal_memory.server.routes import (
     sync_router,
 )
 from surreal_memory.storage.base import NeuralStorage
-from surreal_memory.storage.sqlite_schema import SCHEMA_VERSION
 
 # Static files directory
 STATIC_DIR = Path(__file__).parent / "static"
@@ -39,6 +38,25 @@ STATIC_DIR = Path(__file__).parent / "static"
 # is slow-moving, so cache the built payload per (brain, limit, offset) for a
 # short window (see dashboard_cache).
 _GRAPH_CACHE = TTLCache()
+
+
+def _active_schema_version() -> int:
+    """Return the schema version of the backend actually in use.
+
+    /health used to report the SQLite schema version unconditionally, so a
+    SurrealDB deployment advertised a version number from a store it never
+    touched.
+    """
+    from surreal_memory.unified_config import get_config
+
+    if get_config().storage_backend == "surrealdb":
+        from surreal_memory.storage.surrealdb.schema import SCHEMA_VERSION as SURREAL_VERSION
+
+        return SURREAL_VERSION
+
+    from surreal_memory.storage.sqlite_schema import SCHEMA_VERSION as SQLITE_VERSION
+
+    return SQLITE_VERSION
 
 
 @asynccontextmanager
@@ -560,7 +578,7 @@ def create_app(
             version=__version__,
             brain_name="***",
             uptime_seconds=round(uptime, 3),
-            schema_version=SCHEMA_VERSION,
+            schema_version=_active_schema_version(),
         )
 
     # Readiness check endpoint

--- a/src/surreal_memory/storage/memory_brain_ops.py
+++ b/src/surreal_memory/storage/memory_brain_ops.py
@@ -9,10 +9,6 @@ from typing import Any
 from surreal_memory.core.brain import Brain, BrainConfig, BrainSnapshot
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.memory_types import (
-    Confidence,
-    MemoryType,
-    Priority,
-    Provenance,
     TypedMemory,
 )
 from surreal_memory.core.neuron import Neuron, NeuronType
@@ -113,33 +109,7 @@ class InMemoryBrainMixin:
             for f in self._fibers[brain_id].values()
         ]
 
-        typed_memories = [
-            {
-                "fiber_id": tm.fiber_id,
-                "memory_type": tm.memory_type.value,
-                "priority": tm.priority.value,
-                "provenance": {
-                    "source": tm.provenance.source,
-                    "confidence": tm.provenance.confidence.value,
-                    "verified": tm.provenance.verified,
-                    "verified_at": (
-                        tm.provenance.verified_at.isoformat() if tm.provenance.verified_at else None
-                    ),
-                    "created_by": tm.provenance.created_by,
-                    "last_confirmed": (
-                        tm.provenance.last_confirmed.isoformat()
-                        if tm.provenance.last_confirmed
-                        else None
-                    ),
-                },
-                "expires_at": tm.expires_at.isoformat() if tm.expires_at else None,
-                "project_id": tm.project_id,
-                "tags": list(tm.tags),
-                "metadata": tm.metadata,
-                "created_at": tm.created_at.isoformat(),
-            }
-            for tm in self._typed_memories[brain_id].values()
-        ]
+        typed_memories = [tm.to_dict() for tm in self._typed_memories[brain_id].values()]
 
         projects = [p.to_dict() for p in self._projects[brain_id].values()]
 
@@ -249,39 +219,7 @@ class InMemoryBrainMixin:
         self, brain_id: str, typed_memories_data: list[dict[str, Any]]
     ) -> None:
         for tm_data in typed_memories_data:
-            prov_data = tm_data.get("provenance", {})
-            provenance = Provenance(
-                source=prov_data.get("source", "import"),
-                confidence=Confidence(prov_data.get("confidence", "medium")),
-                verified=prov_data.get("verified", False),
-                verified_at=(
-                    datetime.fromisoformat(prov_data["verified_at"])
-                    if prov_data.get("verified_at")
-                    else None
-                ),
-                created_by=prov_data.get("created_by", "import"),
-                last_confirmed=(
-                    datetime.fromisoformat(prov_data["last_confirmed"])
-                    if prov_data.get("last_confirmed")
-                    else None
-                ),
-            )
-
-            typed_memory = TypedMemory(
-                fiber_id=tm_data["fiber_id"],
-                memory_type=MemoryType(tm_data["memory_type"]),
-                priority=Priority(tm_data["priority"]),
-                provenance=provenance,
-                expires_at=(
-                    datetime.fromisoformat(tm_data["expires_at"])
-                    if tm_data.get("expires_at")
-                    else None
-                ),
-                project_id=tm_data.get("project_id"),
-                tags=frozenset(tm_data.get("tags", [])),
-                metadata=tm_data.get("metadata", {}),
-                created_at=datetime.fromisoformat(tm_data["created_at"]),
-            )
+            typed_memory = TypedMemory.from_dict(tm_data)
             if typed_memory.fiber_id in self._fibers[brain_id]:
                 self._typed_memories[brain_id][typed_memory.fiber_id] = typed_memory
 

--- a/src/surreal_memory/storage/sqlite_brain_ops.py
+++ b/src/surreal_memory/storage/sqlite_brain_ops.py
@@ -10,10 +10,6 @@ from typing import TYPE_CHECKING, Any
 from surreal_memory.core.brain import Brain, BrainConfig, BrainSnapshot
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.memory_types import (
-    Confidence,
-    MemoryType,
-    Priority,
-    Provenance,
     TypedMemory,
 )
 from surreal_memory.core.neuron import Neuron, NeuronType
@@ -377,40 +373,7 @@ class SQLiteBrainMixin:
 
     async def _import_typed_memories(self, typed_memories_data: list[dict[str, Any]]) -> None:
         for tm_data in typed_memories_data:
-            prov_data = tm_data.get("provenance", {})
-            provenance = Provenance(
-                source=prov_data.get("source", "import"),
-                confidence=Confidence(prov_data.get("confidence", "medium")),
-                verified=prov_data.get("verified", False),
-                verified_at=(
-                    datetime.fromisoformat(prov_data["verified_at"])
-                    if prov_data.get("verified_at")
-                    else None
-                ),
-                created_by=prov_data.get("created_by", "import"),
-                last_confirmed=(
-                    datetime.fromisoformat(prov_data["last_confirmed"])
-                    if prov_data.get("last_confirmed")
-                    else None
-                ),
-            )
-
-            typed_memory = TypedMemory(
-                fiber_id=tm_data["fiber_id"],
-                memory_type=MemoryType(tm_data["memory_type"]),
-                priority=Priority(tm_data["priority"]),
-                provenance=provenance,
-                expires_at=(
-                    datetime.fromisoformat(tm_data["expires_at"])
-                    if tm_data.get("expires_at")
-                    else None
-                ),
-                project_id=tm_data.get("project_id"),
-                tags=frozenset(tm_data.get("tags", [])),
-                metadata=tm_data.get("metadata", {}),
-                created_at=datetime.fromisoformat(tm_data["created_at"]),
-            )
-            await self.add_typed_memory(typed_memory)
+            await self.add_typed_memory(TypedMemory.from_dict(tm_data))
 
 
 # ========== Export helpers (module-level) ==========

--- a/src/surreal_memory/storage/sqlite_row_mappers.py
+++ b/src/surreal_memory/storage/sqlite_row_mappers.py
@@ -303,14 +303,9 @@ def row_to_brain(row: aiosqlite.Row) -> Brain:
 
 
 def provenance_to_dict(provenance: Provenance) -> dict[str, object]:
-    """Serialize Provenance to a JSON-compatible dict."""
-    return {
-        "source": provenance.source,
-        "confidence": provenance.confidence.value,
-        "verified": provenance.verified,
-        "verified_at": (provenance.verified_at.isoformat() if provenance.verified_at else None),
-        "created_by": provenance.created_by,
-        "last_confirmed": (
-            provenance.last_confirmed.isoformat() if provenance.last_confirmed else None
-        ),
-    }
+    """Serialize Provenance to a JSON-compatible dict.
+
+    Thin wrapper kept for the SQLite mappers; new code calls
+    ``Provenance.to_dict()`` directly.
+    """
+    return provenance.to_dict()

--- a/src/surreal_memory/storage/sqlite_training_files.py
+++ b/src/surreal_memory/storage/sqlite_training_files.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from surreal_memory.utils.file_hash import compute_file_hash
 from surreal_memory.utils.timeutils import utcnow
 
 if TYPE_CHECKING:
@@ -15,8 +14,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Maximum file size to hash (2GB — streaming hash, safe for large files)
-_MAX_HASH_SIZE = 2 * 1024 * 1024 * 1024
+__all__ = ["SQLiteTrainingFilesMixin", "compute_file_hash"]
 
 
 class SQLiteTrainingFilesMixin:
@@ -158,26 +156,3 @@ class SQLiteTrainingFilesMixin:
                 "failed": row[3] or 0,
                 "total_chunks": row[4] or 0,
             }
-
-
-def compute_file_hash(file_path: Path) -> str:
-    """Compute SHA-256 hash of a file's content.
-
-    Args:
-        file_path: Path to the file.
-
-    Returns:
-        Hex digest of the SHA-256 hash.
-
-    Raises:
-        ValueError: If file is too large.
-    """
-    file_size = file_path.stat().st_size
-    if file_size > _MAX_HASH_SIZE:
-        raise ValueError(f"File too large to hash: {file_size} bytes (max {_MAX_HASH_SIZE})")
-
-    hasher = hashlib.sha256()
-    with open(file_path, "rb") as f:
-        while chunk := f.read(8192):
-            hasher.update(chunk)
-    return hasher.hexdigest()

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -19,7 +19,9 @@ from uuid import uuid4
 
 from surreal_memory.core.brain import Brain, BrainConfig, BrainSnapshot
 from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.memory_types import TypedMemory
 from surreal_memory.core.neuron import Neuron, NeuronState, NeuronType
+from surreal_memory.core.project import Project
 from surreal_memory.core.synapse import Direction, Synapse, SynapseType
 from surreal_memory.storage.base import NeuralStorage
 from surreal_memory.storage.surrealdb._ids import _safe_brain_id, _to_surreal_id
@@ -37,12 +39,53 @@ from surreal_memory.storage.surrealdb.review_schedules import SurrealDBReviewSch
 from surreal_memory.storage.surrealdb.schema import ensure_schema
 from surreal_memory.storage.surrealdb.sources import SurrealDBSourcesMixin
 from surreal_memory.storage.surrealdb.tool_events import SurrealDBToolEventsMixin
-from surreal_memory.storage.surrealdb.typed_memory import SurrealDBTypedMemoryMixin
+from surreal_memory.storage.surrealdb.typed_memory import (
+    SurrealDBTypedMemoryMixin,
+    _row_to_typed_memory,
+)
 from surreal_memory.storage.surrealdb.versions import SurrealDBVersionsMixin
 from surreal_memory.utils.geo import GeoFilter, fiber_within
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
+
+#: Every table carrying a ``brain_id``. ``clear()`` walks this list, so a brain
+#: wipe leaves nothing behind. It used to name nine tables by hand and drift as
+#: new ones appeared: rows in project, source, entity_refs, co_activations,
+#: depth_priors, tool_events and the trace tables survived their brain and
+#: accumulated permanently, since nothing else deletes by brain. Keep this in
+#: sync with the DEFINE TABLE statements in schema.py.
+_BRAIN_SCOPED_TABLES: tuple[str, ...] = (
+    "action_log",
+    "alerts",
+    "brain_versions",
+    "change_log",
+    "co_activations",
+    "cognitive_state",
+    "compression_backups",
+    "depth_priors",
+    "device",
+    "entity_refs",
+    "fiber",
+    "hot_index",
+    "keyword_document_frequency",
+    "knowledge_gaps",
+    # Maturation rows outlive their fiber (delete_fiber has no cascade, by
+    # design -- see engine/consolidation.py's merge path).
+    "maturation",
+    "merkle_hash",
+    "neuron",
+    "neuron_snapshots",
+    "neuron_state",
+    "project",
+    "reasoning_traces",
+    "retrieval_trace",
+    "review_schedules",
+    "source",
+    "synapse",
+    "tool_events",
+    "typed_memory",
+)
 
 
 def _serialize_brain_config(config: Any) -> dict[str, Any]:
@@ -1824,6 +1867,40 @@ class SurrealDBStorage(
             for f in raw_fibers
         ]
 
+        # Typed memories and projects live in their own tables, not as neurons:
+        # without them a snapshot carries the graph but loses memory type,
+        # priority, tags, trust score, expiry, tier and project scoping.
+        # A brain still on a schema that predates either table exports without
+        # it rather than failing outright — but says so, because a silently
+        # thinner snapshot is what made this data go missing in the first place.
+        typed_memories: list[dict[str, Any]] = []
+        try:
+            typed_rows = await self._query(
+                "SELECT * FROM typed_memory WHERE brain_id = $brain_id LIMIT 50000",
+                brain_id=_safe_brain_id(brain_id),
+            )
+            typed_memories = [
+                tm.to_dict() for tm in (_row_to_typed_memory(r) for r in typed_rows) if tm
+            ]
+        except Exception:
+            logger.warning(
+                "Exporting brain %r without typed memories — the typed_memory "
+                "table is unreadable on this schema",
+                brain_id,
+                exc_info=True,
+            )
+
+        projects: list[dict[str, Any]] = []
+        try:
+            projects = [p.to_dict() for p in await self.list_projects(limit=1000)]
+        except Exception:
+            logger.warning(
+                "Exporting brain %r without projects — the project table is "
+                "unreadable on this schema",
+                brain_id,
+                exc_info=True,
+            )
+
         return BrainSnapshot(
             brain_id=brain_id,
             brain_name=brain.name,
@@ -1833,6 +1910,7 @@ class SurrealDBStorage(
             synapses=synapses,
             fibers=fibers,
             config=dict(brain.metadata),
+            metadata={"typed_memories": typed_memories, "projects": projects},
         )
 
     async def import_brain(
@@ -1893,6 +1971,20 @@ class SurrealDBStorage(
                 await self.add_fiber(fiber)
             except Exception:
                 pass
+
+        # Restore the side tables the graph does not carry. Snapshots written by
+        # versions before these were exported simply have no such keys.
+        for pd in snapshot.metadata.get("projects", []):
+            try:
+                await self.add_project(Project.from_dict(pd))
+            except Exception:
+                logger.debug("Skipped unimportable project record", exc_info=True)
+
+        for td in snapshot.metadata.get("typed_memories", []):
+            try:
+                await self.add_typed_memory(TypedMemory.from_dict(td))
+            except Exception:
+                logger.debug("Skipped unimportable typed memory record", exc_info=True)
 
         return bid
 
@@ -1986,20 +2078,8 @@ class SurrealDBStorage(
     # ================================================================
 
     async def clear(self, brain_id: str) -> None:
-        await self._query("DELETE neuron WHERE brain_id = $bid", bid=brain_id)
-        await self._query("DELETE neuron_state WHERE brain_id = $bid", bid=brain_id)
-        await self._query("DELETE synapse WHERE brain_id = $bid", bid=brain_id)
-        await self._query("DELETE fiber WHERE brain_id = $bid", bid=brain_id)
-        # Maturation rows outlive their fiber (delete_fiber has no cascade, by
-        # design -- see engine/consolidation.py's merge path), so a brain wipe
-        # must clear them explicitly or they orphan permanently once the
-        # brain record itself is gone (found live: run 010's own benchmark
-        # left rows behind before this line existed).
-        await self._query("DELETE maturation WHERE brain_id = $bid", bid=brain_id)
-        await self._query("DELETE change_log WHERE brain_id = $bid", bid=brain_id)
-        await self._query("DELETE device WHERE brain_id = $bid", bid=brain_id)
-        await self._query("DELETE merkle_hash WHERE brain_id = $bid", bid=brain_id)
-        await self._query("DELETE typed_memory WHERE brain_id = $bid", bid=brain_id)
+        for table in _BRAIN_SCOPED_TABLES:
+            await self._query(f"DELETE {table} WHERE brain_id = $bid", bid=brain_id)
 
     # ================================================================
     # Vector Search (for cone queries / semantic search)

--- a/src/surreal_memory/storage/surrealdb/typed_memory.py
+++ b/src/surreal_memory/storage/surrealdb/typed_memory.py
@@ -14,7 +14,6 @@ from surreal_memory.core.memory_types import (
     Provenance,
     TypedMemory,
 )
-from surreal_memory.storage.sqlite_row_mappers import provenance_to_dict
 from surreal_memory.storage.surrealdb._ids import _safe_brain_id, _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
@@ -126,7 +125,7 @@ class SurrealDBTypedMemoryMixin:
         sid = _to_surreal_id(typed_memory.fiber_id)
 
         full_metadata = dict(typed_memory.metadata)
-        full_metadata["_provenance"] = provenance_to_dict(typed_memory.provenance)
+        full_metadata["_provenance"] = typed_memory.provenance.to_dict()
 
         record_data: dict[str, Any] = {
             "fiber_id": typed_memory.fiber_id,
@@ -299,7 +298,7 @@ class SurrealDBTypedMemoryMixin:
         sid = _to_surreal_id(typed_memory.fiber_id)
 
         full_metadata = dict(typed_memory.metadata)
-        full_metadata["_provenance"] = provenance_to_dict(typed_memory.provenance)
+        full_metadata["_provenance"] = typed_memory.provenance.to_dict()
 
         rows = await self._query(
             "SELECT id FROM typed_memory WHERE brain_id = $brain_id AND fiber_id = $fiber_id LIMIT 1",

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -20,6 +20,7 @@ import os
 import re
 import shutil
 import tomllib
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -1018,7 +1019,15 @@ def _sanitize_sync_id(value: str) -> str:
     return cleaned
 
 
-_VALID_STORAGE_BACKENDS = {"sqlite", "surrealdb"}
+_VALID_STORAGE_BACKENDS = {"sqlite", "surrealdb", "memory"}
+
+SQLITE_REMOVAL_NOTICE = (
+    "The SQLite storage backend is deprecated and will be REMOVED in 3.0.0. "
+    "Migrate now: run `smem export backup.json`, set "
+    "SURREAL_MEMORY_STORAGE=surrealdb, then `smem import backup.json`. "
+    "For a persistence-free install, set SURREAL_MEMORY_STORAGE=memory. "
+    "See docs/guides/migrating-to-3.0.md."
+)
 
 
 def _validate_storage_backend(value: str) -> str:
@@ -2412,6 +2421,7 @@ def _warn_sqlite_backend() -> None:
         return
     _sqlite_backend_warned = True
     logger = logging.getLogger(__name__)
+    warnings.warn(SQLITE_REMOVAL_NOTICE, DeprecationWarning, stacklevel=3)
     has_surreal_env = bool(os.environ.get("SURREALDB_URL") or os.environ.get("SURREALDB_PASS"))
     if has_surreal_env:
         logger.warning(
@@ -2420,12 +2430,14 @@ def _warn_sqlite_backend() -> None:
             "LOCAL SQLite brain, NOT SurrealDB — this splits your data across two "
             "stores (the dashboard reads SurrealDB). Set "
             'SURREAL_MEMORY_STORAGE=surrealdb (or storage_backend = "surrealdb" '
-            "in config.toml) to use SurrealDB."
+            "in config.toml) to use SurrealDB. %s",
+            SQLITE_REMOVAL_NOTICE,
         )
     else:
         logger.warning(
             "Using the SQLite storage backend (internal test fixture). For real "
-            "use set SURREAL_MEMORY_STORAGE=surrealdb."
+            "use set SURREAL_MEMORY_STORAGE=surrealdb. %s",
+            SQLITE_REMOVAL_NOTICE,
         )
 
 
@@ -2501,10 +2513,15 @@ async def get_shared_storage(brain_name: str | None = None) -> NeuralStorage:
     if config.storage_backend == "surrealdb":
         return await _get_surrealdb_storage(config, name)
 
-    # Default: SQLite — internal test fixture only. Production must set
-    # storage_backend = "surrealdb" explicitly. Warn loudly so a misconfigured
-    # install does not silently route memories into a local SQLite brain that
-    # then diverges from the SurrealDB the dashboard reads.
+    # Non-persistent backend: everything lives in this process and is gone when
+    # it exits. Opt-in only, for trying the tool out without running a database.
+    if config.storage_backend == "memory":
+        return await _get_memory_storage(config, name)
+
+    # Default: SQLite — internal test fixture only, removed in 3.0.0. Production
+    # must set storage_backend = "surrealdb" explicitly. Warn loudly so a
+    # misconfigured install does not silently route memories into a local SQLite
+    # brain that then diverges from the SurrealDB the dashboard reads.
     _warn_sqlite_backend()
     return await _get_sqlite_storage(config, name, brain_name)
 
@@ -2581,6 +2598,54 @@ async def _migrate_brain_runtime_config(
             getattr(brain, "name", "?"),
             exc_info=True,
         )
+
+
+_memory_backend_warned = False
+
+
+async def _get_memory_storage(config: UnifiedConfig, name: str) -> NeuralStorage:
+    """Create or return the cached InMemoryStorage for *name*.
+
+    Nothing is written to disk: closing the process discards every memory. This
+    exists so `pip install surreal-memory` can be tried without provisioning a
+    database, and so container images can run without a datastore volume.
+    """
+    global _memory_backend_warned
+    if not _memory_backend_warned:
+        _memory_backend_warned = True
+        logger.warning(
+            "Using the in-memory storage backend — NOTHING IS PERSISTED. "
+            "Every memory is lost when this process exits. Set "
+            "SURREAL_MEMORY_STORAGE=surrealdb for a durable store."
+        )
+
+    from surreal_memory.core.brain import Brain, BrainConfig
+    from surreal_memory.storage.memory_store import InMemoryStorage
+
+    cache_key = f"memory:{name}"
+    lock = _get_storage_lock()
+    async with lock:
+        cached = _storage_cache.get(cache_key)
+        if cached is not None:
+            cached.set_brain(name)
+            return cached
+
+        # No initialize(): the in-memory store has no connection to open.
+        storage = InMemoryStorage()
+
+        brain = await storage.get_brain(name)
+        if brain is None:
+            brain = await storage.find_brain_by_name(name)
+        if brain is None:
+            brain_config = BrainConfig(
+                **config.brain.to_brain_config_kwargs(config.embedding, config.reranker)
+            )
+            brain = Brain.create(name=name, config=brain_config, brain_id=name)
+            await storage.save_brain(brain)
+
+        storage.set_brain(name)
+        _storage_cache[cache_key] = storage
+        return storage
 
 
 async def _get_sqlite_storage(

--- a/src/surreal_memory/utils/file_hash.py
+++ b/src/surreal_memory/utils/file_hash.py
@@ -1,0 +1,34 @@
+"""Content hashing for files fed to the document trainer."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_MAX_HASH_SIZE = 2 * 1024 * 1024 * 1024
+
+
+def compute_file_hash(file_path: Path) -> str:
+    """Compute SHA-256 hash of a file's content.
+
+    Args:
+        file_path: Path to the file.
+
+    Returns:
+        Hex digest of the SHA-256 hash.
+
+    Raises:
+        ValueError: If file is too large.
+    """
+    file_size = file_path.stat().st_size
+    if file_size > _MAX_HASH_SIZE:
+        raise ValueError(f"File too large to hash: {file_size} bytes (max {_MAX_HASH_SIZE})")
+
+    hasher = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        while chunk := f.read(8192):
+            hasher.update(chunk)
+    return hasher.hexdigest()

--- a/tests/unit/_surrealdb_live.py
+++ b/tests/unit/_surrealdb_live.py
@@ -42,6 +42,8 @@ LIVE_TEST_BRAIN_NAMES = frozenset(
         "u8-geo-live",  # test_surrealdb_geo_live.py
         "ub1-recordid-fix-live",  # test_surrealdb_recordid_fix_live.py
         "parity-test-surreal",  # test_get_project_memories.py
+        "snapshot-roundtrip-live",  # test_surrealdb_export_import_live.py
+        "snapshot-roundtrip-live-target",  # test_surrealdb_export_import_live.py
         "pinned-expiry-test-9f3a1c",  # test_surrealdb_expiry_respects_pinned_live.py
     }
 )

--- a/tests/unit/test_brain_scoped_tables.py
+++ b/tests/unit/test_brain_scoped_tables.py
@@ -1,0 +1,46 @@
+"""`clear()` must wipe every brain-scoped table, not a hand-maintained subset.
+
+The list used to be spelled out inline in clear() and drifted as tables were
+added, so rows in project, source, entity_refs, co_activations, depth_priors,
+tool_events and the trace tables outlived their brain. Nothing else deletes by
+brain, so those rows accumulated permanently. This pins the list to the schema.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from surreal_memory.storage.surrealdb import schema as schema_module
+from surreal_memory.storage.surrealdb.store import _BRAIN_SCOPED_TABLES
+
+_BRAIN_ID_FIELD = re.compile(r"DEFINE FIELD\s+brain_id\s+ON\s+(?:TABLE\s+)?(\w+)", re.IGNORECASE)
+
+
+def _tables_with_brain_id() -> set[str]:
+    source = Path(schema_module.__file__).read_text(encoding="utf-8")
+    return set(_BRAIN_ID_FIELD.findall(source))
+
+
+def test_schema_declares_brain_scoped_tables() -> None:
+    # Guards the regex itself: a rename in schema.py that breaks parsing would
+    # otherwise make the comparison below vacuously pass.
+    assert len(_tables_with_brain_id()) > 5
+
+
+def test_clear_covers_every_brain_scoped_table() -> None:
+    missing = _tables_with_brain_id() - set(_BRAIN_SCOPED_TABLES)
+
+    assert not missing, (
+        f"tables carrying brain_id but never cleared: {sorted(missing)} — "
+        "add them to _BRAIN_SCOPED_TABLES or their rows will outlive the brain"
+    )
+
+
+def test_cleared_tables_all_exist_in_the_schema() -> None:
+    source = Path(schema_module.__file__).read_text(encoding="utf-8")
+    defined = set(re.findall(r"DEFINE TABLE\s+(\w+)", source))
+
+    unknown = set(_BRAIN_SCOPED_TABLES) - defined
+
+    assert not unknown, f"cleared tables absent from the schema: {sorted(unknown)}"

--- a/tests/unit/test_brain_snapshot_roundtrip.py
+++ b/tests/unit/test_brain_snapshot_roundtrip.py
@@ -1,0 +1,176 @@
+"""Snapshot serialization for typed memories — the brain export/import payload.
+
+`smem export` / `smem import`, `smem brain export/import` and multi-device sync
+all move a BrainSnapshot, whose typed-memory records used to be built by
+hand-rolled parsing in each backend. The SQLite importer dropped every field
+added after it was written (trust score, source, tier, validity window,
+supersession), so a round trip quietly downgraded memories.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from surreal_memory.core.brain import Brain
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.memory_types import (
+    Confidence,
+    MemoryType,
+    Priority,
+    Provenance,
+    TypedMemory,
+)
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.storage.memory_store import InMemoryStorage
+from surreal_memory.utils.timeutils import utcnow
+
+
+def _full_typed_memory() -> TypedMemory:
+    """A typed memory with every optional field populated."""
+    now = utcnow()
+    return TypedMemory(
+        fiber_id="fiber-1",
+        memory_type=MemoryType.DECISION,
+        priority=Priority.HIGH,
+        provenance=Provenance(
+            source="user_input",
+            confidence=Confidence.HIGH,
+            verified=True,
+            verified_at=now,
+            created_by="tester",
+            last_confirmed=now,
+        ),
+        expires_at=now + timedelta(days=30),
+        project_id="project-1",
+        tags=frozenset({"alpha", "beta"}),
+        metadata={"note": "keep"},
+        created_at=now,
+        trust_score=0.75,
+        source="user_input",
+        tier="hot",
+        valid_from=now - timedelta(days=1),
+        valid_until=now + timedelta(days=1),
+        superseded_by="fiber-2",
+    )
+
+
+class TestProvenanceSerialization:
+    def test_round_trips_through_dict(self) -> None:
+        now = utcnow()
+        prov = Provenance(
+            source="ai_inference",
+            confidence=Confidence.LOW,
+            verified=False,
+            verified_at=None,
+            created_by="agent",
+            last_confirmed=now,
+        )
+
+        data = prov.to_dict()
+
+        assert data["source"] == "ai_inference"
+        assert data["confidence"] == Confidence.LOW.value
+        assert data["verified_at"] is None
+        assert data["last_confirmed"] == now.isoformat()
+
+
+class TestTypedMemorySerialization:
+    def test_every_field_survives_a_round_trip(self) -> None:
+        original = _full_typed_memory()
+
+        restored = TypedMemory.from_dict(original.to_dict())
+
+        assert restored.fiber_id == original.fiber_id
+        assert restored.memory_type == original.memory_type
+        assert restored.priority == original.priority
+        assert restored.provenance == original.provenance
+        assert restored.expires_at == original.expires_at
+        assert restored.project_id == original.project_id
+        assert restored.tags == original.tags
+        assert restored.metadata == original.metadata
+        assert restored.created_at == original.created_at
+        assert restored.trust_score == original.trust_score
+        assert restored.source == original.source
+        assert restored.tier == original.tier
+        assert restored.valid_from == original.valid_from
+        assert restored.valid_until == original.valid_until
+        assert restored.superseded_by == original.superseded_by
+
+    def test_reads_a_snapshot_written_before_the_newer_fields_existed(self) -> None:
+        legacy = {
+            "fiber_id": "fiber-legacy",
+            "memory_type": "fact",
+            "priority": Priority.NORMAL.value,
+            "provenance": {"source": "import", "confidence": "medium"},
+            "expires_at": None,
+            "project_id": None,
+            "tags": ["old"],
+            "metadata": {},
+            "created_at": utcnow().isoformat(),
+        }
+
+        restored = TypedMemory.from_dict(legacy)
+
+        assert restored.fiber_id == "fiber-legacy"
+        assert restored.memory_type == MemoryType.FACT
+        assert restored.tags == frozenset({"old"})
+        assert restored.trust_score is None
+        assert restored.tier == "warm"
+        assert restored.superseded_by is None
+
+    def test_unparseable_timestamp_does_not_raise(self) -> None:
+        restored = TypedMemory.from_dict(
+            {
+                "fiber_id": "fiber-bad-date",
+                "memory_type": "fact",
+                "expires_at": "not-a-date",
+            }
+        )
+
+        assert restored.expires_at is None
+
+
+class TestBrainSnapshotTypedMemories:
+    async def test_export_import_preserves_the_full_record(self) -> None:
+        source_storage = InMemoryStorage()
+        brain = Brain.create(name="snapshot-source")
+        await source_storage.save_brain(brain)
+        source_storage.set_brain(brain.id)
+
+        neuron = Neuron.create(type=NeuronType.CONCEPT, content="snapshot content")
+        await source_storage.add_neuron(neuron)
+        fiber = Fiber.create(
+            neuron_ids={neuron.id},
+            synapse_ids=set(),
+            anchor_neuron_id=neuron.id,
+            summary="snapshot fiber",
+        )
+        await source_storage.add_fiber(fiber)
+
+        original = TypedMemory(
+            fiber_id=fiber.id,
+            memory_type=MemoryType.DECISION,
+            priority=Priority.HIGH,
+            expires_at=utcnow() + timedelta(days=7),
+            tags=frozenset({"alpha"}),
+            trust_score=0.9,
+            source="user_input",
+            tier="hot",
+        )
+        await source_storage.add_typed_memory(original)
+
+        snapshot = await source_storage.export_brain(brain.id)
+
+        target = InMemoryStorage()
+        await target.import_brain(snapshot, "snapshot-target")
+        target.set_brain("snapshot-target")
+
+        restored = await target.get_typed_memory(fiber.id)
+        assert restored is not None
+        assert restored.memory_type == MemoryType.DECISION
+        assert restored.priority == Priority.HIGH
+        assert restored.tags == frozenset({"alpha"})
+        # Fields the old hand-rolled importer silently discarded.
+        assert restored.trust_score == 0.9
+        assert restored.source == "user_input"
+        assert restored.tier == "hot"

--- a/tests/unit/test_doctor_enhanced.py
+++ b/tests/unit/test_doctor_enhanced.py
@@ -339,6 +339,7 @@ class TestRunDoctorIntegration:
     @patch("surreal_memory.cli.doctor._check_dependencies")
     @patch("surreal_memory.cli.doctor._check_brain")
     @patch("surreal_memory.cli.doctor._check_config_freshness")
+    @patch("surreal_memory.cli.doctor._check_storage_backend")
     @patch("surreal_memory.cli.doctor._check_config")
     @patch("surreal_memory.cli.doctor._check_python_version")
     def test_reports_every_registered_check(self, *mocks: MagicMock) -> None:

--- a/tests/unit/test_doctor_enhanced.py
+++ b/tests/unit/test_doctor_enhanced.py
@@ -341,14 +341,17 @@ class TestRunDoctorIntegration:
     @patch("surreal_memory.cli.doctor._check_config_freshness")
     @patch("surreal_memory.cli.doctor._check_config")
     @patch("surreal_memory.cli.doctor._check_python_version")
-    def test_includes_all_14_checks(self, *mocks: MagicMock) -> None:
+    def test_reports_every_registered_check(self, *mocks: MagicMock) -> None:
         for mock in mocks:
             mock.return_value = {"name": "test", "status": OK, "detail": "ok"}
 
         result = run_doctor(json_output=True)
-        # 14 original + SurrealDB connection + SurrealDB version + MCP env completeness
-        assert result["total"] == 17
-        assert result["passed"] == 17
+        # Bump when run_doctor gains a check: config, storage backend, brain,
+        # dependencies, embedding, schema, MCP config/connection/env, hooks,
+        # dedup, surface, config freshness, CLI tools, SurrealDB
+        # connection/version, Pro plugin, Python version.
+        assert result["total"] == 18
+        assert result["passed"] == 18
 
     def test_quickstart_url_defined(self) -> None:
         assert "quickstart" in QUICKSTART_URL

--- a/tests/unit/test_dx_wizard.py
+++ b/tests/unit/test_dx_wizard.py
@@ -199,8 +199,8 @@ class TestDoctor:
                 m.return_value = {"name": "test", "status": "ok", "detail": "ok"}
 
             result = run_doctor(json_output=True)
-            assert result["passed"] == 17
-            assert result["total"] == 17
+            assert result["passed"] == 18
+            assert result["total"] == 18
             assert result["failed"] == 0
 
     def test_run_doctor_with_failures(self) -> None:
@@ -232,7 +232,7 @@ class TestDoctor:
 
             result = run_doctor(json_output=True)
             assert result["failed"] == 1
-            assert result["passed"] == 16
+            assert result["passed"] == 17
 
     def test_run_doctor_dev_adds_dev_checks(self) -> None:
         from surreal_memory.cli.doctor import run_doctor
@@ -266,8 +266,8 @@ class TestDoctor:
 
             result = run_doctor(json_output=True, dev=True)
 
-        assert result["passed"] == 19
-        assert result["total"] == 19
+        assert result["passed"] == 20
+        assert result["total"] == 20
         assert any(c["tier"] == "dev" for c in result["checks"])
 
 

--- a/tests/unit/test_dx_wizard.py
+++ b/tests/unit/test_dx_wizard.py
@@ -194,8 +194,28 @@ class TestDoctor:
             patch("surreal_memory.cli.doctor._check_surrealdb_connection") as m14,
             patch("surreal_memory.cli.doctor._check_mcp_env_completeness") as m15,
             patch("surreal_memory.cli.doctor._check_surrealdb_version") as m16,
+            patch("surreal_memory.cli.doctor._check_storage_backend") as m17,
         ):
-            for m in [m1, m2, m3, m4, m5, m6, m7, m7b, m8, m9, m10, m11, m12, m13, m14, m15, m16]:
+            for m in [
+                m1,
+                m2,
+                m3,
+                m4,
+                m5,
+                m6,
+                m7,
+                m7b,
+                m8,
+                m9,
+                m10,
+                m11,
+                m12,
+                m13,
+                m14,
+                m15,
+                m16,
+                m17,
+            ]:
                 m.return_value = {"name": "test", "status": "ok", "detail": "ok"}
 
             result = run_doctor(json_output=True)
@@ -224,10 +244,11 @@ class TestDoctor:
             patch("surreal_memory.cli.doctor._check_surrealdb_connection") as m14,
             patch("surreal_memory.cli.doctor._check_mcp_env_completeness") as m15,
             patch("surreal_memory.cli.doctor._check_surrealdb_version") as m16,
+            patch("surreal_memory.cli.doctor._check_storage_backend") as m17,
         ):
             m1.return_value = {"name": "Python", "status": "ok", "detail": "ok"}
             m2.return_value = {"name": "Config", "status": "fail", "detail": "missing"}
-            for m in [m3, m4, m5, m6, m7, m7b, m8, m9, m10, m11, m12, m13, m14, m15, m16]:
+            for m in [m3, m4, m5, m6, m7, m7b, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17]:
                 m.return_value = {"name": "test", "status": "ok", "detail": "ok"}
 
             result = run_doctor(json_output=True)
@@ -255,9 +276,29 @@ class TestDoctor:
             patch("surreal_memory.cli.doctor._check_surrealdb_connection") as m14,
             patch("surreal_memory.cli.doctor._check_mcp_env_completeness") as m16,
             patch("surreal_memory.cli.doctor._check_surrealdb_version") as m17,
+            patch("surreal_memory.cli.doctor._check_storage_backend") as m18,
             patch("surreal_memory.cli.doctor._check_dev_environment") as m15,
         ):
-            for m in [m1, m2, m3, m4, m5, m6, m7, m7b, m8, m9, m10, m11, m12, m13, m14, m16, m17]:
+            for m in [
+                m1,
+                m2,
+                m3,
+                m4,
+                m5,
+                m6,
+                m7,
+                m7b,
+                m8,
+                m9,
+                m10,
+                m11,
+                m12,
+                m13,
+                m14,
+                m16,
+                m17,
+                m18,
+            ]:
                 m.return_value = {"name": "test", "status": "ok", "detail": "ok"}
             m15.return_value = [
                 {"name": "Source checkout", "status": "ok", "detail": "ok"},

--- a/tests/unit/test_surrealdb_export_import_live.py
+++ b/tests/unit/test_surrealdb_export_import_live.py
@@ -1,0 +1,101 @@
+"""Live-DB regression: SurrealDB snapshots must carry typed memories and projects.
+
+Typed memories and projects live in their own SurrealDB tables rather than as
+neurons, and export_brain used to skip both. Every caller of the snapshot —
+`smem export`/`smem import`, `smem brain export/import`, and multi-device sync —
+therefore moved the graph while silently dropping memory type, priority, tags,
+trust score, expiry, tier and project scoping. Skipped unless SURREALDB_URL
+points at a running SurrealDB.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from surreal_memory.core.brain import Brain
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.core.project import Project
+from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
+
+SURREALDB_URL = os.getenv("SURREALDB_URL")
+
+pytestmark = pytest.mark.skipif(
+    not SURREALDB_URL,
+    reason="requires SURREALDB_URL pointing to a running SurrealDB",
+)
+
+_SOURCE_BRAIN = "snapshot-roundtrip-live"
+_TARGET_BRAIN = "snapshot-roundtrip-live-target"
+
+
+@pytest.fixture
+async def storage():  # type: ignore[no-untyped-def]
+    ensure_real_surrealdb_sdk()
+    from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+    store = SurrealDBStorage(url=SURREALDB_URL)
+    await store.initialize()
+    brain = Brain.create(name=_SOURCE_BRAIN, brain_id=_SOURCE_BRAIN)
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+    yield store
+    for leftover in (_TARGET_BRAIN, brain.id):
+        try:
+            await cleanup_live_brains(store, own_brain_id=leftover)
+        except Exception:
+            pass
+    try:
+        await store.close()
+    except Exception:
+        pass
+
+
+class TestSnapshotRoundTripLive:
+    async def test_typed_memories_and_projects_survive_export_import(self, storage) -> None:  # type: ignore[no-untyped-def]
+        project = Project.create(name="live-project", description="snapshot scope")
+        await storage.add_project(project)
+
+        neuron = Neuron.create(type=NeuronType.CONCEPT, content="live snapshot content")
+        await storage.add_neuron(neuron)
+        fiber = Fiber.create(
+            neuron_ids={neuron.id},
+            synapse_ids=set(),
+            anchor_neuron_id=neuron.id,
+            summary="live snapshot fiber",
+        )
+        await storage.add_fiber(fiber)
+        await storage.add_typed_memory(
+            TypedMemory.create(
+                fiber_id=fiber.id,
+                memory_type=MemoryType.DECISION,
+                priority=Priority.HIGH,
+                project_id=project.id,
+                tags={"alpha"},
+                trust_score=0.9,
+                tier="hot",
+            )
+        )
+
+        snapshot = await storage.export_brain(_SOURCE_BRAIN)
+
+        assert len(snapshot.metadata.get("typed_memories", [])) == 1
+        assert len(snapshot.metadata.get("projects", [])) == 1
+
+        await storage.import_brain(snapshot, _TARGET_BRAIN)
+        storage.set_brain(_TARGET_BRAIN)
+
+        restored = await storage.get_typed_memory(fiber.id)
+        assert restored is not None
+        assert restored.memory_type == MemoryType.DECISION
+        assert restored.priority == Priority.HIGH
+        assert restored.tags == frozenset({"alpha"})
+        assert restored.trust_score == 0.9
+        assert restored.tier == "hot"
+        assert restored.project_id == project.id
+
+        restored_projects = await storage.list_projects()
+        assert [p.name for p in restored_projects] == ["live-project"]

--- a/tests/unit/test_training_resume.py
+++ b/tests/unit/test_training_resume.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from surreal_memory.storage.sqlite_training_files import compute_file_hash
+from surreal_memory.utils.file_hash import compute_file_hash
 
 
 class TestComputeFileHash:


### PR DESCRIPTION
Second of the audit-driven cleanups. Setting out to deprecate the SQLite backend
meant documenting export → switch backend → import as the way off it, so the
first job was checking that path actually carries the data. It did not. Two
data-loss defects came out of that, and they are the bulk of this PR; the
deprecation itself is the smaller half.

## Snapshots dropped typed memories and projects on SurrealDB

Typed memories and projects live in their own tables rather than as neurons, and
`export_brain` only collected neurons, synapses and fibers. Every caller of the
snapshot moved the graph while losing what makes it memory:

| Callers | What was lost |
|---|---|
| `smem export` / `smem import` | memory type, priority, tags |
| `smem brain export` / `import` | trust score, source, expiry, tier |
| multi-device sync (`smem sync`) | validity window, supersession, project scoping |

`import_brain` likewise ignored the `typed_memories` / `projects` keys that a
SQLite-produced snapshot does carry, so migrating from SQLite would have kept
the neurons and dropped everything that classified them.

Both sides now round-trip through `TypedMemory.to_dict()` / `from_dict()`. A
brain still on a schema without those tables exports without them and logs which
part is missing, rather than failing outright — verified by the existing v7
upgrade integration test.

### Three copies of the same serialization

The record building lived in three hand-rolled implementations (SQLite,
InMemory, and the SurrealDB metadata payload), each frozen at the moment it was
written. The SQLite and InMemory importers rebuilt only the fields that existed
back then, so `trust_score`, `source`, `tier`, `valid_from`, `valid_until` and
`superseded_by` were discarded on **every** import, on every backend. One
implementation on the model fixes all three and stays correct as fields are
added. `Provenance` grows a matching `to_dict()`.

## `clear()` wiped nine tables out of twenty-seven

The table list was written by hand inside `clear()` and drifted as tables were
added. Rows in `project`, `source`, `entity_refs`, `co_activations`,
`depth_priors`, `tool_events` and the trace tables outlived their brain, and
since nothing else deletes by `brain_id`, they accumulated permanently — after a
version rollback, a transplant, an `import --replace`, or a brain deletion.

`clear()` now walks a single list of brain-scoped tables, and a test pins that
list to the `DEFINE FIELD brain_id` declarations in `schema.py`, so it cannot
drift again.

## Deprecating SQLite

`storage_backend` still defaults to `"sqlite"`, so an install that never sets
the variable writes to a local file the dashboard does not read. 3.0.0 removes
the backend; this release gives it a cycle to migrate:

- resolving to SQLite raises a `DeprecationWarning` next to the existing log
  warning, both naming the way out
- `smem doctor` gains a **Storage backend** check reporting the active backend
- `"memory"` becomes a valid backend instead of an unknown value that quietly
  fell back to SQLite — which is what `docker-compose.yml` has been asking for
  all along. It persists nothing and says so on first use.
- shared code moves out of the SQLite modules so the removal is a pure deletion:
  provenance serialization onto the model, file hashing to `utils/file_hash.py`,
  and `/health` now reports the schema version of the backend in use instead of
  the SQLite migration number it reported even on SurrealDB
- `docs/guides/migrating-to-3.0.md` covers the procedure, states what a snapshot
  does and does not carry, and documents that 3.0.0 never touches existing `.db`
  files — downgrading to 2.x restores them intact

## Verification

- `make verify` green: lint, format, mypy (375 files), security, and the full
  suite — 7182 passed, 44 skipped, 1 xfailed, coverage 72.20% against the 67% gate
- new unit tests: full-field round trip, a snapshot written before the newer
  fields existed still imports, an unparseable timestamp does not raise, and the
  cleared-table list matches the schema
- new live test (`SURREALDB_URL`-gated, skipped in CI) proving typed memories and
  projects survive export → import on SurrealDB; run against a real server, and
  the database is left with no leftover rows afterwards
- the v7 upgrade integration test covers the older-schema export path

Ships as 2.21.0.