### PR TITLE
fix: InMemoryStorage implements the full interface, 19 tests migrate off SQLite

### DIFF
--- a/src/surreal_memory/core/sync_records.py
+++ b/src/surreal_memory/core/sync_records.py
@@ -1,0 +1,40 @@
+"""Records exchanged by multi-device sync, independent of any backend.
+
+These describe the sync contract itself — what a registered device is, and what
+a single logged change looks like — so every storage backend and the sync
+engine speak the same shapes. They lived in the SQLite mixins only because that
+backend defined them first.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DeviceRecord:
+    """A registered device for a brain."""
+
+    device_id: str
+    brain_id: str
+    device_name: str
+    last_sync_at: datetime | None
+    last_sync_sequence: int
+    registered_at: datetime
+
+
+@dataclass(frozen=True)
+class ChangeEntry:
+    """A single change log entry."""
+
+    id: int  # Auto-incremented sequence number
+    brain_id: str
+    entity_type: str  # "neuron", "synapse", "fiber"
+    entity_id: str
+    operation: str  # "insert", "update", "delete"
+    device_id: str
+    changed_at: datetime
+    payload: dict[str, Any] = field(default_factory=dict)
+    synced: bool = False

--- a/src/surreal_memory/storage/memory_collections.py
+++ b/src/surreal_memory/storage/memory_collections.py
@@ -81,6 +81,9 @@ class InMemoryCollectionsMixin:
         tags: set[str] | None = None,
     ) -> list[Fiber]:
         """Find fibers containing any of the given neurons from in-memory store."""
+        if not neuron_ids:
+            return []
+
         brain_id = self._get_brain_id()
         nid_set = set(neuron_ids)
         seen: set[str] = set()
@@ -98,7 +101,9 @@ class InMemoryCollectionsMixin:
             result.append(fiber)
 
         result.sort(key=lambda f: f.salience, reverse=True)
-        return result
+        # Mirrors SQLite's total_limit = limit_per_neuron * len(neuron_ids).
+        total_limit = limit_per_neuron * len(neuron_ids)
+        return result[:total_limit]
 
     async def update_fiber(self, fiber: Fiber) -> None:
         brain_id = self._get_brain_id()

--- a/src/surreal_memory/storage/memory_knowledge.py
+++ b/src/surreal_memory/storage/memory_knowledge.py
@@ -205,6 +205,11 @@ class InMemoryKnowledgeMixin:
         )
         return alert.id
 
+    async def get_alert(self, alert_id: str) -> Alert | None:
+        """Get a single alert by ID within the current brain."""
+        brain_id = self._get_brain_id()
+        return self._alerts.get(brain_id, {}).get(alert_id)
+
     async def get_active_alerts(self, limit: int = 50) -> list[Alert]:
         """Get active/seen/acknowledged alerts (not resolved)."""
         brain_id = self._get_brain_id()

--- a/src/surreal_memory/storage/memory_knowledge.py
+++ b/src/surreal_memory/storage/memory_knowledge.py
@@ -1,0 +1,473 @@
+"""In-memory knowledge storage mixin — sources, alerts, cognitive state, knowledge gaps."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import timedelta
+from typing import Any
+from uuid import uuid4
+
+from surreal_memory.core.alert import Alert, AlertStatus
+from surreal_memory.core.source import Source, SourceStatus
+from surreal_memory.core.synapse import Synapse, SynapseType
+from surreal_memory.utils.timeutils import utcnow
+
+_ALERT_DEDUP_COOLDOWN = timedelta(hours=6)
+
+_MAX_SOURCE_LIMIT = 1_000
+_MAX_ALERT_LIMIT = 200
+_MAX_LIST_LIMIT = 200
+_TOPIC_MAX_LEN = 500
+
+_VISIBLE_ALERT_STATUSES = (AlertStatus.ACTIVE, AlertStatus.SEEN, AlertStatus.ACKNOWLEDGED)
+_PENDING_ALERT_STATUSES = (AlertStatus.ACTIVE, AlertStatus.SEEN)
+
+_SEVERITY_RANK = {"critical": 0, "high": 1, "medium": 2}
+_UNRANKED_SEVERITY = 3
+
+_COGNITIVE_LIST_KEYS = (
+    "neuron_id",
+    "confidence",
+    "evidence_for_count",
+    "evidence_against_count",
+    "status",
+    "predicted_at",
+    "resolved_at",
+    "last_evidence_at",
+    "created_at",
+)
+
+
+def _clamp_confidence(value: float) -> float:
+    """Clamp a confidence score into the persisted [0.01, 0.99] range."""
+    return max(0.01, min(0.99, value))
+
+
+def _clamp_priority(value: float) -> float:
+    """Clamp a knowledge-gap priority into the persisted [0.0, 1.0] range."""
+    return max(0.0, min(1.0, value))
+
+
+def _project_cognitive(state: dict[str, Any]) -> dict[str, Any]:
+    """Project a stored cognitive state onto the list/prediction column subset."""
+    return {key: state[key] for key in _COGNITIVE_LIST_KEYS}
+
+
+def _copy_gap(gap: dict[str, Any]) -> dict[str, Any]:
+    """Return a defensive copy of a stored knowledge gap."""
+    copied = dict(gap)
+    copied["related_neuron_ids"] = list(gap["related_neuron_ids"])
+    return copied
+
+
+class InMemoryKnowledgeMixin:
+    """Mixin providing source registry, alert, cognitive state, and knowledge-gap CRUD."""
+
+    # Declared in InMemoryStorage.__init__
+    _sources: dict[str, dict[str, Source]]
+    _alerts: dict[str, dict[str, Alert]]
+    _cognitive_states: dict[str, dict[str, dict[str, Any]]]
+    _knowledge_gaps: dict[str, dict[str, dict[str, Any]]]
+    _synapses: dict[str, dict[str, Synapse]]
+
+    def _get_brain_id(self) -> str:
+        raise NotImplementedError
+
+    # ========== Source Registry ==========
+
+    async def add_source(self, source: Source) -> str:
+        """Insert a source record. Returns the source ID."""
+        # Keyed by source.brain_id, not the active brain — mirrors the SQLite INSERT.
+        if source.brain_id not in self._sources:
+            self._sources[source.brain_id] = {}
+        self._sources[source.brain_id][source.id] = source
+        return source.id
+
+    async def get_source(self, source_id: str) -> Source | None:
+        """Get a source by ID within the current brain."""
+        brain_id = self._get_brain_id()
+        return self._sources.get(brain_id, {}).get(source_id)
+
+    async def find_source_by_name(self, name: str) -> Source | None:
+        """Find a source by exact name within the current brain."""
+        brain_id = self._get_brain_id()
+        for source in self._sources.get(brain_id, {}).values():
+            if source.name == name:
+                return source
+        return None
+
+    async def list_sources(
+        self,
+        source_type: str | None = None,
+        status: str | None = None,
+        limit: int = 100,
+    ) -> list[Source]:
+        """List sources for the current brain, with optional filters."""
+        brain_id = self._get_brain_id()
+        safe_limit = min(limit, _MAX_SOURCE_LIMIT)
+
+        results: list[Source] = []
+        for source in self._sources.get(brain_id, {}).values():
+            if source_type is not None and source.source_type.value != source_type:
+                continue
+            if status is not None and source.status.value != status:
+                continue
+            results.append(source)
+
+        results.sort(key=lambda s: s.created_at, reverse=True)
+        return results[:safe_limit]
+
+    async def update_source(
+        self,
+        source_id: str,
+        status: str | None = None,
+        version: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        trust: float | None = None,
+    ) -> bool:
+        """Update a source. Returns True if the row was modified."""
+        new_status: SourceStatus | None = None
+        if status is not None:
+            try:
+                new_status = SourceStatus(status)
+            except ValueError:
+                raise ValueError(
+                    f"Invalid status: {status!r}. Must be one of {[s.value for s in SourceStatus]}"
+                )
+
+        brain_id = self._get_brain_id()
+        sources = self._sources.get(brain_id, {})
+        source = sources.get(source_id)
+        if source is None:
+            return False
+
+        changes: dict[str, Any] = {"updated_at": utcnow()}
+        if new_status is not None:
+            changes["status"] = new_status
+        if version is not None:
+            changes["version"] = version
+        if metadata is not None:
+            changes["metadata"] = dict(metadata)
+        if trust is not None:
+            changes["trust"] = trust
+
+        sources[source_id] = replace(source, **changes)
+        return True
+
+    async def delete_source(self, source_id: str) -> bool:
+        """Delete a source. Returns True if deleted."""
+        brain_id = self._get_brain_id()
+        sources = self._sources.get(brain_id, {})
+        if source_id in sources:
+            del sources[source_id]
+            return True
+        return False
+
+    async def count_neurons_for_source(self, source_id: str) -> int:
+        """Count neurons linked to a source via SOURCE_OF synapses."""
+        brain_id = self._get_brain_id()
+        targets = {
+            synapse.target_id
+            for synapse in self._synapses.get(brain_id, {}).values()
+            if synapse.source_id == source_id and synapse.type == SynapseType.SOURCE_OF
+        }
+        return len(targets)
+
+    # ========== Alerts ==========
+
+    async def record_alert(self, alert: Alert) -> str:
+        """Insert a new alert, respecting the dedup cooldown.
+
+        Returns the alert ID if inserted, empty string if suppressed.
+        """
+        brain_id = self._get_brain_id()
+        if brain_id not in self._alerts:
+            self._alerts[brain_id] = {}
+        alerts = self._alerts[brain_id]
+
+        cutoff = utcnow() - _ALERT_DEDUP_COOLDOWN
+        for existing in alerts.values():
+            if existing.alert_type != alert.alert_type:
+                continue
+            if existing.status not in _PENDING_ALERT_STATUSES:
+                continue
+            if existing.created_at > cutoff:
+                return ""
+
+        # Lifecycle timestamps are not persisted on insert — mirrors the SQLite INSERT columns.
+        alerts[alert.id] = replace(
+            alert,
+            brain_id=brain_id,
+            seen_at=None,
+            acknowledged_at=None,
+            resolved_at=None,
+            metadata=dict(alert.metadata),
+        )
+        return alert.id
+
+    async def get_active_alerts(self, limit: int = 50) -> list[Alert]:
+        """Get active/seen/acknowledged alerts (not resolved)."""
+        brain_id = self._get_brain_id()
+        safe_limit = min(limit, _MAX_ALERT_LIMIT)
+
+        visible = [
+            alert
+            for alert in self._alerts.get(brain_id, {}).values()
+            if alert.status in _VISIBLE_ALERT_STATUSES
+        ]
+        visible.sort(key=lambda a: a.created_at, reverse=True)
+        visible.sort(key=lambda a: _SEVERITY_RANK.get(a.severity, _UNRANKED_SEVERITY))
+        return visible[:safe_limit]
+
+    async def count_pending_alerts(self) -> int:
+        """Count active + seen alerts (not acknowledged or resolved)."""
+        brain_id = self._get_brain_id()
+        return sum(
+            1
+            for alert in self._alerts.get(brain_id, {}).values()
+            if alert.status in _PENDING_ALERT_STATUSES
+        )
+
+    async def mark_alert_acknowledged(self, alert_id: str) -> bool:
+        """Mark a single alert as acknowledged. Returns True if updated."""
+        brain_id = self._get_brain_id()
+        alerts = self._alerts.get(brain_id, {})
+        alert = alerts.get(alert_id)
+        if alert is None or alert.status not in _PENDING_ALERT_STATUSES:
+            return False
+
+        alerts[alert_id] = replace(alert, status=AlertStatus.ACKNOWLEDGED, acknowledged_at=utcnow())
+        return True
+
+    async def mark_alerts_seen(self, alert_ids: list[str]) -> int:
+        """Mark alerts as seen. Returns count of updated rows."""
+        if not alert_ids:
+            return 0
+
+        brain_id = self._get_brain_id()
+        alerts = self._alerts.get(brain_id, {})
+        now = utcnow()
+
+        updated = 0
+        for alert_id in alert_ids:
+            alert = alerts.get(alert_id)
+            if alert is None or alert.status != AlertStatus.ACTIVE:
+                continue
+            alerts[alert_id] = replace(alert, status=AlertStatus.SEEN, seen_at=now)
+            updated += 1
+        return updated
+
+    async def resolve_alerts_by_type(self, alert_types: list[str]) -> int:
+        """Resolve all active/seen alerts of given types. Returns count."""
+        if not alert_types:
+            return 0
+
+        brain_id = self._get_brain_id()
+        alerts = self._alerts.get(brain_id, {})
+        wanted = set(alert_types)
+        now = utcnow()
+
+        updated = 0
+        for alert_id, alert in list(alerts.items()):
+            if alert.alert_type.value not in wanted:
+                continue
+            if alert.status not in _PENDING_ALERT_STATUSES:
+                continue
+            alerts[alert_id] = replace(alert, status=AlertStatus.RESOLVED, resolved_at=now)
+            updated += 1
+        return updated
+
+    # ========== Cognitive State ==========
+
+    async def upsert_cognitive_state(
+        self,
+        neuron_id: str,
+        *,
+        confidence: float = 0.5,
+        evidence_for_count: int = 0,
+        evidence_against_count: int = 0,
+        status: str = "active",
+        predicted_at: str | None = None,
+        resolved_at: str | None = None,
+        schema_version: int = 1,
+        parent_schema_id: str | None = None,
+        last_evidence_at: str | None = None,
+    ) -> None:
+        """Insert or update a cognitive state record."""
+        brain_id = self._get_brain_id()
+        if brain_id not in self._cognitive_states:
+            self._cognitive_states[brain_id] = {}
+        states = self._cognitive_states[brain_id]
+        existing = states.get(neuron_id)
+
+        states[neuron_id] = {
+            "neuron_id": neuron_id,
+            "confidence": _clamp_confidence(confidence),
+            "evidence_for_count": evidence_for_count,
+            "evidence_against_count": evidence_against_count,
+            "status": status,
+            "predicted_at": predicted_at,
+            "resolved_at": resolved_at,
+            "schema_version": schema_version,
+            "parent_schema_id": parent_schema_id,
+            "last_evidence_at": last_evidence_at,
+            "created_at": existing["created_at"] if existing else utcnow().isoformat(),
+        }
+
+    async def get_cognitive_state(self, neuron_id: str) -> dict[str, Any] | None:
+        """Get cognitive state for a neuron."""
+        brain_id = self._get_brain_id()
+        state = self._cognitive_states.get(brain_id, {}).get(neuron_id)
+        return dict(state) if state is not None else None
+
+    async def list_cognitive_states(
+        self,
+        *,
+        status: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """List cognitive states, optionally filtered by status."""
+        brain_id = self._get_brain_id()
+        capped_limit = min(limit, _MAX_LIST_LIMIT)
+
+        matching = [
+            state
+            for state in self._cognitive_states.get(brain_id, {}).values()
+            if not status or state["status"] == status
+        ]
+        matching.sort(key=lambda s: s["confidence"], reverse=True)
+        return [_project_cognitive(s) for s in matching[:capped_limit]]
+
+    async def update_cognitive_evidence(
+        self,
+        neuron_id: str,
+        *,
+        confidence: float,
+        evidence_for_count: int,
+        evidence_against_count: int,
+        status: str,
+        resolved_at: str | None = None,
+        last_evidence_at: str | None = None,
+    ) -> None:
+        """Update only evidence-related fields of a cognitive state.
+
+        Unlike upsert_cognitive_state, this preserves predicted_at,
+        schema_version, parent_schema_id, and created_at unchanged.
+        """
+        brain_id = self._get_brain_id()
+        state = self._cognitive_states.get(brain_id, {}).get(neuron_id)
+        if state is None:
+            return
+
+        state["confidence"] = _clamp_confidence(confidence)
+        state["evidence_for_count"] = evidence_for_count
+        state["evidence_against_count"] = evidence_against_count
+        state["status"] = status
+        state["resolved_at"] = resolved_at
+        state["last_evidence_at"] = last_evidence_at
+
+    async def list_predictions(
+        self,
+        *,
+        status: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """List predictions (cognitive states with predicted_at set)."""
+        brain_id = self._get_brain_id()
+        capped_limit = min(limit, _MAX_LIST_LIMIT)
+
+        matching = [
+            state
+            for state in self._cognitive_states.get(brain_id, {}).values()
+            if state["predicted_at"] is not None and (not status or state["status"] == status)
+        ]
+        matching.sort(key=lambda s: str(s["predicted_at"]))
+        return [_project_cognitive(s) for s in matching[:capped_limit]]
+
+    async def get_calibration_stats(self) -> dict[str, int]:
+        """Get prediction calibration statistics."""
+        brain_id = self._get_brain_id()
+        stats = {"correct_count": 0, "wrong_count": 0, "total_resolved": 0, "pending_count": 0}
+
+        for state in self._cognitive_states.get(brain_id, {}).values():
+            if state["predicted_at"] is None:
+                continue
+            state_status = state["status"]
+            if state_status == "confirmed":
+                stats["correct_count"] += 1
+                stats["total_resolved"] += 1
+            elif state_status == "refuted":
+                stats["wrong_count"] += 1
+                stats["total_resolved"] += 1
+            elif state_status == "pending":
+                stats["pending_count"] += 1
+
+        return stats
+
+    # ========== Knowledge Gaps ==========
+
+    async def add_knowledge_gap(
+        self,
+        *,
+        topic: str,
+        detection_source: str,
+        priority: float = 0.5,
+        related_neuron_ids: list[str] | None = None,
+    ) -> str:
+        """Create a new knowledge gap record. Returns the generated gap ID."""
+        brain_id = self._get_brain_id()
+        if brain_id not in self._knowledge_gaps:
+            self._knowledge_gaps[brain_id] = {}
+        gap_id = str(uuid4())
+
+        self._knowledge_gaps[brain_id][gap_id] = {
+            "id": gap_id,
+            "topic": topic[:_TOPIC_MAX_LEN],
+            "detected_at": utcnow().isoformat(),
+            "detection_source": detection_source,
+            "related_neuron_ids": list(related_neuron_ids or []),
+            "resolved_at": None,
+            "resolved_by_neuron_id": None,
+            "priority": _clamp_priority(priority),
+        }
+        return gap_id
+
+    async def get_knowledge_gap(self, gap_id: str) -> dict[str, Any] | None:
+        """Get a single knowledge gap by ID."""
+        brain_id = self._get_brain_id()
+        gap = self._knowledge_gaps.get(brain_id, {}).get(gap_id)
+        return _copy_gap(gap) if gap is not None else None
+
+    async def list_knowledge_gaps(
+        self,
+        *,
+        include_resolved: bool = False,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """List knowledge gaps sorted by priority descending."""
+        brain_id = self._get_brain_id()
+        capped_limit = min(limit, _MAX_LIST_LIMIT)
+
+        matching = [
+            gap
+            for gap in self._knowledge_gaps.get(brain_id, {}).values()
+            if include_resolved or gap["resolved_at"] is None
+        ]
+        matching.sort(key=lambda g: g["priority"], reverse=True)
+        return [_copy_gap(g) for g in matching[:capped_limit]]
+
+    async def resolve_knowledge_gap(
+        self,
+        gap_id: str,
+        *,
+        resolved_by_neuron_id: str | None = None,
+    ) -> bool:
+        """Mark a knowledge gap as resolved. Returns True if it was open and got resolved."""
+        brain_id = self._get_brain_id()
+        gap = self._knowledge_gaps.get(brain_id, {}).get(gap_id)
+        if gap is None or gap["resolved_at"] is not None:
+            return False
+
+        gap["resolved_at"] = utcnow().isoformat()
+        gap["resolved_by_neuron_id"] = resolved_by_neuron_id
+        return True

--- a/src/surreal_memory/storage/memory_lifecycle_ops.py
+++ b/src/surreal_memory/storage/memory_lifecycle_ops.py
@@ -1,0 +1,389 @@
+"""In-memory lifecycle, compression, and hot-index storage mixin for testing."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta
+from typing import Any
+
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.memory_types import MemoryType, TypedMemory
+from surreal_memory.core.neuron import Neuron
+from surreal_memory.core.synapse import Synapse
+from surreal_memory.utils.timeutils import ensure_naive_utc, utcnow
+
+_MAX_HOT_SLOTS = 20
+_MAX_HOT_SUMMARY_CHARS = 500
+_MAX_PROMOTION_CANDIDATES = 200
+
+
+class InMemoryLifecycleMixin:
+    """Mixin providing compression, snapshot, lifecycle, and hot-index ops."""
+
+    # Declared in InMemoryStorage.__init__
+    _neurons: dict[str, dict[str, Neuron]]
+    _synapses: dict[str, dict[str, Synapse]]
+    _fibers: dict[str, dict[str, Fiber]]
+    _typed_memories: dict[str, dict[str, TypedMemory]]
+    _compression_backups: dict[str, dict[str, dict[str, Any]]]
+    _neuron_snapshots: dict[str, dict[str, dict[str, Any]]]
+    _hot_index: dict[str, list[dict[str, Any]]]
+    _cognitive_states: dict[str, dict[str, dict[str, Any]]]
+
+    def _get_brain_id(self) -> str:
+        raise NotImplementedError
+
+    async def delete_neuron(self, neuron_id: str) -> bool:
+        raise NotImplementedError
+
+    # ========== Compression Backups ==========
+
+    async def save_compression_backup(
+        self,
+        fiber_id: str,
+        original_content: str,
+        compression_tier: int,
+        original_token_count: int,
+        compressed_token_count: int,
+    ) -> None:
+        """Save (upsert) a pre-compression content backup for a fiber."""
+        brain_id = self._get_brain_id()
+        self._compression_backups.setdefault(brain_id, {})[fiber_id] = {
+            "fiber_id": fiber_id,
+            "brain_id": brain_id,
+            "original_content": original_content,
+            "compression_tier": compression_tier,
+            "compressed_at": utcnow().isoformat(),
+            "original_token_count": original_token_count,
+            "compressed_token_count": compressed_token_count,
+        }
+
+    async def get_compression_backup(self, fiber_id: str) -> dict[str, Any] | None:
+        """Retrieve the compression backup for a fiber, if any."""
+        brain_id = self._get_brain_id()
+        backup = self._compression_backups.get(brain_id, {}).get(fiber_id)
+        return dict(backup) if backup is not None else None
+
+    async def delete_compression_backup(self, fiber_id: str) -> bool:
+        """Delete the compression backup for a fiber."""
+        brain_id = self._get_brain_id()
+        backups = self._compression_backups.get(brain_id, {})
+        if fiber_id in backups:
+            del backups[fiber_id]
+            return True
+        return False
+
+    async def get_compression_stats(self) -> dict[str, Any]:
+        """Return aggregate compression statistics for the current brain."""
+        brain_id = self._get_brain_id()
+        backups = self._compression_backups.get(brain_id, {}).values()
+
+        counts: dict[int, int] = {}
+        originals: dict[int, int] = {}
+        compressed: dict[int, int] = {}
+        for backup in backups:
+            tier = int(backup["compression_tier"])
+            counts[tier] = counts.get(tier, 0) + 1
+            originals[tier] = originals.get(tier, 0) + int(backup["original_token_count"] or 0)
+            compressed[tier] = compressed.get(tier, 0) + int(backup["compressed_token_count"] or 0)
+
+        by_tier: dict[int, int] = {}
+        total_backups = 0
+        total_tokens_saved = 0
+        for tier in sorted(counts):
+            by_tier[tier] = counts[tier]
+            total_backups += counts[tier]
+            total_tokens_saved += max(0, originals[tier] - compressed[tier])
+
+        return {
+            "total_backups": total_backups,
+            "by_tier": by_tier,
+            "total_tokens_saved": total_tokens_saved,
+        }
+
+    # ========== Neuron Snapshots ==========
+
+    async def save_neuron_snapshot(
+        self,
+        neuron_id: str,
+        brain_id: str,
+        original_content: str,
+        compressed_at: str,
+        tier: int,
+    ) -> None:
+        """Save (upsert) a pre-compression content snapshot for a neuron."""
+        self._neuron_snapshots.setdefault(brain_id, {})[neuron_id] = {
+            "neuron_id": neuron_id,
+            "brain_id": brain_id,
+            "original_content": original_content,
+            "compressed_at": compressed_at,
+            "tier": tier,
+        }
+
+    async def get_neuron_snapshot(self, neuron_id: str) -> dict[str, Any] | None:
+        """Retrieve the snapshot for a neuron, if any."""
+        brain_id = self._get_brain_id()
+        snapshot = self._neuron_snapshots.get(brain_id, {}).get(neuron_id)
+        return dict(snapshot) if snapshot is not None else None
+
+    async def delete_neuron_snapshot(self, neuron_id: str) -> bool:
+        """Delete the snapshot for a neuron."""
+        brain_id = self._get_brain_id()
+        snapshots = self._neuron_snapshots.get(brain_id, {})
+        if neuron_id in snapshots:
+            del snapshots[neuron_id]
+            return True
+        return False
+
+    # ========== Lifecycle State and Neuron Flags ==========
+
+    async def update_neuron_lifecycle(self, neuron_id: str, lifecycle_state: str) -> None:
+        """Update the lifecycle_state for a neuron."""
+        brain_id = self._get_brain_id()
+        neuron = self._neurons.get(brain_id, {}).get(neuron_id)
+        if neuron is None:
+            return
+        self._neurons[brain_id][neuron_id] = neuron.with_metadata(lifecycle_state=lifecycle_state)
+
+    async def get_lifecycle_distribution(self) -> dict[str, int]:
+        """Return count of neurons by lifecycle_state for the current brain."""
+        brain_id = self._get_brain_id()
+        distribution: dict[str, int] = {}
+        for neuron in self._neurons.get(brain_id, {}).values():
+            state = str(neuron.metadata.get("lifecycle_state") or "active")
+            distribution[state] = distribution.get(state, 0) + 1
+        return distribution
+
+    async def update_neuron_ephemeral(self, neuron_id: str, ephemeral: bool) -> None:
+        """Set or clear the ephemeral flag for a neuron."""
+        brain_id = self._get_brain_id()
+        neuron = self._neurons.get(brain_id, {}).get(neuron_id)
+        if neuron is None:
+            return
+        self._neurons[brain_id][neuron_id] = replace(neuron, ephemeral=ephemeral)
+
+    async def update_neurons_ephemeral_batch(self, neuron_ids: list[str], ephemeral: bool) -> None:
+        """Batch-set ephemeral flag for multiple neurons."""
+        if not neuron_ids:
+            return
+        brain_id = self._get_brain_id()
+        neurons = self._neurons.get(brain_id, {})
+        for neuron_id in neuron_ids:
+            neuron = neurons.get(neuron_id)
+            if neuron is not None:
+                neurons[neuron_id] = replace(neuron, ephemeral=ephemeral)
+
+    async def cleanup_ephemeral_neurons(self, max_age_hours: float = 24.0) -> int:
+        """Delete ephemeral neurons older than max_age_hours."""
+        brain_id = self._get_brain_id()
+        cutoff = utcnow() - timedelta(hours=max_age_hours)
+
+        expired = [
+            neuron.id
+            for neuron in self._neurons.get(brain_id, {}).values()
+            if neuron.ephemeral and ensure_naive_utc(neuron.created_at) < cutoff
+        ]
+
+        deleted = 0
+        for neuron_id in expired:
+            if await self.delete_neuron(neuron_id):
+                deleted += 1
+        return deleted
+
+    async def update_neuron_frozen(self, neuron_id: str, frozen: bool) -> None:
+        """Set or clear the frozen flag for a neuron."""
+        brain_id = self._get_brain_id()
+        neuron = self._neurons.get(brain_id, {}).get(neuron_id)
+        if neuron is None:
+            return
+        self._neurons[brain_id][neuron_id] = neuron.with_metadata(frozen=frozen)
+
+    async def batch_update_ghost_shown(self, fiber_ids: list[str], timestamp: datetime) -> int:
+        """Batch update last_ghost_shown_at for multiple fibers."""
+        if not fiber_ids:
+            return 0
+        brain_id = self._get_brain_id()
+        fibers = self._fibers.get(brain_id, {})
+        for fiber_id in fiber_ids:
+            fiber = fibers.get(fiber_id)
+            if fiber is not None:
+                fibers[fiber_id] = replace(fiber, last_ghost_shown_at=timestamp)
+        # SQLite reports the requested count, not the number of rows actually matched.
+        return len(fiber_ids)
+
+    # ========== Hot Index ==========
+
+    async def refresh_hot_index(self, items: list[dict[str, Any]]) -> int:
+        """Replace the hot index with freshly scored items."""
+        brain_id = self._get_brain_id()
+        now = utcnow().isoformat()
+
+        rows: list[dict[str, Any]] = []
+        for item in items[:_MAX_HOT_SLOTS]:
+            rows.append(
+                {
+                    "slot": item["slot"],
+                    "category": item["category"],
+                    "neuron_id": item["neuron_id"],
+                    "summary": str(item["summary"])[:_MAX_HOT_SUMMARY_CHARS],
+                    "confidence": item.get("confidence"),
+                    "score": item["score"],
+                    "updated_at": now,
+                }
+            )
+
+        self._hot_index[brain_id] = rows
+        return len(rows)
+
+    async def get_hot_index(self, limit: int = 10) -> list[dict[str, Any]]:
+        """Get the current hot index items, sorted by score descending."""
+        brain_id = self._get_brain_id()
+        capped = min(limit, _MAX_HOT_SLOTS)
+        rows = sorted(
+            self._hot_index.get(brain_id, []),
+            key=lambda row: float(row["score"]),
+            reverse=True,
+        )
+        return [dict(row) for row in rows[:capped]]
+
+    # ========== Typed Memory Extras ==========
+
+    async def promote_memory_type(
+        self,
+        fiber_id: str,
+        new_type: MemoryType,
+        new_expires_at: str | None = None,
+    ) -> bool:
+        """Promote a memory's type and update its expiry."""
+        brain_id = self._get_brain_id()
+        typed_memories = self._typed_memories.get(brain_id, {})
+        typed_memory = typed_memories.get(fiber_id)
+        if typed_memory is None:
+            return False
+
+        old_type = str(typed_memory.memory_type.value)
+        if old_type == new_type.value:
+            return False
+
+        metadata = dict(typed_memory.metadata)
+        metadata["auto_promoted"] = True
+        metadata["promoted_from"] = old_type
+        metadata["promoted_at"] = utcnow().isoformat()
+
+        expires_at = (
+            ensure_naive_utc(datetime.fromisoformat(new_expires_at)) if new_expires_at else None
+        )
+        typed_memories[fiber_id] = replace(
+            typed_memory,
+            memory_type=new_type,
+            expires_at=expires_at,
+            metadata=metadata,
+        )
+        return True
+
+    async def update_typed_memory_source(self, fiber_id: str, source: str) -> bool:
+        """Update only the source field on a typed memory."""
+        brain_id = self._get_brain_id()
+        typed_memories = self._typed_memories.get(brain_id, {})
+        typed_memory = typed_memories.get(fiber_id)
+        if typed_memory is None:
+            return False
+        typed_memories[fiber_id] = replace(typed_memory, source=source)
+        return True
+
+    async def get_promotion_candidates(
+        self,
+        min_frequency: int = 5,
+        source_type: str = "context",
+    ) -> list[dict[str, Any]]:
+        """Find typed memories eligible for auto-promotion."""
+        brain_id = self._get_brain_id()
+        fibers = self._fibers.get(brain_id, {})
+
+        candidates: list[dict[str, Any]] = []
+        for typed_memory in self._typed_memories.get(brain_id, {}).values():
+            if str(typed_memory.memory_type.value) != source_type:
+                continue
+            fiber = fibers.get(typed_memory.fiber_id)
+            if fiber is None or fiber.frequency < min_frequency or fiber.pinned:
+                continue
+            candidates.append(
+                {
+                    "fiber_id": typed_memory.fiber_id,
+                    "memory_type": str(typed_memory.memory_type.value),
+                    "expires_at": typed_memory.expires_at,
+                    "metadata": dict(typed_memory.metadata),
+                    "frequency": fiber.frequency,
+                    "conductivity": fiber.conductivity,
+                }
+            )
+            if len(candidates) >= _MAX_PROMOTION_CANDIDATES:
+                break
+        return candidates
+
+    # ========== Merkle Buckets and Schema History ==========
+
+    async def get_bucket_entity_ids(
+        self, entity_type: str, prefix: str, *, is_pro: bool = False
+    ) -> list[str]:
+        """Return all entity IDs in the given bucket prefix for delete detection."""
+        if not is_pro:
+            return []
+
+        brain_id = self._get_brain_id()
+        entity_ids: list[str]
+        if entity_type == "neuron":
+            entity_ids = list(self._neurons.get(brain_id, {}))
+        elif entity_type == "synapse":
+            entity_ids = list(self._synapses.get(brain_id, {}))
+        elif entity_type == "fiber":
+            entity_ids = list(self._fibers.get(brain_id, {}))
+        else:
+            return []
+
+        parts = prefix.split("/")
+        if len(parts) != 2:
+            return []
+        hex_prefix = parts[1].lower()
+
+        return sorted(eid for eid in entity_ids if eid[:2].lower() == hex_prefix)
+
+    async def get_schema_history(
+        self,
+        neuron_id: str,
+        *,
+        max_depth: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Walk the version chain for a hypothesis, newest-first."""
+        brain_id = self._get_brain_id()
+        states = self._cognitive_states.get(brain_id, {})
+
+        history: list[dict[str, Any]] = []
+        current_id: str | None = neuron_id
+        seen: set[str] = set()
+
+        while current_id and len(history) < max_depth:
+            if current_id in seen:
+                break
+            seen.add(current_id)
+
+            state = states.get(current_id)
+            if state is None:
+                break
+
+            parent_raw = state.get("parent_schema_id")
+            history.append(
+                {
+                    "neuron_id": str(state.get("neuron_id", current_id)),
+                    "confidence": float(state.get("confidence", 0.5)),
+                    "evidence_for_count": int(state.get("evidence_for_count", 0)),
+                    "evidence_against_count": int(state.get("evidence_against_count", 0)),
+                    "status": str(state.get("status", "")),
+                    "schema_version": int(state.get("schema_version", 1)),
+                    "parent_schema_id": parent_raw,
+                    "created_at": state.get("created_at"),
+                }
+            )
+            current_id = str(parent_raw) if parent_raw is not None else None
+
+        return history

--- a/src/surreal_memory/storage/memory_store.py
+++ b/src/surreal_memory/storage/memory_store.py
@@ -15,19 +15,26 @@ from uuid import uuid4
 
 import networkx as nx
 
+from surreal_memory.core.alert import Alert
 from surreal_memory.core.brain import Brain
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.memory_types import TypedMemory
 from surreal_memory.core.neuron import Neuron, NeuronState, NeuronType
 from surreal_memory.core.project import Project
 from surreal_memory.core.retrieval_trace import RetrievalTrace
+from surreal_memory.core.source import Source
 from surreal_memory.core.synapse import Synapse, SynapseType
+from surreal_memory.core.sync_records import ChangeEntry, DeviceRecord
 from surreal_memory.engine.brain_versioning import BrainVersion
+from surreal_memory.engine.depth_prior import DepthPrior
 from surreal_memory.storage.base import NeuralStorage
 from surreal_memory.storage.memory_brain_ops import InMemoryBrainMixin
 from surreal_memory.storage.memory_collections import InMemoryCollectionsMixin
+from surreal_memory.storage.memory_knowledge import InMemoryKnowledgeMixin
+from surreal_memory.storage.memory_lifecycle_ops import InMemoryLifecycleMixin
 from surreal_memory.storage.memory_pinning import InMemoryPinningMixin
 from surreal_memory.storage.memory_reviews import InMemoryReviewsMixin
+from surreal_memory.storage.memory_sync_ops import InMemorySyncMixin
 from surreal_memory.utils.timeutils import utcnow
 
 
@@ -36,6 +43,9 @@ class InMemoryStorage(
     InMemoryCollectionsMixin,
     InMemoryPinningMixin,
     InMemoryBrainMixin,
+    InMemoryKnowledgeMixin,
+    InMemorySyncMixin,
+    InMemoryLifecycleMixin,
     NeuralStorage,
 ):
     """NetworkX-based in-memory storage for development and testing.
@@ -62,6 +72,18 @@ class InMemoryStorage(
         self._review_schedules: dict[str, dict[str, Any]] = defaultdict(dict)
         self._keyword_df: dict[str, dict[str, int]] = defaultdict(dict)
         self._entity_refs: dict[str, dict[str, list[str]]] = defaultdict(dict)
+        self._sources: dict[str, dict[str, Source]] = defaultdict(dict)
+        self._alerts: dict[str, dict[str, Alert]] = defaultdict(dict)
+        self._cognitive_states: dict[str, dict[str, dict[str, Any]]] = defaultdict(dict)
+        self._knowledge_gaps: dict[str, dict[str, dict[str, Any]]] = defaultdict(dict)
+        self._devices: dict[str, dict[str, DeviceRecord]] = defaultdict(dict)
+        self._change_log: dict[str, list[ChangeEntry]] = defaultdict(list)
+        self._change_log_seq: dict[str, int] = defaultdict(int)
+        self._merkle_hashes: dict[str, dict[str, dict[str, str]]] = defaultdict(dict)
+        self._depth_priors: dict[str, dict[str, dict[int, DepthPrior]]] = defaultdict(dict)
+        self._compression_backups: dict[str, dict[str, dict[str, Any]]] = defaultdict(dict)
+        self._neuron_snapshots: dict[str, dict[str, dict[str, Any]]] = defaultdict(dict)
+        self._hot_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
         self._current_brain_id: str | None = None
 
     @property

--- a/src/surreal_memory/storage/memory_sync_ops.py
+++ b/src/surreal_memory/storage/memory_sync_ops.py
@@ -1,0 +1,444 @@
+"""In-memory multi-device sync storage mixin for testing.
+
+Covers the device registry, change log, Merkle hash cache, and Bayesian
+depth priors, mirroring the semantics of the SQLite backend mixins.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta
+from typing import Any
+
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.neuron import Neuron
+from surreal_memory.core.synapse import Synapse
+from surreal_memory.core.sync_records import ChangeEntry, DeviceRecord
+from surreal_memory.engine.depth_prior import DepthPrior
+from surreal_memory.sync.merkle import ENTITY_TYPES, MerkleTreeBuilder
+from surreal_memory.utils.timeutils import utcnow
+
+_MAX_CHANGE_LIMIT = 10000
+
+
+class InMemorySyncMixin:
+    """Mixin providing device, change log, Merkle, and depth prior ops."""
+
+    # Declared in InMemoryStorage.__init__
+    _neurons: dict[str, dict[str, Neuron]]
+    _synapses: dict[str, dict[str, Synapse]]
+    _fibers: dict[str, dict[str, Fiber]]
+    _devices: dict[str, dict[str, DeviceRecord]]
+    _change_log: dict[str, list[ChangeEntry]]
+    _change_log_seq: dict[str, int]
+    _merkle_hashes: dict[str, dict[str, dict[str, str]]]
+    _depth_priors: dict[str, dict[str, dict[int, DepthPrior]]]
+
+    def _get_brain_id(self) -> str:
+        raise NotImplementedError
+
+    # ========== Device Registry Operations ==========
+
+    async def register_device(self, device_id: str, device_name: str = "") -> DeviceRecord:
+        """Register a device for the current brain (upsert)."""
+        brain_id = self._get_brain_id()
+        now = utcnow()
+
+        if brain_id not in self._devices:
+            self._devices[brain_id] = {}
+        existing = self._devices[brain_id].get(device_id)
+
+        if existing is None:
+            self._devices[brain_id][device_id] = DeviceRecord(
+                device_id=device_id,
+                brain_id=brain_id,
+                device_name=device_name,
+                last_sync_at=None,
+                last_sync_sequence=0,
+                registered_at=now,
+            )
+        else:
+            self._devices[brain_id][device_id] = replace(existing, device_name=device_name)
+
+        # Mirrors SQLite: the return value reflects the insert values, not the
+        # stored row, so re-registering reports a fresh record.
+        return DeviceRecord(
+            device_id=device_id,
+            brain_id=brain_id,
+            device_name=device_name,
+            last_sync_at=None,
+            last_sync_sequence=0,
+            registered_at=now,
+        )
+
+    async def get_device(self, device_id: str) -> DeviceRecord | None:
+        """Get device info for a specific device."""
+        brain_id = self._get_brain_id()
+        return self._devices.get(brain_id, {}).get(device_id)
+
+    async def list_devices(self) -> list[DeviceRecord]:
+        """List all registered devices for the current brain."""
+        brain_id = self._get_brain_id()
+        devices = list(self._devices.get(brain_id, {}).values())
+        devices.sort(key=lambda d: d.registered_at)
+        return devices
+
+    async def update_device_sync(self, device_id: str, last_sync_sequence: int) -> None:
+        """Update the last sync timestamp and sequence for a device."""
+        brain_id = self._get_brain_id()
+        devices = self._devices.get(brain_id, {})
+        existing = devices.get(device_id)
+        if existing is None:
+            return
+        devices[device_id] = replace(
+            existing,
+            last_sync_at=utcnow(),
+            last_sync_sequence=last_sync_sequence,
+        )
+
+    async def remove_device(self, device_id: str) -> bool:
+        """Remove a device from the registry. Returns True if deleted."""
+        brain_id = self._get_brain_id()
+        devices = self._devices.get(brain_id, {})
+        if device_id in devices:
+            del devices[device_id]
+            return True
+        return False
+
+    # ========== Change Log Operations ==========
+
+    async def record_change(
+        self,
+        entity_type: str,
+        entity_id: str,
+        operation: str,
+        device_id: str = "",
+        payload: dict[str, Any] | None = None,
+    ) -> int:
+        """Append a change to the log. Returns the sequence number (id)."""
+        brain_id = self._get_brain_id()
+        return self._append_change(
+            brain_id=brain_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            operation=operation,
+            device_id=device_id,
+            payload=payload or {},
+            changed_at=utcnow(),
+        )
+
+    async def get_changes_since(self, sequence: int = 0, limit: int = 1000) -> list[ChangeEntry]:
+        """Get changes after a given sequence number, ordered by id ASC."""
+        safe_limit = min(limit, _MAX_CHANGE_LIMIT)
+        brain_id = self._get_brain_id()
+        entries = [e for e in self._change_log.get(brain_id, []) if e.id > sequence]
+        entries.sort(key=lambda e: e.id)
+        return entries[:safe_limit]
+
+    async def get_unsynced_changes(self, limit: int = 1000) -> list[ChangeEntry]:
+        """Get all unsynced changes, ordered by id ASC."""
+        safe_limit = min(limit, _MAX_CHANGE_LIMIT)
+        brain_id = self._get_brain_id()
+        entries = [e for e in self._change_log.get(brain_id, []) if not e.synced]
+        entries.sort(key=lambda e: e.id)
+        return entries[:safe_limit]
+
+    async def mark_synced(self, up_to_sequence: int) -> int:
+        """Mark all changes up to a sequence number as synced. Returns count marked."""
+        brain_id = self._get_brain_id()
+        entries = self._change_log.get(brain_id, [])
+        marked = 0
+        for index, entry in enumerate(entries):
+            if entry.id <= up_to_sequence and not entry.synced:
+                entries[index] = replace(entry, synced=True)
+                marked += 1
+        return marked
+
+    async def prune_synced_changes(self, older_than_days: int = 30) -> int:
+        """Delete synced changes older than N days. Returns count pruned."""
+        brain_id = self._get_brain_id()
+        entries = self._change_log.get(brain_id, [])
+        if not entries:
+            return 0
+        cutoff = utcnow() - timedelta(days=older_than_days)
+        kept = [e for e in entries if not (e.synced and e.changed_at < cutoff)]
+        pruned = len(entries) - len(kept)
+        self._change_log[brain_id] = kept
+        return pruned
+
+    async def seed_change_log(self, device_id: str = "") -> dict[str, int]:
+        """Seed the change log with all existing entities as 'insert' entries."""
+        brain_id = self._get_brain_id()
+        now = utcnow()
+        tracked = {(e.entity_type, e.entity_id) for e in self._change_log.get(brain_id, [])}
+        counts: dict[str, int] = {"neurons": 0, "synapses": 0, "fibers": 0}
+
+        for neuron in self._neurons.get(brain_id, {}).values():
+            if neuron.ephemeral or ("neuron", neuron.id) in tracked:
+                continue
+            self._seed_entry(brain_id, "neuron", neuron.id, device_id, _neuron_payload(neuron), now)
+            counts["neurons"] += 1
+
+        for synapse in self._synapses.get(brain_id, {}).values():
+            if ("synapse", synapse.id) in tracked:
+                continue
+            payload = _synapse_payload(synapse)
+            self._seed_entry(brain_id, "synapse", synapse.id, device_id, payload, now)
+            counts["synapses"] += 1
+
+        for fiber in self._fibers.get(brain_id, {}).values():
+            if ("fiber", fiber.id) in tracked:
+                continue
+            self._seed_entry(brain_id, "fiber", fiber.id, device_id, _fiber_payload(fiber), now)
+            counts["fibers"] += 1
+
+        return counts
+
+    async def get_change_log_stats(self) -> dict[str, Any]:
+        """Get change log statistics for the current brain."""
+        brain_id = self._get_brain_id()
+        entries = self._change_log.get(brain_id, [])
+        synced = sum(1 for e in entries if e.synced)
+        return {
+            "total": len(entries),
+            "pending": len(entries) - synced,
+            "synced": synced,
+            "last_sequence": max((e.id for e in entries), default=0),
+        }
+
+    # ========== Merkle Hash Operations ==========
+
+    async def compute_merkle_root(self, entity_type: str, *, is_pro: bool = False) -> str | None:
+        """Compute and cache the Merkle root hash for an entity type."""
+        if not is_pro:
+            return None
+
+        if entity_type not in ENTITY_TYPES:
+            raise ValueError(
+                f"Unknown entity_type: {entity_type!r}. Must be one of {ENTITY_TYPES}."
+            )
+
+        brain_id = self._get_brain_id()
+        tree = MerkleTreeBuilder.build_tree(self._merkle_entities(entity_type), entity_type)
+
+        if brain_id not in self._merkle_hashes:
+            self._merkle_hashes[brain_id] = {}
+        cached = self._merkle_hashes[brain_id].setdefault(entity_type, {})
+        cached[tree.prefix] = tree.hash
+        for child in tree.children:
+            cached[child.prefix] = child.hash
+
+        return tree.hash
+
+    async def get_merkle_tree(self, entity_type: str, *, is_pro: bool = False) -> dict[str, str]:
+        """Return cached {prefix: hash} map for an entity type."""
+        if not is_pro:
+            return {}
+        brain_id = self._get_brain_id()
+        return dict(self._merkle_hashes.get(brain_id, {}).get(entity_type, {}))
+
+    async def invalidate_merkle_prefix(
+        self, entity_type: str, entity_id: str, *, is_pro: bool = False
+    ) -> None:
+        """Delete cached hashes for the bucket containing entity_id."""
+        if not is_pro:
+            return
+
+        brain_id = self._get_brain_id()
+        cached = self._merkle_hashes.get(brain_id, {}).get(entity_type)
+        if not cached:
+            return
+
+        type_prefix = f"{entity_type}s"
+        bucket_key = (
+            entity_id[:2].lower() if len(entity_id) >= 2 else entity_id.lower().ljust(2, "0")
+        )
+        cached.pop(type_prefix, None)
+        cached.pop(f"{type_prefix}/{bucket_key}", None)
+
+    async def get_merkle_root(self, *, is_pro: bool = False) -> str | None:
+        """Get combined root hash across all entity types."""
+        if not is_pro:
+            return None
+
+        brain_id = self._get_brain_id()
+        by_type = self._merkle_hashes.get(brain_id, {})
+        hashes: list[str] = []
+
+        for entity_type in ("neuron", "synapse", "fiber"):
+            cached = by_type.get(entity_type, {}).get(f"{entity_type}s")
+            if cached is None:
+                return None
+            hashes.append(cached)
+
+        return MerkleTreeBuilder.compute_branch_hash(hashes)
+
+    # ========== Depth Prior Operations ==========
+
+    async def get_depth_priors_batch(
+        self,
+        entity_texts: list[str],
+    ) -> dict[str, list[DepthPrior]]:
+        """Batch-fetch Bayesian depth priors for multiple entities."""
+        if not entity_texts:
+            return {}
+
+        brain_id = self._get_brain_id()
+        by_entity = self._depth_priors.get(brain_id, {})
+        return {text: list(by_entity.get(text, {}).values()) for text in entity_texts}
+
+    async def upsert_depth_prior(self, prior: DepthPrior) -> None:
+        """Insert or update a single depth prior."""
+        brain_id = self._get_brain_id()
+
+        if brain_id not in self._depth_priors:
+            self._depth_priors[brain_id] = {}
+        by_entity = self._depth_priors[brain_id]
+        if prior.entity_text not in by_entity:
+            by_entity[prior.entity_text] = {}
+
+        level = int(prior.depth_level)
+        existing = by_entity[prior.entity_text].get(level)
+        # Mirrors SQLite ON CONFLICT: created_at of the original row is retained.
+        stored = replace(prior, created_at=existing.created_at) if existing else prior
+        by_entity[prior.entity_text][level] = stored
+
+    async def get_stale_priors(self, older_than: datetime) -> list[DepthPrior]:
+        """Find depth priors not updated since a given date."""
+        brain_id = self._get_brain_id()
+        by_entity = self._depth_priors.get(brain_id, {})
+        return [
+            prior
+            for by_level in by_entity.values()
+            for prior in by_level.values()
+            if prior.last_updated < older_than
+        ]
+
+    async def delete_depth_priors(self, entity_text: str) -> int:
+        """Delete all depth priors for an entity. Returns count deleted."""
+        brain_id = self._get_brain_id()
+        by_entity = self._depth_priors.get(brain_id, {})
+        removed = by_entity.pop(entity_text, {})
+        return len(removed)
+
+    # ========== Internal helpers ==========
+
+    def _next_sequence(self, brain_id: str) -> int:
+        sequence = self._change_log_seq.get(brain_id, 0) + 1
+        self._change_log_seq[brain_id] = sequence
+        return sequence
+
+    def _append_change(
+        self,
+        *,
+        brain_id: str,
+        entity_type: str,
+        entity_id: str,
+        operation: str,
+        device_id: str,
+        payload: dict[str, Any],
+        changed_at: datetime,
+    ) -> int:
+        if brain_id not in self._change_log:
+            self._change_log[brain_id] = []
+        entry = ChangeEntry(
+            id=self._next_sequence(brain_id),
+            brain_id=brain_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            operation=operation,
+            device_id=device_id,
+            changed_at=changed_at,
+            payload=payload,
+            synced=False,
+        )
+        self._change_log[brain_id].append(entry)
+        return entry.id
+
+    def _seed_entry(
+        self,
+        brain_id: str,
+        entity_type: str,
+        entity_id: str,
+        device_id: str,
+        payload: dict[str, Any],
+        changed_at: datetime,
+    ) -> None:
+        self._append_change(
+            brain_id=brain_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            operation="insert",
+            device_id=device_id,
+            payload=payload,
+            changed_at=changed_at,
+        )
+
+    def _merkle_entities(self, entity_type: str) -> list[tuple[str, str, str]]:
+        """Return (entity_id, updated_at, content_hash) tuples for hashing.
+
+        The in-memory models carry no ``updated_at`` field, so that component is
+        always the empty string — matching SQLite rows written by the current
+        code path, which never populates the column either. Synapses have no
+        content hash on either backend.
+        """
+        brain_id = self._get_brain_id()
+
+        if entity_type == "neuron":
+            neurons = self._neurons.get(brain_id, {}).values()
+            return [(n.id, "", str(n.content_hash)) for n in neurons]
+        if entity_type == "synapse":
+            return [(s.id, "", "") for s in self._synapses.get(brain_id, {}).values()]
+        return [(f.id, "", f.summary or "") for f in self._fibers.get(brain_id, {}).values()]
+
+
+def _neuron_payload(neuron: Neuron) -> dict[str, Any]:
+    """Build a sync payload dict for a neuron."""
+    return {
+        "id": neuron.id,
+        "type": neuron.type.value,
+        "content": neuron.content,
+        "metadata": dict(neuron.metadata),
+        "content_hash": neuron.content_hash,
+        "created_at": neuron.created_at.isoformat(),
+    }
+
+
+def _synapse_payload(synapse: Synapse) -> dict[str, Any]:
+    """Build a sync payload dict for a synapse."""
+    return {
+        "id": synapse.id,
+        "source_id": synapse.source_id,
+        "target_id": synapse.target_id,
+        "type": synapse.type.value,
+        "weight": synapse.weight,
+        "direction": synapse.direction.value,
+        "metadata": dict(synapse.metadata),
+        "reinforced_count": synapse.reinforced_count,
+        "last_activated": synapse.last_activated.isoformat() if synapse.last_activated else None,
+        "created_at": synapse.created_at.isoformat(),
+    }
+
+
+def _fiber_payload(fiber: Fiber) -> dict[str, Any]:
+    """Build a sync payload dict for a fiber."""
+    return {
+        "id": fiber.id,
+        "neuron_ids": sorted(fiber.neuron_ids),
+        "synapse_ids": sorted(fiber.synapse_ids),
+        "anchor_neuron_id": fiber.anchor_neuron_id,
+        "pathway": list(fiber.pathway),
+        "conductivity": fiber.conductivity,
+        "last_conducted": fiber.last_conducted.isoformat() if fiber.last_conducted else None,
+        "time_start": fiber.time_start.isoformat() if fiber.time_start else None,
+        "time_end": fiber.time_end.isoformat() if fiber.time_end else None,
+        "coherence": fiber.coherence,
+        "salience": fiber.salience,
+        "frequency": fiber.frequency,
+        "summary": fiber.summary,
+        "auto_tags": sorted(fiber.auto_tags),
+        "agent_tags": sorted(fiber.agent_tags),
+        "metadata": dict(fiber.metadata),
+        "compression_tier": fiber.compression_tier,
+        "created_at": fiber.created_at.isoformat(),
+    }

--- a/src/surreal_memory/storage/memory_sync_ops.py
+++ b/src/surreal_memory/storage/memory_sync_ops.py
@@ -275,6 +275,12 @@ class InMemorySyncMixin:
 
     # ========== Depth Prior Operations ==========
 
+    async def get_depth_priors(self, entity_text: str) -> list[DepthPrior]:
+        """Get all priors for an entity across all depth levels."""
+        brain_id = self._get_brain_id()
+        by_entity = self._depth_priors.get(brain_id, {})
+        return list(by_entity.get(entity_text, {}).values())
+
     async def get_depth_priors_batch(
         self,
         entity_texts: list[str],

--- a/src/surreal_memory/storage/sqlite_change_log.py
+++ b/src/surreal_memory/storage/sqlite_change_log.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from surreal_memory.core.sync_records import ChangeEntry
 from surreal_memory.utils.timeutils import utcnow
 
 if TYPE_CHECKING:
@@ -15,20 +15,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
-@dataclass(frozen=True)
-class ChangeEntry:
-    """A single change log entry."""
-
-    id: int  # Auto-incremented sequence number
-    brain_id: str
-    entity_type: str  # "neuron", "synapse", "fiber"
-    entity_id: str
-    operation: str  # "insert", "update", "delete"
-    device_id: str
-    changed_at: datetime
-    payload: dict[str, Any] = field(default_factory=dict)
-    synced: bool = False
+__all__ = ["ChangeEntry", "SQLiteChangeLogMixin"]
 
 
 class SQLiteChangeLogMixin:

--- a/src/surreal_memory/storage/sqlite_devices.py
+++ b/src/surreal_memory/storage/sqlite_devices.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from surreal_memory.core.sync_records import DeviceRecord
 from surreal_memory.utils.timeutils import utcnow
 
 if TYPE_CHECKING:
@@ -14,17 +14,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
-@dataclass(frozen=True)
-class DeviceRecord:
-    """A registered device for a brain."""
-
-    device_id: str
-    brain_id: str
-    device_name: str
-    last_sync_at: datetime | None
-    last_sync_sequence: int
-    registered_at: datetime
+__all__ = ["DeviceRecord", "SQLiteDevicesMixin"]
 
 
 class SQLiteDevicesMixin:

--- a/tests/stress/conftest.py
+++ b/tests/stress/conftest.py
@@ -1,23 +1,26 @@
-"""Shared fixtures for stress tests — real SQLiteStorage, no mocks."""
+"""Shared fixtures for stress tests — InMemoryStorage, no mocks.
+
+Named ``sqlite_storage`` for compatibility with the six test files that use it
+as a fixture parameter; the fixture itself now runs on InMemoryStorage, which
+grew the full NeuralStorage surface. Disk-contention behaviour (WAL, concurrent
+file access) was never something this suite exercised — none of the stress
+tests assert on it — so nothing is lost by dropping the file backing.
+"""
 
 from __future__ import annotations
-
-from pathlib import Path
 
 import pytest
 import pytest_asyncio
 
 from surreal_memory.core.brain import Brain, BrainConfig
 from surreal_memory.engine.encoder import MemoryEncoder
-from surreal_memory.storage.sqlite_store import SQLiteStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
 
 
 @pytest_asyncio.fixture
-async def sqlite_storage(tmp_path: Path) -> SQLiteStorage:
-    """Create a real SQLiteStorage with initialized schema and brain."""
-    db_path = tmp_path / "test.db"
-    storage = SQLiteStorage(db_path=str(db_path))
-    await storage.initialize()
+async def sqlite_storage() -> InMemoryStorage:
+    """Create an initialized InMemoryStorage with a stress-test brain."""
+    storage = InMemoryStorage()
 
     config = BrainConfig(
         decay_rate=0.1,
@@ -30,13 +33,11 @@ async def sqlite_storage(tmp_path: Path) -> SQLiteStorage:
     await storage.save_brain(brain)
     storage.set_brain(brain.id)
 
-    yield storage  # type: ignore[misc]
-
-    await storage.close()
+    return storage
 
 
 @pytest_asyncio.fixture
-async def encoder(sqlite_storage: SQLiteStorage) -> MemoryEncoder:
+async def encoder(sqlite_storage: InMemoryStorage) -> MemoryEncoder:
     """Create a MemoryEncoder bound to the stress-test brain."""
     brain = await sqlite_storage.get_brain(sqlite_storage._current_brain_id)  # type: ignore[arg-type]
     assert brain is not None

--- a/tests/unit/test_alerts.py
+++ b/tests/unit/test_alerts.py
@@ -11,20 +11,17 @@ from surreal_memory.core.alert import Alert, AlertStatus, AlertType
 from surreal_memory.core.brain import Brain, BrainConfig
 from surreal_memory.mcp.alert_handler import _hint_to_alert_type
 from surreal_memory.mcp.maintenance_handler import HealthHint, HintSeverity
-from surreal_memory.storage.sqlite_store import SQLiteStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
 from surreal_memory.utils.timeutils import utcnow
 
 # ── Fixtures ─────────────────────────────────────────────────────
 
 
 @pytest_asyncio.fixture
-async def store(tmp_path: object) -> SQLiteStorage:
+async def store(tmp_path: object) -> InMemoryStorage:
     """SQLite storage with alerts table, ready for testing."""
-    import pathlib
 
-    db_path = pathlib.Path(str(tmp_path)) / "test_alerts.db"
-    storage = SQLiteStorage(db_path)
-    await storage.initialize()
+    storage = InMemoryStorage()
 
     brain = Brain.create(name="alert-test", config=BrainConfig(), owner_id="test")
     await storage.save_brain(brain)
@@ -148,7 +145,7 @@ class TestHintMapping:
 class TestSQLiteAlerts:
     """Tests for SQLiteAlertsMixin operations."""
 
-    async def test_record_and_get(self, store: SQLiteStorage) -> None:
+    async def test_record_and_get(self, store: InMemoryStorage) -> None:
         alert = _make_alert()
         result = await store.record_alert(alert)
         assert result == alert.id
@@ -158,7 +155,7 @@ class TestSQLiteAlerts:
         assert fetched.alert_type == AlertType.HIGH_NEURON_COUNT
         assert fetched.status == AlertStatus.ACTIVE
 
-    async def test_dedup_cooldown(self, store: SQLiteStorage) -> None:
+    async def test_dedup_cooldown(self, store: InMemoryStorage) -> None:
         alert1 = _make_alert()
         result1 = await store.record_alert(alert1)
         assert result1 != ""
@@ -167,7 +164,7 @@ class TestSQLiteAlerts:
         result2 = await store.record_alert(alert2)
         assert result2 == ""  # Suppressed
 
-    async def test_different_types_not_deduped(self, store: SQLiteStorage) -> None:
+    async def test_different_types_not_deduped(self, store: InMemoryStorage) -> None:
         a1 = _make_alert(alert_type=AlertType.HIGH_NEURON_COUNT)
         a2 = _make_alert(alert_type=AlertType.LOW_CONNECTIVITY)
         r1 = await store.record_alert(a1)
@@ -175,7 +172,7 @@ class TestSQLiteAlerts:
         assert r1 != ""
         assert r2 != ""
 
-    async def test_get_active_alerts(self, store: SQLiteStorage) -> None:
+    async def test_get_active_alerts(self, store: InMemoryStorage) -> None:
         a1 = _make_alert(severity="critical")
         a2 = _make_alert(alert_type=AlertType.LOW_CONNECTIVITY, severity="low")
         await store.record_alert(a1)
@@ -186,14 +183,14 @@ class TestSQLiteAlerts:
         # Critical severity should come first
         assert alerts[0].severity == "critical"
 
-    async def test_count_pending_alerts(self, store: SQLiteStorage) -> None:
+    async def test_count_pending_alerts(self, store: InMemoryStorage) -> None:
         a1 = _make_alert()
         await store.record_alert(a1)
 
         count = await store.count_pending_alerts()
         assert count == 1
 
-    async def test_mark_seen(self, store: SQLiteStorage) -> None:
+    async def test_mark_seen(self, store: InMemoryStorage) -> None:
         a = _make_alert()
         await store.record_alert(a)
 
@@ -205,7 +202,7 @@ class TestSQLiteAlerts:
         assert fetched.status == AlertStatus.SEEN
         assert fetched.seen_at is not None
 
-    async def test_mark_acknowledged(self, store: SQLiteStorage) -> None:
+    async def test_mark_acknowledged(self, store: InMemoryStorage) -> None:
         a = _make_alert()
         await store.record_alert(a)
 
@@ -216,7 +213,7 @@ class TestSQLiteAlerts:
         assert fetched is not None
         assert fetched.status == AlertStatus.ACKNOWLEDGED
 
-    async def test_resolve_by_type(self, store: SQLiteStorage) -> None:
+    async def test_resolve_by_type(self, store: InMemoryStorage) -> None:
         a1 = _make_alert(alert_type=AlertType.HIGH_NEURON_COUNT)
         a2 = _make_alert(alert_type=AlertType.LOW_CONNECTIVITY)
         await store.record_alert(a1)
@@ -229,7 +226,7 @@ class TestSQLiteAlerts:
         assert len(remaining) == 1
         assert remaining[0].alert_type == AlertType.LOW_CONNECTIVITY
 
-    async def test_acknowledged_not_resolved_by_type(self, store: SQLiteStorage) -> None:
+    async def test_acknowledged_not_resolved_by_type(self, store: InMemoryStorage) -> None:
         a = _make_alert()
         await store.record_alert(a)
         await store.mark_alert_acknowledged(a.id)
@@ -237,6 +234,6 @@ class TestSQLiteAlerts:
         resolved = await store.resolve_alerts_by_type([AlertType.HIGH_NEURON_COUNT.value])
         assert resolved == 0
 
-    async def test_get_nonexistent_alert(self, store: SQLiteStorage) -> None:
+    async def test_get_nonexistent_alert(self, store: InMemoryStorage) -> None:
         result = await store.get_alert("nonexistent")
         assert result is None

--- a/tests/unit/test_change_log.py
+++ b/tests/unit/test_change_log.py
@@ -9,18 +9,16 @@ import pytest
 import pytest_asyncio
 
 from surreal_memory.core.brain import Brain, BrainConfig
+from surreal_memory.storage.memory_store import InMemoryStorage
 from surreal_memory.storage.sqlite_change_log import ChangeEntry
-from surreal_memory.storage.sqlite_store import SQLiteStorage
 
 # ── Fixture ───────────────────────────────────────────────────────────────────
 
 
 @pytest_asyncio.fixture
-async def storage_with_brain(tmp_path: pathlib.Path) -> SQLiteStorage:
-    """Create SQLiteStorage with an initialized brain context."""
-    db_path = tmp_path / "test_change_log.db"
-    storage = SQLiteStorage(db_path)
-    await storage.initialize()
+async def storage_with_brain(tmp_path: pathlib.Path) -> InMemoryStorage:
+    """Create InMemoryStorage with an initialized brain context."""
+    storage = InMemoryStorage()
 
     brain = Brain.create(name="change-log-test", config=BrainConfig())
     await storage.save_brain(brain)
@@ -37,7 +35,7 @@ async def storage_with_brain(tmp_path: pathlib.Path) -> SQLiteStorage:
 class TestRecordChange:
     """Test record_change returns a positive sequence number."""
 
-    async def test_record_change(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_record_change(self, storage_with_brain: InMemoryStorage) -> None:
         """Insert a change, verify returned sequence > 0."""
         seq = await storage_with_brain.record_change(
             entity_type="neuron",
@@ -49,7 +47,7 @@ class TestRecordChange:
         assert seq > 0
 
     async def test_record_change_increments_sequence(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """Each record_change call returns a strictly increasing sequence."""
         seq1 = await storage_with_brain.record_change(
@@ -65,7 +63,7 @@ class TestGetChangesSince:
     """Test get_changes_since returns changes in order after a given sequence."""
 
     async def test_get_changes_since_zero_returns_all(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """get_changes_since(0) returns all 3 inserted changes in order."""
         await storage_with_brain.record_change("neuron", "n-1", "insert", device_id="dev-a")
@@ -79,7 +77,7 @@ class TestGetChangesSince:
         assert changes[2].entity_type == "fiber"
 
     async def test_get_changes_since_filters_by_sequence(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """get_changes_since(seq1) returns only changes after seq1."""
         seq1 = await storage_with_brain.record_change("neuron", "n-1", "insert")
@@ -91,7 +89,7 @@ class TestGetChangesSince:
         assert len(changes) == 2
 
     async def test_get_changes_since_returns_ordered_asc(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """Changes are returned in ascending id order."""
         for i in range(5):
@@ -103,7 +101,7 @@ class TestGetChangesSince:
             assert changes[i].id < changes[i + 1].id
 
     async def test_get_changes_since_returns_change_entry_instances(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """get_changes_since returns ChangeEntry instances."""
         await storage_with_brain.record_change("neuron", "n-x", "insert")
@@ -116,7 +114,7 @@ class TestGetUnsyncedChanges:
     """Test get_unsynced_changes returns only un-marked changes."""
 
     async def test_get_unsynced_changes_returns_all_when_none_synced(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """All new changes are unsynced initially."""
         await storage_with_brain.record_change("neuron", "n-1", "insert")
@@ -126,7 +124,7 @@ class TestGetUnsyncedChanges:
         assert len(unsynced) == 2
 
     async def test_get_unsynced_changes_excludes_synced(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """After mark_synced(seq1), get_unsynced_changes returns only seq2+."""
         seq1 = await storage_with_brain.record_change("neuron", "n-1", "insert")
@@ -139,7 +137,7 @@ class TestGetUnsyncedChanges:
         assert unsynced[0].entity_id == "n-2"
 
     async def test_get_unsynced_changes_empty_after_all_synced(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """After marking all synced, get_unsynced_changes returns empty list."""
         seq1 = await storage_with_brain.record_change("neuron", "n-1", "insert")
@@ -154,7 +152,7 @@ class TestGetUnsyncedChanges:
 class TestMarkSynced:
     """Test mark_synced marks changes and returns correct count."""
 
-    async def test_mark_synced_returns_count(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_mark_synced_returns_count(self, storage_with_brain: InMemoryStorage) -> None:
         """mark_synced returns the number of rows marked."""
         await storage_with_brain.record_change("neuron", "n-1", "insert")
         seq2 = await storage_with_brain.record_change("neuron", "n-2", "insert")
@@ -162,7 +160,9 @@ class TestMarkSynced:
         count = await storage_with_brain.mark_synced(seq2)
         assert count == 2
 
-    async def test_mark_synced_only_marks_unsynced(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_mark_synced_only_marks_unsynced(
+        self, storage_with_brain: InMemoryStorage
+    ) -> None:
         """mark_synced does not count already-synced rows."""
         seq1 = await storage_with_brain.record_change("neuron", "n-1", "insert")
         seq2 = await storage_with_brain.record_change("neuron", "n-2", "insert")
@@ -176,7 +176,7 @@ class TestMarkSynced:
         assert count2 == 1
 
     async def test_mark_synced_persists_synced_flag(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """After mark_synced, get_changes_since still returns those changes
         (synced flag is separate from existence)."""
@@ -192,7 +192,7 @@ class TestPruneSyncedChanges:
     """Test prune_synced_changes removes old synced entries."""
 
     async def test_prune_synced_changes_removes_synced_old(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """Synced changes older than older_than_days=0 are pruned."""
         seq = await storage_with_brain.record_change("neuron", "n-old", "insert")
@@ -207,7 +207,7 @@ class TestPruneSyncedChanges:
         assert all(c.entity_id != "n-old" for c in changes)
 
     async def test_prune_synced_changes_keeps_unsynced(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """Unsynced changes are never pruned."""
         await storage_with_brain.record_change("neuron", "n-keep", "insert")
@@ -220,7 +220,7 @@ class TestPruneSyncedChanges:
         assert any(c.entity_id == "n-keep" for c in unsynced)
 
     async def test_prune_synced_changes_returns_count(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """prune_synced_changes returns an integer count."""
         result = await storage_with_brain.prune_synced_changes(older_than_days=365)
@@ -231,7 +231,7 @@ class TestPruneSyncedChanges:
 class TestGetChangeLogStats:
     """Test get_change_log_stats returns accurate aggregates."""
 
-    async def test_get_change_log_stats_empty(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_get_change_log_stats_empty(self, storage_with_brain: InMemoryStorage) -> None:
         """Stats on empty change log return all zeros."""
         stats = await storage_with_brain.get_change_log_stats()
         assert stats["total"] == 0
@@ -239,7 +239,9 @@ class TestGetChangeLogStats:
         assert stats["synced"] == 0
         assert stats["last_sequence"] == 0
 
-    async def test_get_change_log_stats_with_data(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_get_change_log_stats_with_data(
+        self, storage_with_brain: InMemoryStorage
+    ) -> None:
         """Insert 3 changes, mark 1 synced, verify stats totals."""
         seq1 = await storage_with_brain.record_change("neuron", "n-1", "insert")
         await storage_with_brain.record_change("neuron", "n-2", "insert")
@@ -254,7 +256,7 @@ class TestGetChangeLogStats:
         assert stats["last_sequence"] > 0
 
     async def test_get_change_log_stats_last_sequence_is_highest_id(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """last_sequence equals the highest change id inserted."""
         await storage_with_brain.record_change("neuron", "n-1", "insert")
@@ -267,7 +269,7 @@ class TestGetChangeLogStats:
 class TestChangeEntryFields:
     """Test ChangeEntry frozen dataclass immutability and field types."""
 
-    async def test_change_entry_fields_populated(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_change_entry_fields_populated(self, storage_with_brain: InMemoryStorage) -> None:
         """ChangeEntry returned from storage has all expected fields."""
         await storage_with_brain.record_change(
             entity_type="fiber",
@@ -341,9 +343,7 @@ class TestBrainIsolation:
 
     async def test_brain_isolation(self, tmp_path: pathlib.Path) -> None:
         """Changes in brain A are not visible when brain B is active."""
-        db_path = tmp_path / "isolation_test.db"
-        storage = SQLiteStorage(db_path)
-        await storage.initialize()
+        storage = InMemoryStorage()
 
         brain_a = Brain.create(name="brain-a", config=BrainConfig())
         brain_b = Brain.create(name="brain-b", config=BrainConfig())

--- a/tests/unit/test_compression.py
+++ b/tests/unit/test_compression.py
@@ -35,7 +35,7 @@ from surreal_memory.engine.compression import (
     split_sentences,
 )
 from surreal_memory.engine.consolidation import ConsolidationReport, ConsolidationStrategy
-from surreal_memory.storage.sqlite_store import SQLiteStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
 from surreal_memory.utils.timeutils import utcnow
 
 # ---------------------------------------------------------------------------
@@ -520,16 +520,14 @@ class TestDetermineTargetTier:
 
 
 # ---------------------------------------------------------------------------
-# Storage tests (SQLiteCompressionMixin via SQLiteStorage)
+# Storage tests (SQLiteCompressionMixin via InMemoryStorage)
 # ---------------------------------------------------------------------------
 
 
 @pytest_asyncio.fixture
-async def sqlite_storage(tmp_path: Path) -> SQLiteStorage:
-    """SQLiteStorage backed by a temp file, brain context set."""
-    db_path = tmp_path / "test_compression.db"
-    store = SQLiteStorage(db_path)
-    await store.initialize()
+async def sqlite_storage(tmp_path: Path) -> InMemoryStorage:
+    """InMemoryStorage backed by a temp file, brain context set."""
+    store = InMemoryStorage()
     brain = Brain.create(name="test-compression-brain")
     await store.save_brain(brain)
     store.set_brain(brain.id)
@@ -538,7 +536,7 @@ async def sqlite_storage(tmp_path: Path) -> SQLiteStorage:
 
 class TestSQLiteCompressionMixin:
     @pytest.mark.asyncio
-    async def test_save_and_get_backup(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_save_and_get_backup(self, sqlite_storage: InMemoryStorage) -> None:
         """Round-trip: save a backup then retrieve it with matching fields."""
         await sqlite_storage.save_compression_backup(
             fiber_id="fiber-abc",
@@ -556,12 +554,14 @@ class TestSQLiteCompressionMixin:
         assert result["compressed_token_count"] == 40
 
     @pytest.mark.asyncio
-    async def test_get_nonexistent_backup_returns_none(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_get_nonexistent_backup_returns_none(
+        self, sqlite_storage: InMemoryStorage
+    ) -> None:
         result = await sqlite_storage.get_compression_backup("does-not-exist")
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_delete_backup_returns_true(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_delete_backup_returns_true(self, sqlite_storage: InMemoryStorage) -> None:
         await sqlite_storage.save_compression_backup(
             fiber_id="fiber-del",
             original_content="Some content.",
@@ -573,7 +573,7 @@ class TestSQLiteCompressionMixin:
         assert deleted is True
 
     @pytest.mark.asyncio
-    async def test_delete_backup_removes_row(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_delete_backup_removes_row(self, sqlite_storage: InMemoryStorage) -> None:
         await sqlite_storage.save_compression_backup(
             fiber_id="fiber-gone",
             original_content="Content.",
@@ -587,20 +587,20 @@ class TestSQLiteCompressionMixin:
 
     @pytest.mark.asyncio
     async def test_delete_nonexistent_backup_returns_false(
-        self, sqlite_storage: SQLiteStorage
+        self, sqlite_storage: InMemoryStorage
     ) -> None:
         deleted = await sqlite_storage.delete_compression_backup("ghost-fiber")
         assert deleted is False
 
     @pytest.mark.asyncio
-    async def test_compression_stats_empty(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_compression_stats_empty(self, sqlite_storage: InMemoryStorage) -> None:
         stats = await sqlite_storage.get_compression_stats()
         assert stats["total_backups"] == 0
         assert stats["by_tier"] == {}
         assert stats["total_tokens_saved"] == 0
 
     @pytest.mark.asyncio
-    async def test_compression_stats_counts_by_tier(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_compression_stats_counts_by_tier(self, sqlite_storage: InMemoryStorage) -> None:
         await sqlite_storage.save_compression_backup(
             fiber_id="f1",
             original_content="Content 1.",
@@ -629,7 +629,7 @@ class TestSQLiteCompressionMixin:
         assert stats["total_tokens_saved"] == (100 - 40) + (80 - 30) + (60 - 10)
 
     @pytest.mark.asyncio
-    async def test_upsert_backup_replaces_existing(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_upsert_backup_replaces_existing(self, sqlite_storage: InMemoryStorage) -> None:
         """Saving twice for the same fiber_id replaces the old backup."""
         await sqlite_storage.save_compression_backup(
             fiber_id="fiber-upsert",
@@ -653,9 +653,7 @@ class TestSQLiteCompressionMixin:
     @pytest.mark.asyncio
     async def test_brain_isolation(self, tmp_path: Path) -> None:
         """Backups stored under brain A are not visible under brain B."""
-        db_path = tmp_path / "isolation.db"
-        store = SQLiteStorage(db_path)
-        await store.initialize()
+        store = InMemoryStorage()
 
         brain_a = Brain.create(name="brain-a")
         brain_b = Brain.create(name="brain-b")

--- a/tests/unit/test_depth_prior.py
+++ b/tests/unit/test_depth_prior.py
@@ -18,7 +18,7 @@ from surreal_memory.engine.depth_prior import AdaptiveDepthSelector, DepthPrior
 from surreal_memory.engine.retrieval_types import DepthLevel
 from surreal_memory.extraction.entities import Entity, EntityType
 from surreal_memory.extraction.parser import Perspective, QueryIntent, Stimulus
-from surreal_memory.storage.sqlite_store import SQLiteStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
 from surreal_memory.utils.timeutils import utcnow
 
 # ---------------------------------------------------------------------------
@@ -457,16 +457,14 @@ class TestAdaptiveDepthSelectorRecordOutcome:
 
 
 # ---------------------------------------------------------------------------
-# Storage tests using real SQLiteStorage + tmp_path
+# Storage tests using real InMemoryStorage + tmp_path
 # ---------------------------------------------------------------------------
 
 
 @pytest_asyncio.fixture
-async def sqlite_storage(tmp_path: Path) -> SQLiteStorage:
-    """SQLiteStorage backed by a temp file, brain context set."""
-    db_path = tmp_path / "test_depth.db"
-    store = SQLiteStorage(db_path)
-    await store.initialize()
+async def sqlite_storage(tmp_path: Path) -> InMemoryStorage:
+    """InMemoryStorage backed by a temp file, brain context set."""
+    store = InMemoryStorage()
     brain = Brain.create(name="test-depth-brain")
     await store.save_brain(brain)
     store.set_brain(brain.id)
@@ -474,11 +472,9 @@ async def sqlite_storage(tmp_path: Path) -> SQLiteStorage:
 
 
 @pytest_asyncio.fixture
-async def sqlite_storage_alt_brain(tmp_path: Path) -> SQLiteStorage:
-    """Second SQLiteStorage sharing the same DB file but a different brain."""
-    db_path = tmp_path / "test_depth.db"
-    store = SQLiteStorage(db_path)
-    await store.initialize()
+async def sqlite_storage_alt_brain(tmp_path: Path) -> InMemoryStorage:
+    """Second InMemoryStorage sharing the same DB file but a different brain."""
+    store = InMemoryStorage()
 
     brain_a = Brain.create(name="brain-A")
     brain_b = Brain.create(name="brain-B")
@@ -492,7 +488,7 @@ async def sqlite_storage_alt_brain(tmp_path: Path) -> SQLiteStorage:
 
 class TestSQLiteDepthPriorStorage:
     @pytest.mark.asyncio
-    async def test_upsert_and_get_depth_prior(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_upsert_and_get_depth_prior(self, sqlite_storage: InMemoryStorage) -> None:
         """Round-trip: upsert then get_depth_priors returns same data."""
         prior = DepthPrior(
             entity_text="Alice",
@@ -513,7 +509,7 @@ class TestSQLiteDepthPriorStorage:
         assert r.total_queries == 5
 
     @pytest.mark.asyncio
-    async def test_upsert_updates_existing(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_upsert_updates_existing(self, sqlite_storage: InMemoryStorage) -> None:
         """Upserting same (entity, depth) key updates fields, not inserts duplicate."""
         prior = DepthPrior(entity_text="Bob", depth_level=DepthLevel.INSTANT, alpha=2.0, beta=1.0)
         await sqlite_storage.upsert_depth_prior(prior)
@@ -530,7 +526,7 @@ class TestSQLiteDepthPriorStorage:
         assert results[0].total_queries == 4
 
     @pytest.mark.asyncio
-    async def test_get_depth_priors_batch(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_get_depth_priors_batch(self, sqlite_storage: InMemoryStorage) -> None:
         """Batch fetch returns priors grouped by entity."""
         for entity, depth, alpha in [
             ("A", DepthLevel.INSTANT, 2.0),
@@ -549,14 +545,16 @@ class TestSQLiteDepthPriorStorage:
         assert result["B"][0].alpha == pytest.approx(4.0)
 
     @pytest.mark.asyncio
-    async def test_get_depth_priors_batch_empty_input(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_get_depth_priors_batch_empty_input(
+        self, sqlite_storage: InMemoryStorage
+    ) -> None:
         """Empty entity list returns empty dict without DB error."""
         result = await sqlite_storage.get_depth_priors_batch([])
         assert result == {}
 
     @pytest.mark.asyncio
     async def test_get_depth_priors_batch_missing_entity(
-        self, sqlite_storage: SQLiteStorage
+        self, sqlite_storage: InMemoryStorage
     ) -> None:
         """Entity with no priors gets empty list in result."""
         await sqlite_storage.upsert_depth_prior(
@@ -567,7 +565,7 @@ class TestSQLiteDepthPriorStorage:
         assert result["absent"] == []
 
     @pytest.mark.asyncio
-    async def test_get_stale_priors(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_get_stale_priors(self, sqlite_storage: InMemoryStorage) -> None:
         """get_stale_priors returns priors with last_updated before the cutoff."""
         old_time = utcnow() - timedelta(days=60)
         stale_prior = DepthPrior(
@@ -591,7 +589,7 @@ class TestSQLiteDepthPriorStorage:
         assert "fresh" not in entity_texts
 
     @pytest.mark.asyncio
-    async def test_delete_depth_priors(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_delete_depth_priors(self, sqlite_storage: InMemoryStorage) -> None:
         """delete_depth_priors removes all depth levels for an entity."""
         for depth in [DepthLevel.INSTANT, DepthLevel.CONTEXT, DepthLevel.DEEP]:
             await sqlite_storage.upsert_depth_prior(
@@ -605,7 +603,7 @@ class TestSQLiteDepthPriorStorage:
         assert remaining == []
 
     @pytest.mark.asyncio
-    async def test_delete_nonexistent_returns_zero(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_delete_nonexistent_returns_zero(self, sqlite_storage: InMemoryStorage) -> None:
         """Deleting an entity with no priors returns 0."""
         count = await sqlite_storage.delete_depth_priors("ghost")
         assert count == 0
@@ -613,9 +611,7 @@ class TestSQLiteDepthPriorStorage:
     @pytest.mark.asyncio
     async def test_brain_isolation(self, tmp_path: Path) -> None:
         """Priors stored under brain A are not visible under brain B."""
-        db_path = tmp_path / "isolation.db"
-        store = SQLiteStorage(db_path)
-        await store.initialize()
+        store = InMemoryStorage()
 
         brain_a = Brain.create(name="brain-a")
         brain_b = Brain.create(name="brain-b")
@@ -639,7 +635,7 @@ class TestSQLiteDepthPriorStorage:
         assert len(priors_a) == 1
 
     @pytest.mark.asyncio
-    async def test_all_depth_levels_round_trip(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_all_depth_levels_round_trip(self, sqlite_storage: InMemoryStorage) -> None:
         """Every DepthLevel value can be stored and retrieved correctly."""
         for level in DepthLevel:
             prior = DepthPrior(
@@ -654,13 +650,13 @@ class TestSQLiteDepthPriorStorage:
 
 
 # ---------------------------------------------------------------------------
-# Integration: AdaptiveDepthSelector + real SQLiteStorage
+# Integration: AdaptiveDepthSelector + real InMemoryStorage
 # ---------------------------------------------------------------------------
 
 
 class TestAdaptiveDepthSelectorIntegration:
     @pytest.mark.asyncio
-    async def test_full_cycle_record_then_select(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_full_cycle_record_then_select(self, sqlite_storage: InMemoryStorage) -> None:
         """Record many successes for CONTEXT, then select_depth should choose CONTEXT."""
         selector = AdaptiveDepthSelector(sqlite_storage, epsilon=0.0)
         stimulus = _make_stimulus(["Project"])
@@ -683,7 +679,7 @@ class TestAdaptiveDepthSelectorIntegration:
 
     @pytest.mark.asyncio
     async def test_record_outcome_persists_across_selector_instances(
-        self, sqlite_storage: SQLiteStorage
+        self, sqlite_storage: InMemoryStorage
     ) -> None:
         """Outcomes recorded by one selector instance are visible to another."""
         selector_a = AdaptiveDepthSelector(sqlite_storage, epsilon=0.0)

--- a/tests/unit/test_device_storage.py
+++ b/tests/unit/test_device_storage.py
@@ -7,18 +7,16 @@ import pathlib
 import pytest_asyncio
 
 from surreal_memory.core.brain import Brain, BrainConfig
+from surreal_memory.storage.memory_store import InMemoryStorage
 from surreal_memory.storage.sqlite_devices import DeviceRecord
-from surreal_memory.storage.sqlite_store import SQLiteStorage
 
 # ── Fixture ───────────────────────────────────────────────────────────────────
 
 
 @pytest_asyncio.fixture
-async def storage_with_brain(tmp_path: pathlib.Path) -> SQLiteStorage:
-    """SQLiteStorage with one initialized brain, ready for device tests."""
-    db_path = tmp_path / "test_devices.db"
-    storage = SQLiteStorage(db_path)
-    await storage.initialize()
+async def storage_with_brain(tmp_path: pathlib.Path) -> InMemoryStorage:
+    """InMemoryStorage with one initialized brain, ready for device tests."""
+    storage = InMemoryStorage()
 
     brain = Brain.create(name="device-test", config=BrainConfig())
     await storage.save_brain(brain)
@@ -35,7 +33,7 @@ async def storage_with_brain(tmp_path: pathlib.Path) -> SQLiteStorage:
 class TestRegisterDevice:
     """Test register_device creates and returns a DeviceRecord."""
 
-    async def test_register_device(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_register_device(self, storage_with_brain: InMemoryStorage) -> None:
         """Register a device — verify all returned fields."""
         record = await storage_with_brain.register_device(
             device_id="dev-001", device_name="my-laptop"
@@ -49,7 +47,7 @@ class TestRegisterDevice:
         # registered_at is populated
         assert record.registered_at is not None
 
-    async def test_register_device_upsert(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_register_device_upsert(self, storage_with_brain: InMemoryStorage) -> None:
         """Registering the same device_id twice updates device_name."""
         await storage_with_brain.register_device("dev-001", "old-name")
         await storage_with_brain.register_device("dev-001", "new-name")
@@ -58,12 +56,14 @@ class TestRegisterDevice:
         assert fetched is not None
         assert fetched.device_name == "new-name"
 
-    async def test_register_device_without_name(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_register_device_without_name(self, storage_with_brain: InMemoryStorage) -> None:
         """register_device with no name uses empty string."""
         record = await storage_with_brain.register_device("dev-no-name")
         assert record.device_name == ""
 
-    async def test_register_device_stores_brain_id(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_register_device_stores_brain_id(
+        self, storage_with_brain: InMemoryStorage
+    ) -> None:
         """Registered DeviceRecord carries the current brain_id."""
         record = await storage_with_brain.register_device("dev-002", "desktop")
         expected_brain_id = storage_with_brain._get_brain_id()
@@ -73,12 +73,12 @@ class TestRegisterDevice:
 class TestGetDevice:
     """Test get_device retrieves or returns None."""
 
-    async def test_get_device_not_found(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_get_device_not_found(self, storage_with_brain: InMemoryStorage) -> None:
         """get_device returns None when device_id is not registered."""
         result = await storage_with_brain.get_device("nonexistent-dev")
         assert result is None
 
-    async def test_get_device_returns_record(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_get_device_returns_record(self, storage_with_brain: InMemoryStorage) -> None:
         """get_device returns the correct DeviceRecord after registration."""
         await storage_with_brain.register_device("dev-abc", "work-machine")
 
@@ -88,7 +88,7 @@ class TestGetDevice:
         assert record.device_name == "work-machine"
 
     async def test_get_device_returns_device_record_type(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """get_device returns a DeviceRecord instance."""
         await storage_with_brain.register_device("dev-typed", "typed-machine")
@@ -99,12 +99,12 @@ class TestGetDevice:
 class TestListDevices:
     """Test list_devices returns all devices sorted by registered_at."""
 
-    async def test_list_devices_empty(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_list_devices_empty(self, storage_with_brain: InMemoryStorage) -> None:
         """list_devices returns empty list when no devices registered."""
         devices = await storage_with_brain.list_devices()
         assert devices == []
 
-    async def test_list_devices_two_devices(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_list_devices_two_devices(self, storage_with_brain: InMemoryStorage) -> None:
         """register 2 devices, list returns 2 sorted by registered_at ASC."""
         await storage_with_brain.register_device("dev-first", "machine-a")
         await storage_with_brain.register_device("dev-second", "machine-b")
@@ -117,7 +117,7 @@ class TestListDevices:
         assert "dev-second" in ids
 
     async def test_list_devices_sorted_by_registered_at(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """Devices come back in ascending registered_at order."""
         await storage_with_brain.register_device("dev-a", "alpha")
@@ -130,7 +130,7 @@ class TestListDevices:
             assert devices[i].registered_at <= devices[i + 1].registered_at
 
     async def test_list_devices_returns_device_record_instances(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """All items returned by list_devices are DeviceRecord instances."""
         await storage_with_brain.register_device("dev-x", "x")
@@ -141,7 +141,7 @@ class TestListDevices:
 class TestUpdateDeviceSync:
     """Test update_device_sync updates last_sync_at and last_sync_sequence."""
 
-    async def test_update_device_sync(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_update_device_sync(self, storage_with_brain: InMemoryStorage) -> None:
         """After update_device_sync, fetched record reflects new values."""
         await storage_with_brain.register_device("dev-sync", "sync-machine")
 
@@ -153,7 +153,7 @@ class TestUpdateDeviceSync:
         assert record.last_sync_at is not None
 
     async def test_update_device_sync_increases_sequence(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """Updating sync twice carries the latest sequence."""
         await storage_with_brain.register_device("dev-seq", "seq-machine")
@@ -165,7 +165,7 @@ class TestUpdateDeviceSync:
         assert record.last_sync_sequence == 99
 
     async def test_update_device_sync_sets_last_sync_at(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """update_device_sync sets last_sync_at to a recent timestamp."""
         from surreal_memory.utils.timeutils import utcnow
@@ -184,7 +184,7 @@ class TestUpdateDeviceSync:
 class TestRemoveDevice:
     """Test remove_device deletes a registered device."""
 
-    async def test_remove_device(self, storage_with_brain: SQLiteStorage) -> None:
+    async def test_remove_device(self, storage_with_brain: InMemoryStorage) -> None:
         """remove_device returns True and the device is no longer found."""
         await storage_with_brain.register_device("dev-remove", "to-remove")
 
@@ -195,14 +195,14 @@ class TestRemoveDevice:
         assert fetched is None
 
     async def test_remove_device_not_found_returns_false(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """remove_device returns False if device_id does not exist."""
         result = await storage_with_brain.remove_device("ghost-device")
         assert result is False
 
     async def test_remove_device_does_not_affect_others(
-        self, storage_with_brain: SQLiteStorage
+        self, storage_with_brain: InMemoryStorage
     ) -> None:
         """Removing one device does not remove others."""
         await storage_with_brain.register_device("dev-keep", "keeper")
@@ -219,9 +219,7 @@ class TestBrainIsolation:
 
     async def test_brain_isolation(self, tmp_path: pathlib.Path) -> None:
         """Devices in brain A are invisible when brain B is the active context."""
-        db_path = tmp_path / "isolation_devices.db"
-        storage = SQLiteStorage(db_path)
-        await storage.initialize()
+        storage = InMemoryStorage()
 
         brain_a = Brain.create(name="brain-a", config=BrainConfig())
         brain_b = Brain.create(name="brain-b", config=BrainConfig())

--- a/tests/unit/test_ephemeral.py
+++ b/tests/unit/test_ephemeral.py
@@ -13,8 +13,8 @@ import pytest
 
 from surreal_memory.core.brain import Brain
 from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.storage.memory_store import InMemoryStorage
 from surreal_memory.storage.sqlite_schema import SCHEMA_VERSION
-from surreal_memory.storage.sqlite_store import SQLiteStorage
 from surreal_memory.utils.timeutils import utcnow
 
 # ── Schema ──────────────────────────────────────────────────────────
@@ -53,10 +53,9 @@ class TestNeuronEphemeral:
 
 
 @pytest.fixture
-async def storage(tmp_path: Path) -> SQLiteStorage:
-    """Create a fresh SQLiteStorage with a default brain."""
-    s = SQLiteStorage(db_path=str(tmp_path / "test_ephemeral.db"))
-    await s.initialize()
+async def storage(tmp_path: Path) -> InMemoryStorage:
+    """Create a fresh InMemoryStorage with a default brain."""
+    s = InMemoryStorage()
     brain = Brain.create(name="ephemeral-test")
     await s.save_brain(brain)
     s.set_brain(brain.id)
@@ -65,7 +64,7 @@ async def storage(tmp_path: Path) -> SQLiteStorage:
 
 @pytest.mark.asyncio
 class TestEphemeralStorage:
-    async def test_add_ephemeral_neuron(self, storage: SQLiteStorage) -> None:
+    async def test_add_ephemeral_neuron(self, storage: InMemoryStorage) -> None:
         n = Neuron.create(type=NeuronType.CONCEPT, content="temp note", ephemeral=True)
         await storage.add_neuron(n)
 
@@ -73,7 +72,7 @@ class TestEphemeralStorage:
         assert fetched is not None
         assert fetched.ephemeral is True
 
-    async def test_add_permanent_neuron(self, storage: SQLiteStorage) -> None:
+    async def test_add_permanent_neuron(self, storage: InMemoryStorage) -> None:
         n = Neuron.create(type=NeuronType.CONCEPT, content="permanent note")
         await storage.add_neuron(n)
 
@@ -81,7 +80,7 @@ class TestEphemeralStorage:
         assert fetched is not None
         assert fetched.ephemeral is False
 
-    async def test_find_neurons_ephemeral_filter(self, storage: SQLiteStorage) -> None:
+    async def test_find_neurons_ephemeral_filter(self, storage: InMemoryStorage) -> None:
         n_perm = Neuron.create(type=NeuronType.CONCEPT, content="permanent fact")
         n_eph = Neuron.create(type=NeuronType.CONCEPT, content="ephemeral fact", ephemeral=True)
         await storage.add_neuron(n_perm)
@@ -101,7 +100,7 @@ class TestEphemeralStorage:
         assert len(eph_only) == 1
         assert eph_only[0].ephemeral is True
 
-    async def test_find_neurons_no_filter_includes_all(self, storage: SQLiteStorage) -> None:
+    async def test_find_neurons_no_filter_includes_all(self, storage: InMemoryStorage) -> None:
         for i in range(3):
             await storage.add_neuron(
                 Neuron.create(
@@ -113,7 +112,7 @@ class TestEphemeralStorage:
         all_neurons = await storage.find_neurons()
         assert len(all_neurons) == 3
 
-    async def test_cleanup_ephemeral_neurons(self, storage: SQLiteStorage) -> None:
+    async def test_cleanup_ephemeral_neurons(self, storage: InMemoryStorage) -> None:
         # Create an ephemeral neuron with old timestamp
         old_time = utcnow() - timedelta(hours=25)
         n_old = Neuron(
@@ -140,7 +139,7 @@ class TestEphemeralStorage:
         assert n_fresh.id in remaining_ids
         assert n_perm.id in remaining_ids
 
-    async def test_cleanup_does_not_touch_permanent(self, storage: SQLiteStorage) -> None:
+    async def test_cleanup_does_not_touch_permanent(self, storage: InMemoryStorage) -> None:
         old_time = utcnow() - timedelta(hours=48)
         n_perm = Neuron(
             id="old-perm",
@@ -153,7 +152,7 @@ class TestEphemeralStorage:
         deleted = await storage.cleanup_ephemeral_neurons(max_age_hours=24.0)
         assert deleted == 0
 
-    async def test_batch_get_includes_ephemeral_flag(self, storage: SQLiteStorage) -> None:
+    async def test_batch_get_includes_ephemeral_flag(self, storage: InMemoryStorage) -> None:
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="a", ephemeral=True)
         n2 = Neuron.create(type=NeuronType.CONCEPT, content="b", ephemeral=False)
         await storage.add_neuron(n1)
@@ -169,7 +168,7 @@ class TestEphemeralStorage:
 
 @pytest.mark.asyncio
 class TestEphemeralSyncExclusion:
-    async def test_seed_change_log_excludes_ephemeral(self, storage: SQLiteStorage) -> None:
+    async def test_seed_change_log_excludes_ephemeral(self, storage: InMemoryStorage) -> None:
         n_perm = Neuron.create(type=NeuronType.CONCEPT, content="permanent for sync")
         n_eph = Neuron.create(type=NeuronType.CONCEPT, content="ephemeral no sync", ephemeral=True)
         await storage.add_neuron(n_perm)
@@ -191,7 +190,7 @@ class TestEphemeralSyncExclusion:
 
 @pytest.mark.asyncio
 class TestEphemeralConsolidationExclusion:
-    async def test_find_neurons_ephemeral_false_excludes(self, storage: SQLiteStorage) -> None:
+    async def test_find_neurons_ephemeral_false_excludes(self, storage: InMemoryStorage) -> None:
         """Consolidation uses find_neurons(ephemeral=False) — must exclude ephemeral."""
         n_eph = Neuron.create(type=NeuronType.CONCEPT, content="temp debug note", ephemeral=True)
         n_perm = Neuron.create(type=NeuronType.CONCEPT, content="important decision")

--- a/tests/unit/test_event_timestamp.py
+++ b/tests/unit/test_event_timestamp.py
@@ -9,7 +9,7 @@ import pytest
 
 from surreal_memory.core.brain import Brain
 from surreal_memory.engine.encoder import MemoryEncoder
-from surreal_memory.storage.sqlite_store import SQLiteStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
 from surreal_memory.utils.timeutils import utcnow
 
 
@@ -17,8 +17,7 @@ class TestEventTimestampMCP:
     """Test event_at parameter in encoder (simulating MCP handler logic)."""
 
     async def test_encode_with_custom_timestamp(self, tmp_path: Path) -> None:
-        storage = SQLiteStorage(tmp_path / "test.db")
-        await storage.initialize()
+        storage = InMemoryStorage()
 
         brain = Brain.create(name="test-brain")
         await storage.save_brain(brain)
@@ -51,8 +50,7 @@ class TestEventTimestampMCP:
         await storage.close()
 
     async def test_encode_without_timestamp_uses_now(self, tmp_path: Path) -> None:
-        storage = SQLiteStorage(tmp_path / "test.db")
-        await storage.initialize()
+        storage = InMemoryStorage()
 
         brain = Brain.create(name="test-brain")
         await storage.save_brain(brain)

--- a/tests/unit/test_find_fibers_tag_pushdown.py
+++ b/tests/unit/test_find_fibers_tag_pushdown.py
@@ -10,9 +10,7 @@ the sibling live tests.
 
 from __future__ import annotations
 
-import tempfile
 from collections.abc import AsyncIterator
-from pathlib import Path
 
 import pytest
 
@@ -20,28 +18,17 @@ from surreal_memory.core.brain import Brain
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.storage.memory_store import InMemoryStorage
-from surreal_memory.storage.sqlite_store import SQLiteStorage
 
 _TAG = "lc-session:keep-me"
 
 
-@pytest.fixture(params=["memory", "sqlite"])
-async def storage(request: pytest.FixtureRequest) -> AsyncIterator[object]:
-    if request.param == "memory":
-        s: object = InMemoryStorage()
-        brain = Brain.create(name="tagpush")
-        await s.save_brain(brain)  # type: ignore[attr-defined]
-        s.set_brain(brain.id)  # type: ignore[attr-defined]
-        yield s
-    else:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            sq = SQLiteStorage(Path(tmpdir) / "t.db")
-            await sq.initialize()
-            brain = Brain.create(name="tagpush")
-            await sq.save_brain(brain)
-            sq.set_brain(brain.id)
-            yield sq
-            await sq.close()
+@pytest.fixture
+async def storage() -> AsyncIterator[object]:
+    s: object = InMemoryStorage()
+    brain = Brain.create(name="tagpush")
+    await s.save_brain(brain)  # type: ignore[attr-defined]
+    s.set_brain(brain.id)  # type: ignore[attr-defined]
+    return s
 
 
 async def _add(storage: object, summary: str, salience: float, tag: str | None) -> Fiber:

--- a/tests/unit/test_geo_recall.py
+++ b/tests/unit/test_geo_recall.py
@@ -10,9 +10,7 @@ a mock. A hard filter: fibers outside the radius (or without a location) are dro
 
 from __future__ import annotations
 
-import tempfile
 from collections.abc import AsyncIterator
-from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -23,7 +21,6 @@ from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.engine.retrieval import ReflexPipeline, _fiber_near
 from surreal_memory.engine.retrieval_types import DepthLevel, RetrievalResult, Subgraph
 from surreal_memory.storage.memory_store import InMemoryStorage
-from surreal_memory.storage.sqlite_store import SQLiteStorage
 from surreal_memory.utils.geo import GeoFilter, GeoPoint
 
 _OSLO = {"lat": 59.9139, "lon": 10.7522, "label": "Oslo"}
@@ -59,19 +56,17 @@ class TestFiberNearUnit:
 
 
 @pytest.fixture
-async def storage() -> AsyncIterator[SQLiteStorage]:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        s = SQLiteStorage(Path(tmpdir) / "test.db")
-        await s.initialize()
-        brain = Brain.create(name="geo_test")
-        await s.save_brain(brain)
-        s.set_brain(brain.id)
-        yield s
-        await s.close()
+async def storage() -> AsyncIterator[InMemoryStorage]:
+    s = InMemoryStorage()
+    brain = Brain.create(name="geo_test")
+    await s.save_brain(brain)
+    s.set_brain(brain.id)
+    yield s
+    await s.close()
 
 
 async def _add_located_fiber(
-    storage: SQLiteStorage, content: str, location: dict[str, float] | None
+    storage: InMemoryStorage, content: str, location: dict[str, float] | None
 ) -> Fiber:
     neuron = Neuron.create(type=NeuronType.CONCEPT, content=content)
     await storage.add_neuron(neuron)
@@ -87,7 +82,7 @@ async def _add_located_fiber(
 
 
 class TestNearThroughPipeline:
-    async def test_near_keeps_only_fibers_in_radius(self, storage: SQLiteStorage) -> None:
+    async def test_near_keeps_only_fibers_in_radius(self, storage: InMemoryStorage) -> None:
         oslo = await _add_located_fiber(storage, "Cafe Mocca is in Oslo Norway", _OSLO)
         bergen = await _add_located_fiber(storage, "Cafe Mocca is in Bergen Norway", _BERGEN)
 
@@ -97,7 +92,7 @@ class TestNearThroughPipeline:
         assert oslo.id in result.fibers_matched
         assert bergen.id not in result.fibers_matched  # ~305 km away, filtered out
 
-    async def test_wider_radius_keeps_both(self, storage: SQLiteStorage) -> None:
+    async def test_wider_radius_keeps_both(self, storage: InMemoryStorage) -> None:
         oslo = await _add_located_fiber(storage, "Cafe Mocca is in Oslo Norway", _OSLO)
         bergen = await _add_located_fiber(storage, "Cafe Mocca is in Bergen Norway", _BERGEN)
 
@@ -107,7 +102,7 @@ class TestNearThroughPipeline:
         assert oslo.id in result.fibers_matched
         assert bergen.id in result.fibers_matched  # 400 km covers Bergen
 
-    async def test_no_near_is_a_noop(self, storage: SQLiteStorage) -> None:
+    async def test_no_near_is_a_noop(self, storage: InMemoryStorage) -> None:
         # Golden invariant: near=None leaves recall unchanged (both returned).
         oslo = await _add_located_fiber(storage, "Cafe Mocca is in Oslo Norway", _OSLO)
         bergen = await _add_located_fiber(storage, "Cafe Mocca is in Bergen Norway", _BERGEN)
@@ -119,7 +114,7 @@ class TestNearThroughPipeline:
         assert bergen.id in result.fibers_matched
 
     async def test_fiber_without_location_excluded_when_near_set(
-        self, storage: SQLiteStorage
+        self, storage: InMemoryStorage
     ) -> None:
         located = await _add_located_fiber(storage, "Cafe Mocca is in Oslo Norway", _OSLO)
         unlocated = await _add_located_fiber(storage, "Cafe Mocca is in Oslo Norway too", None)
@@ -151,7 +146,7 @@ def _sentinel_result() -> RetrievalResult:
 class TestNearBypassesFastPaths:
     """The valid_at lesson: an early-return fast-path must NOT swallow the geo filter."""
 
-    async def test_near_skips_temporal_fast_path(self, storage: SQLiteStorage) -> None:
+    async def test_near_skips_temporal_fast_path(self, storage: InMemoryStorage) -> None:
         oslo = await _add_located_fiber(storage, "Cafe Mocca is in Oslo Norway", _OSLO)
         pipeline = ReflexPipeline(storage, BrainConfig())
 
@@ -168,24 +163,14 @@ class TestNearBypassesFastPaths:
         assert oslo.id in geo.fibers_matched
 
 
-@pytest.fixture(params=["memory", "sqlite"])
-async def browse_storage(request: pytest.FixtureRequest) -> AsyncIterator[object]:
-    """Same geo browse contract on both in-process backends (SurrealDB: *_live test)."""
-    if request.param == "memory":
-        s: object = InMemoryStorage()
-        brain = Brain.create(name="geo_browse")
-        await s.save_brain(brain)  # type: ignore[attr-defined]
-        s.set_brain(brain.id)  # type: ignore[attr-defined]
-        yield s
-    else:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            sq = SQLiteStorage(Path(tmpdir) / "test.db")
-            await sq.initialize()
-            brain = Brain.create(name="geo_browse")
-            await sq.save_brain(brain)
-            sq.set_brain(brain.id)
-            yield sq
-            await sq.close()
+@pytest.fixture
+async def browse_storage() -> AsyncIterator[object]:
+    """Geo browse contract on the in-process backend (SurrealDB: *_live test)."""
+    s: object = InMemoryStorage()
+    brain = Brain.create(name="geo_browse")
+    await s.save_brain(brain)  # type: ignore[attr-defined]
+    s.set_brain(brain.id)  # type: ignore[attr-defined]
+    return s
 
 
 async def _browse_add(storage: object, content: str, location: dict[str, float] | None) -> Fiber:

--- a/tests/unit/test_get_fibers_exclude_expired.py
+++ b/tests/unit/test_get_fibers_exclude_expired.py
@@ -6,9 +6,7 @@ immediately (before consolidation cleanup) instead of only under hard delete.
 
 from __future__ import annotations
 
-import tempfile
 from collections.abc import AsyncIterator
-from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -19,7 +17,6 @@ from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.storage.base import NeuralStorage
 from surreal_memory.storage.memory_store import InMemoryStorage
-from surreal_memory.storage.sqlite_store import SQLiteStorage
 from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
 
@@ -90,15 +87,13 @@ async def in_memory() -> InMemoryStorage:
 
 
 @pytest.fixture
-async def sqlite() -> AsyncIterator[SQLiteStorage]:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        storage = SQLiteStorage(Path(tmpdir) / "test.db")
-        await storage.initialize()
-        brain = Brain.create(name="test_brain")
-        await storage.save_brain(brain)
-        storage.set_brain(brain.id)
-        yield storage
-        await storage.close()
+async def sqlite() -> AsyncIterator[InMemoryStorage]:
+    storage = InMemoryStorage()
+    brain = Brain.create(name="test_brain")
+    await storage.save_brain(brain)
+    storage.set_brain(brain.id)
+    yield storage
+    await storage.close()
 
 
 async def _assert_exclude_expired(storage: NeuralStorage) -> None:
@@ -125,5 +120,5 @@ async def test_in_memory_get_fibers_excludes_expired(in_memory: InMemoryStorage)
 
 
 @pytest.mark.asyncio
-async def test_sqlite_get_fibers_excludes_expired(sqlite: SQLiteStorage) -> None:
+async def test_sqlite_get_fibers_excludes_expired(sqlite: InMemoryStorage) -> None:
     await _assert_exclude_expired(sqlite)

--- a/tests/unit/test_get_project_memories.py
+++ b/tests/unit/test_get_project_memories.py
@@ -24,7 +24,7 @@ from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.project import Project
 from surreal_memory.storage.base import NeuralStorage
-from surreal_memory.storage.sqlite_store import SQLiteStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
 from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
 
 SURREALDB_URL = os.getenv("SURREALDB_URL")
@@ -98,9 +98,8 @@ async def _seed_six_memories(
 
 
 @pytest.fixture
-async def sqlite_storage(tmp_path: Path) -> SQLiteStorage:
-    storage = SQLiteStorage(tmp_path / "parity.db")
-    await storage.initialize()
+async def sqlite_storage(tmp_path: Path) -> InMemoryStorage:
+    storage = InMemoryStorage()
     brain = Brain.create(name="parity-test")
     await storage.save_brain(brain)
     storage.set_brain(brain.id)
@@ -140,7 +139,7 @@ async def surrealdb_storage():  # type: ignore[no-untyped-def]
 class TestGetProjectMemoriesParity:
     @pytest.mark.asyncio
     async def test_sqlite_filters_by_project_id_excludes_expired(
-        self, sqlite_storage: SQLiteStorage
+        self, sqlite_storage: InMemoryStorage
     ) -> None:
         seed = await _seed_six_memories(sqlite_storage)
         rows = await sqlite_storage.get_project_memories(seed.alpha_id)
@@ -149,14 +148,18 @@ class TestGetProjectMemoriesParity:
         assert rows[0].fiber_id in seed.fibers_by_project[seed.alpha_id]
 
     @pytest.mark.asyncio
-    async def test_sqlite_include_expired_returns_both(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_sqlite_include_expired_returns_both(
+        self, sqlite_storage: InMemoryStorage
+    ) -> None:
         seed = await _seed_six_memories(sqlite_storage)
         rows = await sqlite_storage.get_project_memories(seed.alpha_id, include_expired=True)
         assert {r.fiber_id for r in rows} == seed.fibers_by_project[seed.alpha_id]
         assert len(rows) == 2
 
     @pytest.mark.asyncio
-    async def test_sqlite_other_projects_not_returned(self, sqlite_storage: SQLiteStorage) -> None:
+    async def test_sqlite_other_projects_not_returned(
+        self, sqlite_storage: InMemoryStorage
+    ) -> None:
         seed = await _seed_six_memories(sqlite_storage)
         rows = await sqlite_storage.get_project_memories(seed.beta_id)
         assert {r.fiber_id for r in rows} == seed.fibers_by_project[seed.beta_id]
@@ -168,7 +171,7 @@ class TestGetProjectMemoriesParity:
     @pytest.mark.asyncio
     @_skip_surrealdb
     async def test_surrealdb_matches_sqlite_partitioning(
-        self, sqlite_storage: SQLiteStorage, surrealdb_storage: NeuralStorage
+        self, sqlite_storage: InMemoryStorage, surrealdb_storage: NeuralStorage
     ) -> None:
         """Cross-backend parity: same partition shape on both backends.
 

--- a/tests/unit/test_golden_ranking.py
+++ b/tests/unit/test_golden_ranking.py
@@ -13,24 +13,28 @@ which is float-deterministic for a given query.
 
 from __future__ import annotations
 
-import tempfile
-from pathlib import Path
-
 import pytest
 
 from surreal_memory.core.brain import Brain, BrainConfig
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.engine.retrieval import ReflexPipeline
-from surreal_memory.storage.sqlite_store import SQLiteStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
 
 # Ordered (fiber_id) ranking recorded on the pre-trust baseline for QUERY below.
 # Regenerate ONLY intentionally (a real ranking change): run this test, read the
 # assertion diff, and paste the observed order here.
+#
+# Re-recorded for the SQLite -> InMemoryStorage backend swap (PR6): SQLite's FTS5
+# index stems "synapses" (query) to match "synapse" (g-synapse's neuron content),
+# so g-synapse entered the SQLite-backed ranking. InMemoryStorage.find_neurons()
+# does plain case-insensitive substring matching (no stemming), so it never
+# anchors on g-synapse for this query and the fiber is correctly absent here —
+# this is a known, accepted limitation of the in-memory test double relative to
+# both real backends' full-text search, not a ranking regression.
 GOLDEN_ORDER: list[str] = [
     "g-activation",
     "g-decay",
-    "g-synapse",
 ]
 
 QUERY = "spreading activation through weighted synapses in the neural graph"
@@ -56,10 +60,8 @@ _FIBERS: list[tuple[str, str, str]] = [
 ]
 
 
-async def _build() -> SQLiteStorage:
-    tmp = tempfile.mkdtemp()
-    store = SQLiteStorage(Path(tmp) / "golden.db")
-    await store.initialize()
+async def _build() -> InMemoryStorage:
+    store = InMemoryStorage()
     brain = Brain.create(name="golden_brain")
     await store.save_brain(brain)
     store.set_brain(brain.id)
@@ -138,8 +140,7 @@ async def test_trust_weight_demotes_low_trust_fiber() -> None:
     # trust-multiply (score *= (1-tw) + tw*trust) would fail this.
     from surreal_memory.core.memory_types import MemoryType, TypedMemory
 
-    store = SQLiteStorage(Path(tempfile.mkdtemp()) / "trust_dir.db")
-    await store.initialize()
+    store = InMemoryStorage()
     brain = Brain.create(name="trust_dir")
     await store.save_brain(brain)
     store.set_brain(brain.id)

--- a/tests/unit/test_inmemory_completeness.py
+++ b/tests/unit/test_inmemory_completeness.py
@@ -1,0 +1,56 @@
+"""InMemoryStorage has to implement the whole NeuralStorage interface.
+
+It is the test double the suite runs on, so a method it leaves as an inherited
+stub is a feature that silently loses its coverage: `hasattr` says yes, the
+call raises. Sixty-four methods sat in that state — sources, alerts, cognitive
+state, knowledge gaps, devices, change log, Merkle sync, depth priors,
+compression backups, neuron snapshots, lifecycle flags, hot index — tolerable
+only while SQLite was around to back the tests that needed them.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from surreal_memory.storage.base import NeuralStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
+
+
+def _interface_methods() -> set[str]:
+    return {
+        name
+        for name, member in inspect.getmembers(NeuralStorage, predicate=inspect.isfunction)
+        if not name.startswith("_")
+    }
+
+
+def _inherited_stubs(cls: type) -> set[str]:
+    """Interface methods `cls` never overrode, still raising NotImplementedError."""
+    stubs: set[str] = set()
+    for name in _interface_methods():
+        impl = getattr(cls, name, None)
+        if impl is None:
+            stubs.add(name)
+            continue
+        if not impl.__qualname__.startswith("NeuralStorage"):
+            continue
+        try:
+            if "NotImplementedError" in inspect.getsource(impl):
+                stubs.add(name)
+        except OSError:  # pragma: no cover - source always available in-tree
+            continue
+    return stubs
+
+
+def test_the_interface_is_non_trivial() -> None:
+    # Guards the introspection itself: an empty set here would make the
+    # assertion below pass without having checked anything.
+    assert len(_interface_methods()) > 100
+
+
+def test_in_memory_storage_implements_every_method() -> None:
+    missing = _inherited_stubs(InMemoryStorage)
+
+    assert not missing, (
+        f"{len(missing)} NeuralStorage method(s) still inherited as stubs: {sorted(missing)}"
+    )

--- a/tests/unit/test_reranker_http_and_config.py
+++ b/tests/unit/test_reranker_http_and_config.py
@@ -29,7 +29,7 @@ from surreal_memory.engine.reranker import (
     rerank_activations,
     reranker_available,
 )
-from surreal_memory.storage.sqlite_store import SQLiteStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
 from surreal_memory.storage.surrealdb.store import (
     _deserialize_brain_config,
     _serialize_brain_config,
@@ -342,8 +342,7 @@ class TestSqliteRerankerPersistence:
 
     @pytest.mark.asyncio
     async def test_sqlite_roundtrip_persists_reranker(self, tmp_path: Path) -> None:
-        store = SQLiteStorage(tmp_path / "s.db")
-        await store.initialize()
+        store = InMemoryStorage()
         try:
             brain = Brain.create(
                 name="rr_brain",
@@ -377,8 +376,7 @@ class TestMigrateDoesNotTouchReranker:
 
     @pytest.mark.asyncio
     async def test_migrate_does_not_enable_reranker(self, tmp_path: Path) -> None:
-        store = SQLiteStorage(tmp_path / "m.db")
-        await store.initialize()
+        store = InMemoryStorage()
         try:
             brain = Brain.create(name="legacy")  # reranker off by default
             await store.save_brain(brain)
@@ -401,8 +399,7 @@ class TestMigrateDoesNotTouchReranker:
         # The exact reranker-flip scenario: the shared brain has reranker ON (set
         # by another client), and this client's app config has it OFF. Migration
         # must NOT disable it on the shared brain.
-        store = SQLiteStorage(tmp_path / "n.db")
-        await store.initialize()
+        store = InMemoryStorage()
         try:
             brain = Brain.create(
                 name="shared",

--- a/tests/unit/test_source_registry.py
+++ b/tests/unit/test_source_registry.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from surreal_memory.core.source import Source, SourceStatus, SourceType
+from surreal_memory.storage.memory_store import InMemoryStorage
 
 # ──────────────────── Source dataclass ────────────────────
 
@@ -122,15 +123,12 @@ class TestSchemaMigrationV23:
 
 
 class TestSQLiteSourcesMixin:
-    """Test source CRUD via SQLiteStorage."""
+    """Test source CRUD via InMemoryStorage."""
 
     @pytest.fixture
     async def storage(self, tmp_path):
-        from surreal_memory.storage.sqlite_store import SQLiteStorage
 
-        db_path = tmp_path / "test.db"
-        s = SQLiteStorage(db_path)
-        await s.initialize()
+        s = InMemoryStorage()
         # Create a brain
         from surreal_memory.core.brain import Brain
 

--- a/tests/unit/test_storage_brain_id_parity.py
+++ b/tests/unit/test_storage_brain_id_parity.py
@@ -46,15 +46,12 @@ class TestBrainIdProperty:
 
 
 class TestSQLiteStorageBrainId:
-    """Verify SQLiteStorage brain_id property."""
+    """Verify InMemoryStorage brain_id property."""
 
     @pytest.fixture
     async def storage(self, tmp_path):
-        from surreal_memory.storage.sqlite_store import SQLiteStorage
 
-        db_path = tmp_path / "test.db"
-        s = SQLiteStorage(db_path)
-        await s.initialize()
+        s = InMemoryStorage()
         yield s
         await s.close()
 

--- a/tests/unit/test_synapse_paging.py
+++ b/tests/unit/test_synapse_paging.py
@@ -9,7 +9,6 @@ property, not merely that an offset was accepted.
 
 from __future__ import annotations
 
-import pathlib
 import sys
 from unittest.mock import AsyncMock, MagicMock
 
@@ -20,7 +19,6 @@ from surreal_memory.core.brain import Brain, BrainConfig
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.synapse import Synapse, SynapseType
 from surreal_memory.storage.memory_store import InMemoryStorage
-from surreal_memory.storage.sqlite_store import SQLiteStorage
 
 try:  # pragma: no cover - mirrors tests/unit/test_surrealdb_store.py
     import surrealdb  # noqa: F401
@@ -113,15 +111,13 @@ class TestInMemoryPaging:
 class TestSQLitePaging:
     @pytest_asyncio.fixture
     async def storage(self, tmp_path: object):
-        db_path = pathlib.Path(str(tmp_path)) / "test_paging.db"
-        store = SQLiteStorage(db_path)
-        await store.initialize()
+        store = InMemoryStorage()
         brain = Brain.create(name="paging", config=BrainConfig(), owner_id="test")
         await store.save_brain(brain)
         store.set_brain(brain.id)
         return store
 
-    async def test_pages_partition_the_result_set(self, storage: SQLiteStorage) -> None:
+    async def test_pages_partition_the_result_set(self, storage: InMemoryStorage) -> None:
         neurons = _make_neurons(TOTAL)
         for neuron in neurons:
             await storage.add_neuron(neuron)
@@ -133,7 +129,7 @@ class TestSQLitePaging:
 
         _assert_pages_partition(pages, len(synapses))
 
-    async def test_offset_beyond_the_end_is_empty(self, storage: SQLiteStorage) -> None:
+    async def test_offset_beyond_the_end_is_empty(self, storage: InMemoryStorage) -> None:
         neurons = _make_neurons(3)
         for neuron in neurons:
             await storage.add_neuron(neuron)
@@ -142,7 +138,7 @@ class TestSQLitePaging:
 
         assert await storage.get_synapses(limit=PAGE, offset=999) == []
 
-    async def test_filters_still_apply_while_paging(self, storage: SQLiteStorage) -> None:
+    async def test_filters_still_apply_while_paging(self, storage: InMemoryStorage) -> None:
         neurons = _make_neurons(5)
         for neuron in neurons:
             await storage.add_neuron(neuron)

--- a/tests/unit/test_tag_filter_query.py
+++ b/tests/unit/test_tag_filter_query.py
@@ -17,41 +17,34 @@ Test cases:
 
 from __future__ import annotations
 
-import tempfile
-from pathlib import Path
-
 import pytest
 
 from surreal_memory.core.brain import Brain
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.synapse import Synapse, SynapseType
-from surreal_memory.storage.sqlite_store import SQLiteStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
 
 
 @pytest.fixture
-async def storage() -> SQLiteStorage:
-    """Create a temporary SQLite storage with a test brain."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = Path(tmpdir) / "test.db"
-        storage = SQLiteStorage(db_path)
-        await storage.initialize()
+async def storage() -> InMemoryStorage:
+    """Create an in-memory storage with a test brain."""
+    storage = InMemoryStorage()
 
-        # Create and set brain
-        brain = Brain.create(name="test_brain")
-        await storage.save_brain(brain)
-        storage.set_brain(brain.id)
+    # Create and set brain
+    brain = Brain.create(name="test_brain")
+    await storage.save_brain(brain)
+    storage.set_brain(brain.id)
 
-        yield storage
-
-        await storage.close()
+    yield storage
+    await storage.close()
 
 
 class TestTagFilterQueryNoTags:
     """Test backward compatibility: find_fibers_batch() without tag filtering."""
 
     @pytest.mark.asyncio
-    async def test_find_fibers_batch_no_tags_filter(self, storage: SQLiteStorage) -> None:
+    async def test_find_fibers_batch_no_tags_filter(self, storage: InMemoryStorage) -> None:
         """Tags=None should return all matching fibers (backward compatible)."""
         # Create neurons
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="Python")
@@ -98,7 +91,9 @@ class TestTagFilterSingleTag:
     """Test single tag filtering across all tag columns."""
 
     @pytest.mark.asyncio
-    async def test_find_fibers_batch_single_tag_in_agent_tags(self, storage: SQLiteStorage) -> None:
+    async def test_find_fibers_batch_single_tag_in_agent_tags(
+        self, storage: InMemoryStorage
+    ) -> None:
         """Single tag in agent_tags should be found."""
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="Knowledge base")
         n2 = Neuron.create(type=NeuronType.CONCEPT, content="Query")
@@ -127,7 +122,9 @@ class TestTagFilterSingleTag:
         assert result[0].id == f1.id
 
     @pytest.mark.asyncio
-    async def test_find_fibers_batch_single_tag_in_auto_tags(self, storage: SQLiteStorage) -> None:
+    async def test_find_fibers_batch_single_tag_in_auto_tags(
+        self, storage: InMemoryStorage
+    ) -> None:
         """Single tag in auto_tags should be found."""
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="Entity extraction")
         n2 = Neuron.create(type=NeuronType.CONCEPT, content="NLP")
@@ -156,7 +153,7 @@ class TestTagFilterSingleTag:
         assert result[0].id == f1.id
 
     @pytest.mark.asyncio
-    async def test_find_fibers_batch_single_tag_mismatch(self, storage: SQLiteStorage) -> None:
+    async def test_find_fibers_batch_single_tag_mismatch(self, storage: InMemoryStorage) -> None:
         """Single tag that doesn't match should return empty."""
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="Topic")
         await storage.add_neuron(n1)
@@ -179,7 +176,7 @@ class TestTagFilterANDSemantics:
 
     @pytest.mark.asyncio
     async def test_find_fibers_batch_multiple_tags_and_semantics(
-        self, storage: SQLiteStorage
+        self, storage: InMemoryStorage
     ) -> None:
         """Fiber must have ALL tags (AND semantics)."""
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="React KB")
@@ -228,7 +225,7 @@ class TestTagFilterANDSemantics:
 
     @pytest.mark.asyncio
     async def test_find_fibers_batch_multiple_tags_across_columns(
-        self, storage: SQLiteStorage
+        self, storage: InMemoryStorage
     ) -> None:
         """Fiber with tags spread across auto_tags and agent_tags should match."""
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="Hybrid tags")
@@ -254,7 +251,7 @@ class TestTagFilterMixedFibers:
     """Test filtering with multiple fibers having different tag combinations."""
 
     @pytest.mark.asyncio
-    async def test_find_fibers_batch_mixed_fibers(self, storage: SQLiteStorage) -> None:
+    async def test_find_fibers_batch_mixed_fibers(self, storage: InMemoryStorage) -> None:
         """Filter returns only matching fibers from mixed set."""
         # Create neurons
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="Node 1")
@@ -340,13 +337,13 @@ class TestTagFilterEdgeCases:
     """Test edge cases and special scenarios."""
 
     @pytest.mark.asyncio
-    async def test_find_fibers_batch_empty_neuron_list(self, storage: SQLiteStorage) -> None:
+    async def test_find_fibers_batch_empty_neuron_list(self, storage: InMemoryStorage) -> None:
         """Empty neuron list should return empty."""
         result = await storage.find_fibers_batch([], tags={"kb"})
         assert len(result) == 0
 
     @pytest.mark.asyncio
-    async def test_find_fibers_batch_no_neurons_with_tag(self, storage: SQLiteStorage) -> None:
+    async def test_find_fibers_batch_no_neurons_with_tag(self, storage: InMemoryStorage) -> None:
         """When no neurons in neuron_ids, should return empty."""
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="Unrelated")
         await storage.add_neuron(n1)
@@ -364,7 +361,7 @@ class TestTagFilterEdgeCases:
         assert len(result) == 0
 
     @pytest.mark.asyncio
-    async def test_find_fibers_batch_tag_case_sensitivity(self, storage: SQLiteStorage) -> None:
+    async def test_find_fibers_batch_tag_case_sensitivity(self, storage: InMemoryStorage) -> None:
         """Tag matching should be case-sensitive."""
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="Case test")
         await storage.add_neuron(n1)
@@ -387,7 +384,7 @@ class TestTagFilterEdgeCases:
         assert len(result) == 1
 
     @pytest.mark.asyncio
-    async def test_find_fibers_batch_empty_tags_set(self, storage: SQLiteStorage) -> None:
+    async def test_find_fibers_batch_empty_tags_set(self, storage: InMemoryStorage) -> None:
         """Empty tags set should return no filters (all fibers)."""
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="Any fiber")
         await storage.add_neuron(n1)
@@ -410,7 +407,7 @@ class TestTagFilterIntegration:
     """Integration tests combining multiple features."""
 
     @pytest.mark.asyncio
-    async def test_find_fibers_batch_with_limit_and_tags(self, storage: SQLiteStorage) -> None:
+    async def test_find_fibers_batch_with_limit_and_tags(self, storage: InMemoryStorage) -> None:
         """Tag filtering should respect limit_per_neuron."""
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="Hub")
         n2 = Neuron.create(type=NeuronType.CONCEPT, content="Node")
@@ -434,7 +431,7 @@ class TestTagFilterIntegration:
         assert len(result) <= 2
 
     @pytest.mark.asyncio
-    async def test_find_fibers_batch_preserves_properties(self, storage: SQLiteStorage) -> None:
+    async def test_find_fibers_batch_preserves_properties(self, storage: InMemoryStorage) -> None:
         """Retrieved fibers should maintain all properties including tags."""
         n1 = Neuron.create(type=NeuronType.CONCEPT, content="Full fiber")
         await storage.add_neuron(n1)

--- a/tests/unit/test_tier_engine.py
+++ b/tests/unit/test_tier_engine.py
@@ -19,7 +19,7 @@ from surreal_memory.core.memory_types import (
 )
 from surreal_memory.core.neuron import Neuron, NeuronState, NeuronType
 from surreal_memory.engine.tier_engine import TierChange, TierEngine, TierReport
-from surreal_memory.storage.sqlite_store import SQLiteStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
 from surreal_memory.unified_config import TierConfig
 from surreal_memory.utils.timeutils import utcnow
 
@@ -27,11 +27,9 @@ from surreal_memory.utils.timeutils import utcnow
 
 
 @pytest_asyncio.fixture
-async def storage(tmp_path: Path) -> SQLiteStorage:
-    """Create an initialized SQLiteStorage with a brain."""
-    db_path = tmp_path / "test_tier.db"
-    store = SQLiteStorage(db_path=str(db_path))
-    await store.initialize()
+async def storage(tmp_path: Path) -> InMemoryStorage:
+    """Create an initialized InMemoryStorage with a brain."""
+    store = InMemoryStorage()
 
     config = BrainConfig(
         decay_rate=0.1,
@@ -61,7 +59,7 @@ def tier_config() -> TierConfig:
 
 
 async def _create_memory(
-    storage: SQLiteStorage,
+    storage: InMemoryStorage,
     fiber_id: str,
     memory_type: MemoryType = MemoryType.FACT,
     tier: str = MemoryTier.WARM,
@@ -200,7 +198,7 @@ class TestTierReport:
 class TestPromotion:
     @pytest.mark.asyncio
     async def test_promotes_warm_with_high_access(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """WARM memories with access_frequency >= threshold get promoted to HOT."""
         await _create_memory(storage, "f1", access_frequency=5, last_activated_days_ago=1)
@@ -218,7 +216,7 @@ class TestPromotion:
 
     @pytest.mark.asyncio
     async def test_does_not_promote_below_threshold(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """WARM memories below promote_threshold stay WARM."""
         await _create_memory(storage, "f1", access_frequency=2, last_activated_days_ago=1)
@@ -228,7 +226,7 @@ class TestPromotion:
         assert len(report.promoted) == 0
 
     @pytest.mark.asyncio
-    async def test_respects_max_hot_cap(self, storage: SQLiteStorage) -> None:
+    async def test_respects_max_hot_cap(self, storage: InMemoryStorage) -> None:
         """Promotion stops when max_hot_memories cap is reached."""
         config = TierConfig(
             auto_enabled=True,
@@ -260,7 +258,7 @@ class TestPromotion:
 
     @pytest.mark.asyncio
     async def test_dry_run_does_not_mutate(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """Dry run calculates changes but doesn't apply them."""
         await _create_memory(storage, "f1", access_frequency=5, last_activated_days_ago=1)
@@ -282,7 +280,7 @@ class TestPromotion:
 class TestDemotion:
     @pytest.mark.asyncio
     async def test_demotes_inactive_hot(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """HOT memories inactive for > demote_inactive_days get demoted to WARM."""
         await _create_memory(
@@ -304,7 +302,7 @@ class TestDemotion:
 
     @pytest.mark.asyncio
     async def test_does_not_demote_recently_active(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """HOT memories accessed recently stay HOT."""
         await _create_memory(
@@ -326,7 +324,7 @@ class TestDemotion:
 class TestArchive:
     @pytest.mark.asyncio
     async def test_archives_long_inactive_warm(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """WARM memories inactive for > cold_archive_days get archived to COLD."""
         await _create_memory(
@@ -346,7 +344,7 @@ class TestArchive:
 
     @pytest.mark.asyncio
     async def test_does_not_archive_recent_warm(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """WARM memories with recent access stay WARM."""
         await _create_memory(
@@ -367,7 +365,7 @@ class TestArchive:
 class TestBoundaryProtection:
     @pytest.mark.asyncio
     async def test_boundary_never_demoted(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """BOUNDARY type memories are never demoted from HOT."""
         await _create_memory(
@@ -386,7 +384,7 @@ class TestBoundaryProtection:
 
     @pytest.mark.asyncio
     async def test_boundary_never_archived(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """BOUNDARY type WARM memories are never archived to COLD."""
         await _create_memory(
@@ -410,7 +408,7 @@ class TestBoundaryProtection:
 class TestPinnedProtection:
     @pytest.mark.asyncio
     async def test_pinned_never_demoted(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """Pinned fibers are never demoted from HOT."""
         await _create_memory(
@@ -429,7 +427,7 @@ class TestPinnedProtection:
 
     @pytest.mark.asyncio
     async def test_pinned_never_archived(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """Pinned fibers are never archived from WARM."""
         await _create_memory(
@@ -451,7 +449,7 @@ class TestPinnedProtection:
 
 class TestOscillation:
     @pytest.mark.asyncio
-    async def test_no_promote_then_demote_same_cycle(self, storage: SQLiteStorage) -> None:
+    async def test_no_promote_then_demote_same_cycle(self, storage: InMemoryStorage) -> None:
         """A memory promoted in this cycle cannot be demoted in the same cycle."""
         config = TierConfig(
             auto_enabled=True,
@@ -483,7 +481,7 @@ class TestOscillation:
 class TestPromotionHistory:
     @pytest.mark.asyncio
     async def test_history_recorded_on_promotion(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """Promotion adds an entry to promotion_history in metadata."""
         await _create_memory(
@@ -504,7 +502,7 @@ class TestPromotionHistory:
 
     @pytest.mark.asyncio
     async def test_history_recorded_on_demotion(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """Demotion adds an entry to promotion_history in metadata."""
         await _create_memory(
@@ -550,7 +548,7 @@ class TestTierChange:
 class TestNeverActivatedFallback:
     @pytest.mark.asyncio
     async def test_demotes_hot_never_activated(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """HOT memories that were never activated get demoted using created_at fallback."""
         # last_activated_days_ago=None → last_activated=None, but created 100 days ago
@@ -579,7 +577,7 @@ class TestNeverActivatedFallback:
 
     @pytest.mark.asyncio
     async def test_archives_warm_never_activated(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """WARM memories never activated get archived using created_at fallback."""
         await _create_memory(
@@ -642,7 +640,7 @@ class TestTierConfigValidation:
 class TestHistoryCap:
     @pytest.mark.asyncio
     async def test_history_capped_at_20(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """promotion_history is capped at 20 entries."""
         # Create a memory with 19 existing history entries
@@ -678,7 +676,7 @@ class TestHistoryCap:
 class TestDoubleReportDryRun:
     @pytest.mark.asyncio
     async def test_dry_run_idempotent(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """Running evaluate twice returns the same report (no side effects)."""
         await _create_memory(
@@ -709,7 +707,7 @@ class TestDoubleReportDryRun:
 class TestBrainIdMismatch:
     @pytest.mark.asyncio
     async def test_warns_on_brain_id_mismatch(
-        self, storage: SQLiteStorage, tier_config: TierConfig
+        self, storage: InMemoryStorage, tier_config: TierConfig
     ) -> None:
         """TierEngine logs warning when brain_id doesn't match storage."""
         await _create_memory(storage, "f1", access_frequency=5)

--- a/tests/unit/test_valid_at_pipeline.py
+++ b/tests/unit/test_valid_at_pipeline.py
@@ -12,9 +12,7 @@ only real intervals (time_start < time_end) are event-time filtered.
 
 from __future__ import annotations
 
-import tempfile
 from datetime import datetime, timedelta
-from pathlib import Path
 
 import pytest
 
@@ -22,7 +20,7 @@ from surreal_memory.core.brain import Brain, BrainConfig
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.engine.retrieval import ReflexPipeline, _fiber_valid_at
-from surreal_memory.storage.sqlite_store import SQLiteStorage
+from surreal_memory.storage.memory_store import InMemoryStorage
 
 _T = datetime(2026, 1, 15, 12, 0, 0)
 
@@ -57,19 +55,19 @@ class TestFiberValidAtUnit:
 
 
 @pytest.fixture
-async def storage() -> SQLiteStorage:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        s = SQLiteStorage(Path(tmpdir) / "test.db")
-        await s.initialize()
-        brain = Brain.create(name="valid_at_test")
-        await s.save_brain(brain)
-        s.set_brain(brain.id)
-        yield s
-        await s.close()
+async def storage() -> InMemoryStorage:
+    s = InMemoryStorage()
+    brain = Brain.create(name="valid_at_test")
+    await s.save_brain(brain)
+    s.set_brain(brain.id)
+    yield s
+    await s.close()
 
 
 class TestValidAtThroughPipeline:
-    async def test_zero_width_fiber_survives_valid_at_filter(self, storage: SQLiteStorage) -> None:
+    async def test_zero_width_fiber_survives_valid_at_filter(
+        self, storage: InMemoryStorage
+    ) -> None:
         # A fiber with a zero-width event window (as BuildFiberStep produces) must be
         # returned by a valid_at recall for a DIFFERENT time — the pre-fix bug dropped it.
         neuron = Neuron.create(type=NeuronType.CONCEPT, content="Emma lives in Oslo Norway")


### PR DESCRIPTION
## Summary
- `InMemoryStorage` was missing 64 of `NeuralStorage`'s 172 methods (inherited `NotImplementedError` stubs) — tolerable while SQLite backed the tests that needed those surfaces, not once SQLite is removed and InMemoryStorage becomes the only backend CI can run against. Adds three new mixins (`memory_knowledge.py`, `memory_sync_ops.py`, `memory_lifecycle_ops.py`) mirroring the SQLite implementations' filtering/ordering/limit behavior without the SQL. `test_inmemory_completeness.py` pins zero remaining stubs via introspection.
- Migrates 19 test files off `SQLiteStorage` onto `InMemoryStorage`. The migration surfaced three real `InMemoryStorage` bugs, fixed here: missing `get_alert`, missing `get_depth_priors`, and `find_fibers_batch` never applying `limit_per_neuron` (returned every match instead of the requested cap).
- Fixes two dual-backend test fixtures that had silently become duplicate-coverage parametrizations (`memory`/`sqlite` branches both running identical code).
- Re-records `test_golden_ranking.py`'s snapshot for the backend swap: `InMemoryStorage.find_neurons` does plain substring matching, not SQLite's stemmed FTS5, so one fiber that only matched via stemming ("synapses" → "synapse") correctly drops out of the ranking — a known, accepted gap in the test double, not a scoring regression.
- `DeviceRecord`/`ChangeEntry` moved to `core/sync_records.py` (they describe the sync contract itself, not anything SQLite-specific) since the new in-memory sync mixin needs them too; old locations re-export for compatibility.

Two pre-existing bugs found along the way were filed separately rather than fixed here (out of scope for this backfill): a `sqlite_merkle.py` crash on synapse Merkle roots (missing `content_hash` column), and — while rebasing onto the latest `main` — a fresh regression in the just-merged PR #139 (SurrealDB pinning/training-file persistence returns shredded IDs and a missing field when live-tested).

## Test plan
- [x] `make verify` green: 7192 passed, 44 skipped, 1 xfailed, coverage 71.26% (gate 67%)
- [x] `tests/stress/` green (32/32) after switching its fixture off SQLite
- [x] `test_inmemory_completeness.py` — zero inherited stubs
- [x] Rebased onto latest `main` (post #139); re-ran full suite after resolving the `InMemoryStorage` MRO conflict with #139's new `InMemoryPinningMixin`
- [x] Live SurrealDB checked after live-DB test runs — only `default` brain remains, no orphans