### PR TITLE
fix: smem doctor drops dead SQLite-era checks, adds real brain check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] — 2026-08-02 — `smem doctor` no longer carries dead SQLite-era checks
+
+### Fixed
+
+Two `smem doctor` checks became permanently inert when the SQLite backend was
+removed in 3.0.0: `Schema version` could only ever return `SKIP` for either
+remaining storage backend (SurrealDB applies its schema idempotently with no
+stored version marker to compare against), and `Brain database` fell through
+to a dead code path that checked for a local `.db` file that no longer exists
+for any valid backend. Both permanently capped the doctor summary below 100%
+even on a fully healthy install.
+
+`Schema version` is removed. `Brain database` now does a real check for the
+`surrealdb` backend: it looks up the configured brain in SurrealDB and reports
+whether it exists, instead of unconditionally skipping.
+
 ## [3.0.0] — 2026-08-02 — The SQLite storage backend is removed
 
 ### Breaking: `storage_backend = "sqlite"` is now a hard error

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.0.0"
+version = "3.0.1"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/cli/doctor.py
+++ b/src/surreal_memory/cli/doctor.py
@@ -39,7 +39,6 @@ _CHECK_TIERS: dict[str, str] = {
     "Storage backend": TIER_CORE,
     "Brain database": TIER_CORE,
     "Dependencies": TIER_CORE,
-    "Schema version": TIER_CORE,
     "CLI tools": TIER_CORE,
     "SurrealDB connection": TIER_CORE,
     "SurrealDB version": TIER_CORE,
@@ -83,7 +82,6 @@ def run_doctor(
     checks.append(_check_brain())
     checks.append(_check_dependencies())
     checks.append(_check_embedding_provider())
-    checks.append(_check_schema_version())
     checks.append(_check_mcp_config())
     checks.append(_check_mcp_connection())
     checks.append(_check_hooks())
@@ -350,48 +348,74 @@ def _check_storage_backend() -> dict[str, Any]:
     }
 
 
+def _run_surrealdb_get_brain(brain_name: str) -> Any:
+    """Look up a brain by name via a short-lived SurrealDB connection."""
+    import asyncio
+
+    from surreal_memory.storage.surrealdb.connection import SurrealSettings
+    from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+    async def _lookup() -> Any:
+        settings = SurrealSettings.from_env()
+        storage = SurrealDBStorage(
+            url=settings.url,
+            user=settings.user,
+            password=settings.password,
+            namespace=settings.namespace,
+            database=settings.database,
+        )
+        try:
+            await asyncio.wait_for(storage.initialize(), timeout=5)
+            return await storage.get_brain(brain_name)
+        finally:
+            await storage.close()
+
+    return run_async(_lookup())
+
+
 def _check_brain() -> dict[str, Any]:
-    """Check default brain DB exists and is accessible."""
-    from surreal_memory.unified_config import get_surrealmemory_dir
-
-    data_dir = get_surrealmemory_dir()
-
+    """Check the configured brain exists and is accessible."""
     try:
         from surreal_memory.unified_config import get_config
 
         config = get_config(reload=True)
-        brain_name = config.current_brain
-        if config.storage_backend == "surrealdb":
-            return {
-                "name": "Brain database",
-                "status": SKIP,
-                "detail": "surrealdb backend — brain lives in SurrealDB, not a local .db file",
-            }
-        if config.storage_backend == "memory":
-            return {
-                "name": "Brain database",
-                "status": SKIP,
-                "detail": "memory backend — non-persistent, no database file to check",
-            }
-    except Exception:
-        brain_name = "default"
-
-    brains_dir = data_dir / "brains"
-    db_path = brains_dir / f"{brain_name}.db"
-
-    if not db_path.exists():
+    except Exception as exc:
         return {
             "name": "Brain database",
-            "status": FAIL,
-            "detail": f"{db_path} not found",
-            "fix": f"Run: smem brain create {brain_name}",
+            "status": WARN,
+            "detail": f"could not load config to check brain: {type(exc).__name__}",
         }
 
-    size_kb = db_path.stat().st_size / 1024
+    brain_name = config.current_brain
+
+    if config.storage_backend == "memory":
+        return {
+            "name": "Brain database",
+            "status": SKIP,
+            "detail": "memory backend — non-persistent, no brain to check",
+        }
+
+    try:
+        brain = _run_surrealdb_get_brain(brain_name)
+    except Exception as exc:
+        return {
+            "name": "Brain database",
+            "status": WARN,
+            "detail": f"could not reach SurrealDB: {type(exc).__name__}",
+            "fix": "Ensure SurrealDB is running and SURREALDB_URL is correct",
+        }
+
+    if brain is None:
+        return {
+            "name": "Brain database",
+            "status": WARN,
+            "detail": f"brain '{brain_name}' not created yet — will be created on first remember",
+        }
+
     return {
         "name": "Brain database",
         "status": OK,
-        "detail": f"{brain_name} ({size_kb:.0f} KB)",
+        "detail": f"{brain_name} (created {brain.created_at.date()})",
     }
 
 
@@ -498,31 +522,6 @@ def _check_embedding_provider() -> dict[str, Any]:
         "status": OK,
         "detail": f"{provider} (model: {config.embedding.model})",
     }
-
-
-def _check_schema_version() -> dict[str, Any]:
-    """Check database schema version."""
-    try:
-        from surreal_memory.unified_config import get_config
-
-        config = get_config(reload=True)
-        if config.storage_backend == "surrealdb":
-            return {
-                "name": "Schema version",
-                "status": SKIP,
-                "detail": "surrealdb backend — schema managed by SurrealDB migrations",
-            }
-        return {
-            "name": "Schema version",
-            "status": SKIP,
-            "detail": "memory backend — non-persistent, no schema to version",
-        }
-    except Exception:
-        return {
-            "name": "Schema version",
-            "status": WARN,
-            "detail": "could not check — ensure brain is accessible",
-        }
 
 
 def _check_mcp_config() -> dict[str, Any]:

--- a/tests/unit/test_doctor_enhanced.py
+++ b/tests/unit/test_doctor_enhanced.py
@@ -334,7 +334,6 @@ class TestRunDoctorIntegration:
     @patch("surreal_memory.cli.doctor._check_surrealdb_connection")
     @patch("surreal_memory.cli.doctor._check_mcp_connection")
     @patch("surreal_memory.cli.doctor._check_mcp_config")
-    @patch("surreal_memory.cli.doctor._check_schema_version")
     @patch("surreal_memory.cli.doctor._check_embedding_provider")
     @patch("surreal_memory.cli.doctor._check_dependencies")
     @patch("surreal_memory.cli.doctor._check_brain")
@@ -348,11 +347,11 @@ class TestRunDoctorIntegration:
 
         result = run_doctor(json_output=True)
         # Bump when run_doctor gains a check: config, storage backend, brain,
-        # dependencies, embedding, schema, MCP config/connection/env, hooks,
+        # dependencies, embedding, MCP config/connection/env, hooks,
         # dedup, surface, config freshness, CLI tools, SurrealDB
         # connection/version, Pro plugin, Python version.
-        assert result["total"] == 18
-        assert result["passed"] == 18
+        assert result["total"] == 17
+        assert result["passed"] == 17
 
     def test_quickstart_url_defined(self) -> None:
         assert "quickstart" in QUICKSTART_URL

--- a/tests/unit/test_dx_wizard.py
+++ b/tests/unit/test_dx_wizard.py
@@ -182,7 +182,6 @@ class TestDoctor:
             patch("surreal_memory.cli.doctor._check_brain") as m3,
             patch("surreal_memory.cli.doctor._check_dependencies") as m4,
             patch("surreal_memory.cli.doctor._check_embedding_provider") as m5,
-            patch("surreal_memory.cli.doctor._check_schema_version") as m6,
             patch("surreal_memory.cli.doctor._check_mcp_config") as m7,
             patch("surreal_memory.cli.doctor._check_mcp_connection") as m7b,
             patch("surreal_memory.cli.doctor._check_cli_tools") as m8,
@@ -202,7 +201,6 @@ class TestDoctor:
                 m3,
                 m4,
                 m5,
-                m6,
                 m7,
                 m7b,
                 m8,
@@ -219,8 +217,8 @@ class TestDoctor:
                 m.return_value = {"name": "test", "status": "ok", "detail": "ok"}
 
             result = run_doctor(json_output=True)
-            assert result["passed"] == 18
-            assert result["total"] == 18
+            assert result["passed"] == 17
+            assert result["total"] == 17
             assert result["failed"] == 0
 
     def test_run_doctor_with_failures(self) -> None:
@@ -232,7 +230,6 @@ class TestDoctor:
             patch("surreal_memory.cli.doctor._check_brain") as m3,
             patch("surreal_memory.cli.doctor._check_dependencies") as m4,
             patch("surreal_memory.cli.doctor._check_embedding_provider") as m5,
-            patch("surreal_memory.cli.doctor._check_schema_version") as m6,
             patch("surreal_memory.cli.doctor._check_mcp_config") as m7,
             patch("surreal_memory.cli.doctor._check_mcp_connection") as m7b,
             patch("surreal_memory.cli.doctor._check_cli_tools") as m8,
@@ -248,12 +245,12 @@ class TestDoctor:
         ):
             m1.return_value = {"name": "Python", "status": "ok", "detail": "ok"}
             m2.return_value = {"name": "Config", "status": "fail", "detail": "missing"}
-            for m in [m3, m4, m5, m6, m7, m7b, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17]:
+            for m in [m3, m4, m5, m7, m7b, m8, m9, m10, m11, m12, m13, m14, m15, m16, m17]:
                 m.return_value = {"name": "test", "status": "ok", "detail": "ok"}
 
             result = run_doctor(json_output=True)
             assert result["failed"] == 1
-            assert result["passed"] == 17
+            assert result["passed"] == 16
 
     def test_run_doctor_dev_adds_dev_checks(self) -> None:
         from surreal_memory.cli.doctor import run_doctor
@@ -264,7 +261,6 @@ class TestDoctor:
             patch("surreal_memory.cli.doctor._check_brain") as m3,
             patch("surreal_memory.cli.doctor._check_dependencies") as m4,
             patch("surreal_memory.cli.doctor._check_embedding_provider") as m5,
-            patch("surreal_memory.cli.doctor._check_schema_version") as m6,
             patch("surreal_memory.cli.doctor._check_mcp_config") as m7,
             patch("surreal_memory.cli.doctor._check_mcp_connection") as m7b,
             patch("surreal_memory.cli.doctor._check_cli_tools") as m8,
@@ -285,7 +281,6 @@ class TestDoctor:
                 m3,
                 m4,
                 m5,
-                m6,
                 m7,
                 m7b,
                 m8,
@@ -307,8 +302,8 @@ class TestDoctor:
 
             result = run_doctor(json_output=True, dev=True)
 
-        assert result["passed"] == 20
-        assert result["total"] == 20
+        assert result["passed"] == 19
+        assert result["total"] == 19
         assert any(c["tier"] == "dev" for c in result["checks"])
 
 

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.0.0"
+        assert surreal_memory.__version__ == "3.0.1"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary
- `Schema version` check removed — after 3.0.0 removed SQLite it could only ever return `SKIP` for both remaining backends (`surrealdb`/`memory`); SurrealDB applies its schema idempotently on every start with no stored version marker to compare against, so there was nothing left to check.
- `Brain database` check rewritten — it previously fell through to a dead `.db`-file existence check that no longer applies to any valid backend post-3.0.0. It now does a real lookup: connects to SurrealDB and calls `get_brain(current_brain)`, reporting `OK` (brain exists, with creation date) or `WARN` (not created yet — will be created on first `remember`) instead of unconditionally `SKIP`.
- Both checks were permanently capping the `smem doctor` summary below 100% on a fully healthy 3.0.0 install (16/18), which reads as "something's wrong" when nothing is.

## Test plan
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy src/ --ignore-missing-imports` clean
- [x] `tests/unit/test_dx_wizard.py` + `tests/unit/test_doctor_enhanced.py` — 79/79 passing (4 tests updated: mocks for the removed check dropped, check-count assertions 18→17)
- [x] Full `tests/unit/` — 6708/6708 passing (36 skipped, unrelated markers)
- [x] Doc generators (`gen_cli_docs`, `gen_mcp_docs`, `gen_config_docs`, `gen_api_docs`) — all `--check` clean
- [x] `check_dead_modules.py` — no unreachable modules
- [x] Live `smem doctor` against a real SurrealDB brain — confirmed `[OK] Brain database  default (created 2026-06-22)`, total dropped cleanly 18→17