### PR TITLE
fix: pinned neurons and training-file records survive the round trip

### DIFF
--- a/src/surreal_memory/storage/surrealdb/pinning.py
+++ b/src/surreal_memory/storage/surrealdb/pinning.py
@@ -110,17 +110,25 @@ class SurrealDBPinningMixin:
     async def get_pinned_neuron_ids(self) -> set[str]:
         """Get every neuron ID belonging to a pinned fiber in the current brain."""
         brain_id = self._get_brain_id()
+        # Deliberately NOT ``SELECT VALUE neuron_ids``. That projects the arrays
+        # themselves, so the driver returns a list of lists
+        # (``[['n1', 'n2'], ['n3']]``) — and ``_query`` unwraps any result whose
+        # first element is a list, collapsing it to the FIRST pinned fiber's
+        # array alone. The loop below then walked that array's id *strings*, so
+        # ``get_pinned_neuron_ids`` handed decay and prune a set of single
+        # characters, which matches no neuron id: every pinned neuron was still
+        # decayed to zero and pruned, exactly the loss this mixin exists to stop.
+        # Projecting the field keeps every row a dict, which ``_query`` passes
+        # through untouched.
         rows = await self._query(
-            "SELECT VALUE neuron_ids FROM fiber WHERE brain_id = $brain_id AND pinned = true",
+            "SELECT neuron_ids FROM fiber WHERE brain_id = $brain_id AND pinned = true",
             brain_id=brain_id,
         )
 
         result: set[str] = set()
         for row in rows:
-            # ``SELECT VALUE neuron_ids`` yields the arrays themselves; a fiber
-            # written before the field existed can still surface as NONE.
-            if row:
-                result.update(str(nid) for nid in row)
+            # A fiber written before the field existed can still surface as NONE.
+            result.update(str(nid) for nid in row.get("neuron_ids") or ())
         return result
 
     async def list_pinned_fibers(self, limit: int = 50) -> list[dict[str, Any]]:

--- a/src/surreal_memory/storage/surrealdb/training_files.py
+++ b/src/surreal_memory/storage/surrealdb/training_files.py
@@ -89,7 +89,18 @@ class SurrealDBTrainingFilesMixin:
             )
             return record_id
 
-        record_id = str(uuid4())
+        # ``uuid4().hex``, not ``str(uuid4())``: a dash-form uuid is not a legal
+        # SurrealDB record name, so ``_to_surreal_id`` folds every '-' to '_' —
+        # and that underscore form is what a later SELECT reports as the row's
+        # id. Returning the dash form here meant the id a caller got back from
+        # ``upsert_training_file`` never equalled the id
+        # ``get_training_file_by_hash`` reported for the very same row, so the
+        # second upsert of a file looked like a different record. Minting the id
+        # already inside ``[A-Za-z0-9_]`` makes ``_to_surreal_id`` a no-op on it,
+        # so one id identifies one row on the way in and on the way out. Rows
+        # written by earlier versions already carry the underscore form, which is
+        # likewise unchanged by ``_to_surreal_id`` and keeps resolving.
+        record_id = uuid4().hex
         await self._ensure_conn().insert(
             "training_files",
             {
@@ -175,6 +186,13 @@ def _row_to_record(row: dict[str, Any]) -> dict[str, Any]:
     if rid is not None:
         text = f"{rid.table_name}:{rid.id}" if hasattr(rid, "table_name") else str(rid)
         row["id"] = text.split(":", 1)[1] if ":" in text else text
+    # SurrealDB stores NONE by dropping the field, so an untrained row comes back
+    # from ``SELECT *`` with no ``trained_at`` key at all — ``option<datetime>``
+    # in the schema permits the absence, it does not materialise a null. Callers
+    # subscript the key (``record["trained_at"]`` to test "finished yet?"), which
+    # raised KeyError. Every other column carries a schema DEFAULT, so this is
+    # the one field that can go missing.
+    row.setdefault("trained_at", None)
     for key in ("created_at", "trained_at"):
         val = row.get(key)
         if isinstance(val, datetime):


### PR DESCRIPTION
Three deterministic bugs that only a live SurrealDB reproduces, so
tests/integration/test_surrealdb_pinning.py (self-skipping without
SURREALDB_URL, and CI has no server) went red on main unnoticed:

* get_pinned_neuron_ids projected `SELECT VALUE neuron_ids`, which returns
  a list of arrays. _query unwraps any result whose first element is a
  list, so that collapsed to the first pinned fiber's array alone, and the
  caller then iterated those id *strings* character by character. Decay and
  prune received a set of single characters, matching no neuron id, so they
  still zeroed and deleted every pinned neuron — the precise data loss this
  mixin was added to prevent. Projecting the field keeps each row a dict,
  which _query passes through untouched.

* upsert_training_file returned a dash-form uuid while storing the record
  under the underscore form _to_surreal_id produces, so the id a caller got
  back never equalled the one get_training_file_by_hash reported for the
  same row, and re-training a file looked like a new record. The id is now
  minted as uuid4().hex, already inside [A-Za-z0-9_], so _to_surreal_id is
  a no-op on it and one id means one row in both directions. Rows written
  by earlier versions carry the underscore form and keep resolving.

* SurrealDB stores NONE by dropping the field, so an untrained row came
  back from SELECT * with no trained_at key at all and callers testing
  record["trained_at"] hit KeyError. The row mapper now defaults it.

Verified against a real SurrealDB 3.2.0: tests/integration/ is 39 passed,
1 xfailed (was 5 failed, 12 passed in the pinning module), and make verify
is green.