### PR TITLE
fix: smem brain and the dashboard see brains that live only in SurrealDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.2] — 2026-08-02 — `smem brain` and the dashboard see brains that live only in SurrealDB
+
+### Fixed
+
+Two separate, same-named `list_brains()` methods existed with no relation to
+each other: `UnifiedConfig.list_brains()` and `CLIConfig.list_brains()` both
+only glob local `*.db`/`*.json` fixture files — they never query SurrealDB,
+the only production backend since v2.0.0. Five `smem brain` subcommands
+(`list`, `use`, `create`, `import`, `delete`) and two dashboard endpoints
+(`POST /brains/switch`, `GET /brain-files`) called one of these instead of
+the correct `unified_config.list_available_brains()`, which queries the
+active backend directly. Net effect on a SurrealDB-backed install: `smem
+brain list` and the dashboard's brain-files panel always reported zero
+brains, and switching to a brain via the dashboard 404'd even though the
+same dashboard's `/brains` endpoint listed it correctly.
+
+All five CLI call sites and both dashboard endpoints now route through
+`list_available_brains()`. `smem brain delete` also gained a guard: a brain
+that exists only in SurrealDB has no local file to delete, so attempting to
+delete one now reports a clear "not supported yet" message instead of
+crashing with an unhandled `FileNotFoundError` — deleting SurrealDB-backed
+brains programmatically is not yet implemented.
+
 ## [3.0.1] — 2026-08-02 — `smem doctor` no longer carries dead SQLite-era checks
 
 ### Fixed

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.0.1"
+version = "3.0.2"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/cli/commands/brain.py
+++ b/src/surreal_memory/cli/commands/brain.py
@@ -18,8 +18,25 @@ from surreal_memory.cli._helpers import (
 )
 from surreal_memory.safety.freshness import analyze_freshness
 from surreal_memory.safety.sensitive import check_sensitive_content
+from surreal_memory.unified_config import list_available_brains
 
 brain_app = typer.Typer(help="Brain management commands")
+
+
+def _list_brains() -> list[str]:
+    """Sync wrapper around list_available_brains for non-async commands.
+
+    CLIConfig.list_brains only globs local *.json/*.db fixture files, so it
+    never sees brains that live in SurrealDB (the only production backend
+    since v2.0.0) — every brain command using it reported "no brains found"
+    on a healthy SurrealDB install. list_available_brains queries the active
+    backend directly.
+    """
+
+    async def _list() -> list[str]:
+        return await list_available_brains()
+
+    return run_async(_list())
 
 
 @brain_app.command("list")
@@ -35,7 +52,7 @@ def brain_list(
     import os
 
     config = get_config()
-    brains = config.list_brains()
+    brains = _list_brains()
     # Effective brain: env var overrides config (matches CLI get_storage resolution)
     env_brain = os.environ.get("SURREAL_MEMORY_BRAIN")
     current = resolve_brain(None, config)
@@ -77,7 +94,7 @@ def brain_use(
 
     config = get_config()
 
-    if name not in config.list_brains():
+    if name not in _list_brains():
         typer.secho(
             f"Brain '{name}' not found. Create it with: smem brain create {name}",
             fg=typer.colors.RED,
@@ -115,7 +132,7 @@ def brain_create(
     async def _create() -> None:
         config = get_config()
 
-        if name in config.list_brains():
+        if name in await list_available_brains():
             typer.secho(f"Brain '{name}' already exists.", fg=typer.colors.RED)
             raise typer.Exit(1)
 
@@ -306,7 +323,7 @@ def brain_import(
         config = get_config()
         brain_name = resolve_brain(name, config, default=data.get("brain_name", "imported"))
 
-        if brain_name in config.list_brains():
+        if brain_name in await list_available_brains():
             typer.secho(
                 f"Brain '{brain_name}' already exists. Use --name to specify different name.",
                 fg=typer.colors.RED,
@@ -356,7 +373,7 @@ def brain_delete(
     """
     config = get_config()
 
-    if name not in config.list_brains():
+    if name not in _list_brains():
         typer.secho(f"Brain '{name}' not found.", fg=typer.colors.RED)
         raise typer.Exit(1)
 
@@ -373,6 +390,18 @@ def brain_delete(
             return
 
     brain_path = get_brain_path_auto(config, name)
+    if not brain_path.exists():
+        # Brain lives only in SurrealDB (no local fixture file to unlink).
+        # There is no delete_brain() on the storage interface yet, so this
+        # cannot be completed programmatically — say so instead of either
+        # crashing on the missing file or silently reporting fake success.
+        typer.secho(
+            f"Brain '{name}' is stored in SurrealDB — deleting it isn't "
+            "supported yet. Remove its rows directly in SurrealDB, or run "
+            f"`smem brain export --name {name}` to back it up first.",
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(1)
     brain_path.unlink()
     typer.secho(f"Deleted brain: {name}", fg=typer.colors.GREEN)
 

--- a/src/surreal_memory/server/routes/dashboard_api.py
+++ b/src/surreal_memory/server/routes/dashboard_api.py
@@ -331,10 +331,10 @@ async def switch_brain(
     Updates config.toml (persistent) AND app.state.storage so that
     all endpoints immediately use the new brain's DB without restart.
     """
-    from surreal_memory.unified_config import get_config, get_shared_storage
+    from surreal_memory.unified_config import get_config, get_shared_storage, list_available_brains
 
     cfg = get_config()
-    available = cfg.list_brains()
+    available = await list_available_brains()
     if request.brain_name not in available:
         raise HTTPException(
             status_code=404,
@@ -816,10 +816,10 @@ class BrainFilesResponse(BaseModel):
 )
 async def get_brain_files() -> BrainFilesResponse:
     """Get file path and size information for all brain databases."""
-    from surreal_memory.unified_config import get_config
+    from surreal_memory.unified_config import get_config, list_available_brains
 
     cfg = get_config()
-    brain_names = cfg.list_brains()
+    brain_names = await list_available_brains()
     active_name = cfg.current_brain
     brains_dir = Path(cfg.get_brain_db_path("_probe_")).parent
 

--- a/tests/unit/test_cli_brain_surrealdb_listing.py
+++ b/tests/unit/test_cli_brain_surrealdb_listing.py
@@ -1,0 +1,133 @@
+"""Regression tests: `smem brain` subcommands must see SurrealDB-only brains.
+
+CLIConfig.list_brains only globs local *.json/*.db fixture files, so every
+`smem brain` subcommand that checked brain existence via config.list_brains()
+reported "no brains found" / "not found" on a healthy SurrealDB install (the
+only production backend since v2.0.0) even though the brain genuinely exists.
+These commands must route through unified_config.list_available_brains()
+instead, which queries the active backend directly.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from typer.testing import CliRunner
+
+from surreal_memory.cli.main import app
+
+runner = CliRunner()
+
+CLI = "surreal_memory.cli.commands.brain"
+
+
+def _cli_config(current_brain: str = "default") -> MagicMock:
+    config = MagicMock()
+    config.current_brain = current_brain
+    config.save = MagicMock()
+    return config
+
+
+def test_brain_list_shows_surrealdb_only_brain() -> None:
+    """A brain that exists only in SurrealDB (no local .db/.json file) must
+    still show up in `smem brain list` — this is the exact bug reported."""
+    with (
+        patch(f"{CLI}.get_config", return_value=_cli_config()),
+        patch(
+            f"{CLI}.list_available_brains",
+            new=AsyncMock(return_value=["default", "surrealdb-only-brain"]),
+        ),
+    ):
+        result = runner.invoke(app, ["brain", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert "surrealdb-only-brain" in result.output
+
+
+def test_brain_list_json_includes_surrealdb_only_brain() -> None:
+    with (
+        patch(f"{CLI}.get_config", return_value=_cli_config()),
+        patch(
+            f"{CLI}.list_available_brains",
+            new=AsyncMock(return_value=["default", "surrealdb-only-brain"]),
+        ),
+    ):
+        result = runner.invoke(app, ["brain", "list", "--json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "surrealdb-only-brain" in data["brains"]
+
+
+def test_brain_use_finds_surrealdb_only_brain() -> None:
+    """Switching to a brain that only exists in SurrealDB must not fail with
+    'not found' just because there's no local file for it."""
+    config = _cli_config()
+    with (
+        patch(f"{CLI}.get_config", return_value=config),
+        patch(
+            f"{CLI}.list_available_brains",
+            new=AsyncMock(return_value=["surrealdb-only-brain"]),
+        ),
+    ):
+        result = runner.invoke(app, ["brain", "use", "surrealdb-only-brain"])
+
+    assert result.exit_code == 0, result.output
+    assert config.current_brain == "surrealdb-only-brain"
+    config.save.assert_called_once()
+
+
+def test_brain_create_rejects_existing_surrealdb_only_name() -> None:
+    """Creating a brain whose name already exists in SurrealDB must be
+    rejected, even though no local file with that name exists."""
+    with (
+        patch(f"{CLI}.get_config", return_value=_cli_config()),
+        patch(f"{CLI}.list_available_brains", new=AsyncMock(return_value=["taken"])),
+        patch(f"{CLI}.get_storage", new=AsyncMock()),
+    ):
+        result = runner.invoke(app, ["brain", "create", "taken"])
+
+    assert result.exit_code == 1
+    assert "already exists" in result.output
+
+
+def test_brain_delete_on_surrealdb_only_brain_gives_clear_error_not_crash() -> None:
+    """Deleting a brain that only exists in SurrealDB (no local file to
+    unlink) must fail with a clear message, not an unhandled
+    FileNotFoundError from Path.unlink()."""
+    config = _cli_config(current_brain="default")
+    fake_path = MagicMock()
+    fake_path.exists.return_value = False
+
+    with (
+        patch(f"{CLI}.get_config", return_value=config),
+        patch(
+            f"{CLI}.list_available_brains",
+            new=AsyncMock(return_value=["surrealdb-only-brain"]),
+        ),
+        patch(f"{CLI}.get_brain_path_auto", return_value=fake_path),
+    ):
+        result = runner.invoke(app, ["brain", "delete", "surrealdb-only-brain", "--force"])
+
+    assert result.exit_code == 1
+    assert "isn't supported yet" in result.output
+    fake_path.unlink.assert_not_called()
+
+
+def test_brain_delete_still_deletes_local_file_brain() -> None:
+    """A brain that DOES have a local file (legacy/test-fixture mode) must
+    still be deletable exactly as before."""
+    config = _cli_config(current_brain="default")
+    fake_path = MagicMock()
+    fake_path.exists.return_value = True
+
+    with (
+        patch(f"{CLI}.get_config", return_value=config),
+        patch(f"{CLI}.list_available_brains", new=AsyncMock(return_value=["local-brain"])),
+        patch(f"{CLI}.get_brain_path_auto", return_value=fake_path),
+    ):
+        result = runner.invoke(app, ["brain", "delete", "local-brain", "--force"])
+
+    assert result.exit_code == 0, result.output
+    fake_path.unlink.assert_called_once()

--- a/tests/unit/test_dashboard_api.py
+++ b/tests/unit/test_dashboard_api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -307,3 +307,79 @@ class TestStorageStatusEndpoint:
         assert data["url"] == "http://surrealdb:8000"
         assert data["namespace"] == "myns"
         assert data["database"] == "mydb"
+
+
+class TestBrainListingUsesActiveBackend:
+    """switch_brain and get_brain_files must see SurrealDB-only brains.
+
+    Both previously enumerated brains via cfg.list_brains(), which only globs
+    local *.json/*.db fixture files — so a brain that only exists in
+    SurrealDB (the only production backend since v2.0.0) was invisible to
+    both endpoints: switching to it 404'd, and it never appeared in the
+    Settings "Brain Files" panel.
+    """
+
+    def test_switch_brain_accepts_surrealdb_only_brain(self, client: TestClient) -> None:
+        cfg = MagicMock()
+        cfg.switch_brain = MagicMock()
+        new_storage = AsyncMock()
+
+        with (
+            patch("surreal_memory.unified_config.get_config", return_value=cfg),
+            patch(
+                "surreal_memory.unified_config.list_available_brains",
+                new=AsyncMock(return_value=["surrealdb-only-brain"]),
+            ),
+            patch(
+                "surreal_memory.unified_config.get_shared_storage",
+                new=AsyncMock(return_value=new_storage),
+            ),
+        ):
+            resp = client.post(
+                "/api/dashboard/brains/switch", json={"brain_name": "surrealdb-only-brain"}
+            )
+
+        assert resp.status_code == 200, resp.text
+        cfg.switch_brain.assert_called_once_with("surrealdb-only-brain")
+
+    def test_switch_brain_404s_for_truly_missing_brain(self, client: TestClient) -> None:
+        cfg = MagicMock()
+        with (
+            patch("surreal_memory.unified_config.get_config", return_value=cfg),
+            patch(
+                "surreal_memory.unified_config.list_available_brains",
+                new=AsyncMock(return_value=["some-other-brain"]),
+            ),
+        ):
+            resp = client.post("/api/dashboard/brains/switch", json={"brain_name": "nonexistent"})
+
+        assert resp.status_code == 404
+
+    def test_brain_files_lists_surrealdb_only_brain_with_zero_size(
+        self, client: TestClient
+    ) -> None:
+        """A SurrealDB-only brain has no local file, so it must show up with
+        size 0 rather than being omitted entirely."""
+        cfg = MagicMock()
+        cfg.current_brain = "surrealdb-only-brain"
+        fake_path = MagicMock()
+        fake_path.parent = "/fake/brains"
+        fake_path.exists.return_value = False
+        cfg.get_brain_db_path = MagicMock(return_value=fake_path)
+
+        with (
+            patch("surreal_memory.unified_config.get_config", return_value=cfg),
+            patch(
+                "surreal_memory.unified_config.list_available_brains",
+                new=AsyncMock(return_value=["surrealdb-only-brain"]),
+            ),
+        ):
+            resp = client.get("/api/dashboard/brain-files")
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        names = [b["name"] for b in data["brains"]]
+        assert "surrealdb-only-brain" in names
+        entry = next(b for b in data["brains"] if b["name"] == "surrealdb-only-brain")
+        assert entry["size_bytes"] == 0
+        assert entry["is_active"] is True

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.0.1"
+        assert surreal_memory.__version__ == "3.0.2"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary
- Two separate, same-named `list_brains()` methods existed with no relation to each other: `UnifiedConfig.list_brains()` (`unified_config.py`) and `CLIConfig.list_brains()` (`cli/config.py`) both only glob local `*.db`/`*.json` fixture files — neither queries SurrealDB, the only production backend since v2.0.0. The correct function, `unified_config.list_available_brains()`, already existed and queries the active backend directly, but wasn't used at the actual call sites.
- **`cli/commands/brain.py`** — all five call sites (`list`, `use`, `create`, `import`, `delete`) now route through `list_available_brains()` instead of `CLIConfig.list_brains()`. Added a `_list_brains()` sync wrapper for the non-async commands.
- **`server/routes/dashboard_api.py`** — `GET /brain-files` (the endpoint explicitly reported) and `POST /brains/switch` (an identical instance of the same bug I found while reading the file — the dashboard's `/brains` endpoint already correctly lists SurrealDB brains, but switching to one 404'd) both now route through `list_available_brains()`.
- **Found and fixed a related landmine**: `brain_delete`'s existence check always failed for SurrealDB-only brains before this fix (so it never reached the code below). Once the check is fixed, the brain is found — but the next line, `brain_path.unlink()`, assumes a local `.db` file exists, which it doesn't for a SurrealDB-only brain. Added a guard so this now reports a clear "not supported yet" message instead of crashing with `FileNotFoundError`. Full SurrealDB-native brain deletion is a separate, bigger feature (no `delete_brain()` exists anywhere in the storage interface) and is out of scope here.

## Net effect before this fix
On a SurrealDB-backed install (the only production backend), `smem brain list` and the dashboard's brain-files panel always reported zero brains, and switching to a brain via the dashboard 404'd even though the same dashboard's `/brains` endpoint listed it correctly.

## Test plan
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy src/ --ignore-missing-imports` clean
- [x] 9 new regression tests, all passing: `tests/unit/test_cli_brain_surrealdb_listing.py` (6 — list/use/create/delete against a SurrealDB-only brain, including the new delete guard) + `tests/unit/test_dashboard_api.py` (+3 — switch_brain success/404, brain-files zero-size entry)
- [x] Full `tests/unit/` — 6717/6717 passing
- [x] Full `make verify` (lint + format + typecheck + test-cov + security) — coverage 70.50% (gate 67%); 5 pre-existing `test_surrealdb_pinning.py` failures confirmed via `git stash` to exist identically without this change (tracked separately); 10 live-SurrealDB errors confirmed transient (31/31 pass in isolation)
- [x] `uv run mkdocs build --strict` clean
- [x] Live smoke test: `smem brain list` with the local `default.db` fixture file **temporarily removed** still correctly lists `default` — proof it's genuinely querying SurrealDB, not falling back to the file glob
- [x] DoD: cleaned up a test brain (`all-types-roundtrip`) left behind by a test run, cascade-deleted by `brain_id` across `neuron`/`neuron_state`/`typed_memory` + the brain row itself; verified only `default` remains and zero orphans