### PR TITLE
ci: fail the build on modules nothing can reach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Run ruff format check
         run: ruff format --check src/ tests/
 
+      # Reads the source tree only — no install needed, and ruff cannot see
+      # this class of dead code because a test importing a module counts as an
+      # import.
+      - name: Check for unreachable modules
+        run: python scripts/check_dead_modules.py --strict
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-dev lint format typecheck test test-cov security audit check clean build docs gen-docs serve
+.PHONY: install install-dev lint format typecheck test test-cov security audit audit-dead check clean build docs gen-docs serve
 
 # Install package
 install:
@@ -41,6 +41,10 @@ security:
 # Preview extended rules (non-blocking audit)
 audit:
 	ruff check src/ tests/ --select S,A,DTZ,T20,PT,PERF,PIE,ERA --statistics || true
+
+# Modules nothing outside tests/ can reach (ruff's F401 cannot see these)
+audit-dead:
+	python scripts/check_dead_modules.py
 
 # Format check (no changes, just verify — matches CI)
 format-check:

--- a/scripts/check_dead_modules.py
+++ b/scripts/check_dead_modules.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Report modules that nothing but their own tests imports.
+
+Usage:
+    python scripts/check_dead_modules.py            # report, exit 0
+    python scripts/check_dead_modules.py --strict   # exit 1 if anything is dead
+
+Ruff cannot see this class of dead code: a module imported by the test written
+for it *is* imported, so F401 stays quiet while nothing in the product reaches
+it. Three such modules shipped for months before an audit found them.
+
+Reachability is computed from the points where execution actually starts —
+console scripts in ``pyproject.toml``, ``__main__`` modules, dotted paths in
+string literals (uvicorn targets, ``importlib`` lookups), and anything an
+example, benchmark or script imports — then followed through the import graph.
+Lazy imports inside functions count, which matters here because optional
+dependencies are loaded that way throughout. ``tests/`` is not a root: a module
+that only its own test reaches is exactly what this looks for.
+
+**Scope.** This finds unreachable *modules*. It does not find a module that is
+imported but whose symbols nobody calls — ``storage/factory.py`` is imported by
+its package ``__init__`` and so counts as reachable, even though
+``create_storage`` has no caller. Catching that needs symbol-level analysis.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PACKAGE = "surreal_memory"
+SRC = ROOT / "src"
+PACKAGE_ROOT = SRC / PACKAGE
+
+#: Directories whose imports keep a module alive. `tests/` is deliberately absent.
+SCAN_ROOTS = ("src", "examples", "scripts", "benchmarks", "qa")
+
+#: Never reported: package markers and `python -m` entry points.
+_EXEMPT_BASENAMES = frozenset({"__init__.py", "__main__.py"})
+
+_DOTTED = re.compile(rf"{PACKAGE}(?:\.[A-Za-z_][A-Za-z0-9_]*)+")
+
+
+def _module_name(path: Path) -> str:
+    return ".".join(path.relative_to(SRC).with_suffix("").parts)
+
+
+def _all_modules() -> dict[str, Path]:
+    return {
+        _module_name(p): p
+        for p in sorted(PACKAGE_ROOT.rglob("*.py"))
+        if p.name not in _EXEMPT_BASENAMES
+    }
+
+
+def _scan_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SCAN_ROOTS:
+        directory = ROOT / root
+        if directory.is_dir():
+            files.extend(sorted(directory.rglob("*.py")))
+    return files
+
+
+def _imports_in(path: Path, tree: ast.AST) -> set[str]:
+    """Every ``surreal_memory.*`` module path this file imports."""
+    found: set[str] = set()
+
+    own_module = _module_name(path) if path.is_relative_to(SRC) else ""
+    own_package = own_module.rsplit(".", 1)[0] if "." in own_module else PACKAGE
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith(PACKAGE):
+                    found.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                parts = own_package.split(".")
+                base = ".".join(parts[: max(len(parts) - node.level + 1, 1)])
+                module = f"{base}.{node.module}" if node.module else base
+            else:
+                module = node.module or ""
+            if not module.startswith(PACKAGE):
+                continue
+            found.add(module)
+            # `from pkg import submodule` imports a module, not an attribute.
+            for alias in node.names:
+                found.add(f"{module}.{alias.name}")
+    return found
+
+
+def _string_references(parsed: dict[Path, ast.AST]) -> set[str]:
+    """Dotted paths inside string literals — uvicorn targets and friends.
+
+    String *literals* only, never raw file text: an ``import`` line is text
+    too, so scanning source verbatim would mark every imported module as
+    externally referenced and quietly defeat the whole check.
+    """
+    found: set[str] = set()
+    for tree in parsed.values():
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                found.update(_DOTTED.findall(node.value.replace(":", ".")))
+    return found
+
+
+def _console_script_modules() -> set[str]:
+    try:
+        data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return set()
+    targets = data.get("project", {}).get("scripts", {}).values()
+    return {str(target).split(":", 1)[0] for target in targets}
+
+
+def find_dead_modules() -> list[str]:
+    modules = _all_modules()
+
+    parsed: dict[Path, ast.AST] = {}
+    for path in _scan_files():
+        try:
+            parsed[path] = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, SyntaxError):
+            continue
+
+    # Import graph over the package, plus the roots execution actually starts from.
+    edges: dict[str, set[str]] = {}
+    roots: set[str] = set(_console_script_modules()) | _string_references(parsed)
+
+    for path, tree in parsed.items():
+        inside_package = path.is_relative_to(PACKAGE_ROOT)
+        importer = _module_name(path) if inside_package else ""
+        targets = _imports_in(path, tree)
+        if inside_package:
+            edges.setdefault(importer, set()).update(targets)
+            if path.name in _EXEMPT_BASENAMES:
+                # `python -m pkg` and package import both execute these.
+                roots.add(importer)
+        else:
+            # An example, benchmark or script reaching in is an external caller.
+            roots |= targets
+
+    reachable: set[str] = set()
+    queue = [r for r in roots]
+    while queue:
+        current = queue.pop()
+        if current in reachable:
+            continue
+        reachable.add(current)
+        queue.extend(edges.get(current, ()))
+        # Importing a module runs its package's __init__, which may pull in more.
+        package_init = f"{current.rsplit('.', 1)[0]}.__init__" if "." in current else ""
+        if package_init and package_init not in reachable:
+            queue.append(package_init)
+
+    return sorted(name for name in modules if name not in reachable)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Report unreachable modules")
+    parser.add_argument("--strict", action="store_true", help="Exit 1 when anything is dead")
+    args = parser.parse_args()
+
+    dead = find_dead_modules()
+    if not dead:
+        print("No unreachable modules.")
+        return
+
+    print(f"{len(dead)} module(s) reachable only from tests, if at all:")
+    for name in dead:
+        print(f"  {name}")
+    print()
+    print("Delete them, wire them up, or — if something reaches them by a name this")
+    print("check cannot see — make that reference visible.")
+    sys.exit(1 if args.strict else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_check_dead_modules.py
+++ b/tests/unit/test_check_dead_modules.py
@@ -1,0 +1,103 @@
+"""The dead-module guard has to catch what ruff cannot, without false alarms.
+
+Both directions matter. A guard that misses test-only modules is pointless; one
+that flags live code gets switched off within a week. The cases below are the
+import shapes this codebase actually uses.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "check_dead_modules.py"
+
+
+@pytest.fixture(scope="module")
+def guard():  # type: ignore[no-untyped-def]
+    spec = importlib.util.spec_from_file_location("check_dead_modules", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_dead_modules"] = module
+    spec.loader.exec_module(module)
+    yield module
+    sys.modules.pop("check_dead_modules", None)
+
+
+def _imports(guard, source: str, module_path: str = "surreal_memory/thing.py") -> set[str]:  # type: ignore[no-untyped-def]
+    path = guard.SRC / module_path
+    return guard._imports_in(path, ast.parse(source))
+
+
+class TestImportDetection:
+    def test_plain_import(self, guard) -> None:  # type: ignore[no-untyped-def]
+        assert "surreal_memory.engine.retrieval" in _imports(
+            guard, "import surreal_memory.engine.retrieval"
+        )
+
+    def test_from_import_of_a_submodule(self, guard) -> None:  # type: ignore[no-untyped-def]
+        assert "surreal_memory.storage.base" in _imports(
+            guard, "from surreal_memory.storage import base"
+        )
+
+    def test_import_nested_in_a_function(self, guard) -> None:  # type: ignore[no-untyped-def]
+        # Optional dependencies are loaded this way throughout the codebase, so
+        # a guard that only looked at module level would call them all dead.
+        source = "def load():\n    from surreal_memory.adapters import langchain\n"
+
+        assert "surreal_memory.adapters.langchain" in _imports(guard, source)
+
+    def test_relative_import(self, guard) -> None:  # type: ignore[no-untyped-def]
+        found = _imports(
+            guard,
+            "from .store import SurrealDBStorage",
+            module_path="surreal_memory/storage/surrealdb/typed_memory.py",
+        )
+
+        assert "surreal_memory.storage.surrealdb.store" in found
+
+    def test_unrelated_imports_are_ignored(self, guard) -> None:  # type: ignore[no-untyped-def]
+        assert _imports(guard, "import json\nfrom pathlib import Path") == set()
+
+
+class TestStringReferences:
+    def test_a_dotted_target_in_a_literal_counts(self, guard) -> None:  # type: ignore[no-untyped-def]
+        # How the server is actually started: uvicorn.run("...:create_app").
+        tree = ast.parse('uvicorn.run("surreal_memory.server.app:create_app")')
+
+        assert "surreal_memory.server.app.create_app" in guard._string_references({Path("x"): tree})
+
+    def test_an_import_statement_is_not_a_string_reference(self, guard) -> None:  # type: ignore[no-untyped-def]
+        # Scanning raw file text instead of literals would match the import line
+        # itself, marking every imported module as externally referenced and
+        # silently disabling the whole check.
+        tree = ast.parse("from surreal_memory.storage.factory import create_storage")
+
+        assert guard._string_references({Path("x"): tree}) == set()
+
+
+class TestConsoleScripts:
+    def test_entry_points_come_from_pyproject(self, guard) -> None:  # type: ignore[no-untyped-def]
+        modules = guard._console_script_modules()
+
+        assert "surreal_memory.cli" in modules
+        assert "surreal_memory.hooks.pre_compact" in modules
+
+
+class TestAgainstTheRealTree:
+    def test_the_package_has_no_unreachable_modules(self, guard) -> None:  # type: ignore[no-untyped-def]
+        dead = guard.find_dead_modules()
+
+        assert dead == [], f"unreachable modules: {dead}"
+
+    def test_router_modules_are_not_false_positives(self, guard) -> None:  # type: ignore[no-untyped-def]
+        # Route modules are reached only through their package __init__, which
+        # app.py imports. A one-hop rule reports all of them; reachability does
+        # not.
+        dead = guard.find_dead_modules()
+
+        assert not [name for name in dead if ".server.routes." in name]


### PR DESCRIPTION
Fifth of the audit-driven cleanups, and the one that stops the first from
happening again.

## The gap

Three modules — `engine/fuzzy_query.py`, `extraction/llm_provider.py` and
`integrations/nanobot/protocol.py` — shipped for months with no caller anywhere
in the product. Ruff never saw them, and could not: each had a test written for
it, and a module imported by its own test is, as far as `F401` is concerned,
imported.

## The check

`scripts/check_dead_modules.py` computes reachability from the points where
execution actually begins:

- console scripts declared in `pyproject.toml`
- `__main__` modules
- dotted paths inside **string literals** — that is how uvicorn is handed the app
- anything an example, benchmark or script imports

then follows the import graph. `tests/` is deliberately not a root: a module
that only its own test reaches is precisely what this looks for.

## Verified in both directions

A guard that reports nothing proves nothing — a broken one behaves identically.
So it was run against the tree as it stood **before** those three modules were
deleted (`e053608`, in a throwaway worktree):

```
3 module(s) reachable only from tests, if at all:
  surreal_memory.engine.fuzzy_query
  surreal_memory.extraction.llm_provider
  surreal_memory.integrations.nanobot.protocol
```

Against `main`: `No unreachable modules.`

## Two drafts that looked fine and were not

Both are pinned by tests now, because both would have been invisible.

**Raw-text scanning silently disabled the whole check.** String references were
first matched against raw file text, to catch targets passed as strings. But an
`import` line is text too — so every module imported anywhere counted as
"externally referenced", and the check reduced to reporting nothing, forever. It
passed on `main` and would have kept passing. Literals now come from the parsed
AST.

**A one-hop rule flagged live code.** "Its only importer is its own package
`__init__`" named every `server/routes/*` module — all of which are reached
through `routes/__init__.py`, which `app.py` imports. Full reachability does not
make that mistake.

A third detail worth stating: lazy imports inside functions must count. Optional
dependencies are resolved at call time throughout this codebase, so a
module-level-only scan would declare most of `integration/` dead.

## Scope, stated in the script

This finds unreachable **modules**, not unused symbols. `storage/factory.py` is
imported by its package `__init__` and therefore counts as reachable, even
though `create_storage` has no caller — catching that needs symbol-level
analysis. The docstring says so rather than implying wider coverage than it has.
That particular module goes away with the SQLite backend anyway.

## Wiring

Runs in the **Lint** job, strict from the start since `main` is clean today. It
only reads the source tree, so it needs no install step — confirmed with the
system interpreter. Locally: `make audit-dead`.

## Verification

- `make verify` green — 7197 passed, coverage 72.19% against the 67% gate
- 10 new tests covering both directions and each import shape in use