### PR TITLE
fix: smem index/reindex batch their writes and stop duplicating on re-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] — 2026-08-03 — `smem index`/`smem reindex` batch their writes and stop duplicating on re-run
+
+### Added
+
+- **`smem index --force`** — wipes the existing code index and rebuilds it from scratch, ignoring change tracking. The explicit escape hatch for the new incremental-skip behaviour below.
+
+### Fixed
+
+- **`smem index` duplicated every neuron/synapse/fiber on every re-run.** `CodebaseEncoder` never hashed or compared file content, so re-indexing an unchanged tree recreated it wholesale with fresh IDs. It now tracks each file's mtime and a content simhash on the file's own neuron: unchanged files are skipped entirely, a touched-but-content-identical file is skipped via the simhash comparison, and a genuinely changed file has its previous neurons/synapses/fiber removed before being rebuilt.
+- **`[embedding] endpoint` in `config.toml` was silently dead.** `_create_provider` never called `EmbeddingSettings.resolved_endpoint()`, so the `openai` and `ollama` providers only ever picked up an endpoint from the `SURREAL_MEMORY_EMBEDDING_ENDPOINT` environment variable — the config field had no effect on the canonical embedding path (`smem_remember`, `smem reindex`, the doc trainer). Both providers now receive the resolved endpoint, and the provider cache key includes it so editing the endpoint returns a freshly built provider instead of one pointed at the old address.
+
+### Performance
+
+- **`smem index`'s directory walk stopped materializing the whole tree before filtering it.** It used to `sorted(directory.rglob("*"))` over the entire tree — including excluded directories like `.git`, `.venv`, and nested `.claude/worktrees` checkouts — and only rejected them file-by-file afterward, with a `resolve()` syscall on every single path before the extension/exclude filters ran. It now walks with `os.walk`, pruning excluded directory names in place so they're never descended into, and only resolves paths that already passed the extension filter.
+- **Codebase indexing batches its database writes.** Every file used to cost 3 sequential round-trips per neuron (entity + activation state + change-log row), 2 per synapse, and 2 per fiber. `CodebaseEncoder` now builds every file's neurons/synapses/fiber in memory across the whole directory and flushes them in a handful of multi-statement writes at the end (new `add_neurons_batch`/`add_fibers_batch` on `NeuralStorage`, with a sequential fallback for backends that don't override them). `add_synapses_batch`'s own change-log write was also fixed to log in one bulk insert instead of looping per synapse — a "batch" writer that still cost N round-trips for its own bookkeeping.
+- **`smem reindex` writes embedding vectors in one round-trip per batch instead of one per neuron**, via the existing `update_neuron_embeddings` batch writer (now promoted to a `NeuralStorage` interface method with a sequential fallback, replacing an ad hoc `getattr` check).
+
+### Changed
+
+- **Embeddings for code symbols are computed from more than just the symbol's name.** A code neuron's `content` doubles as its dedup/identity key (`Klasa.metoda`), which left almost nothing for the embedding provider to work with. `Neuron.embedding_text()` composes `content` with the symbol's `signature`/`docstring` from its metadata when present, and both `smem reindex` and inline post-encode embedding now use it — `content` itself, and dedup, are unaffected.
+
 ## [3.0.3] — 2026-08-03 — `smem watch` no longer crashes on SurrealDB; `smem index` no longer indexes itself 24x over
 
 ### Fixed

--- a/docs/getting-started/cli-reference.md
+++ b/docs/getting-started/cli-reference.md
@@ -472,6 +472,7 @@ smem index [OPTIONS]
 | `--ext / -e` | text | No | — | File extensions to index (e.g. .py) |
 | `--status / -s` | boolean | No | `False` | Show indexing status instead of scanning |
 | `--json / -j` | boolean | No | `False` | Output as JSON |
+| `--force` | boolean | No | `False` | Wipe the existing code index and re-index every file, ignoring change tracking |
 
 ### `smem import`
 

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.0.3"
+version = "3.1.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.0.3"
+__version__ = "3.1.0"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/cli/commands/codebase.py
+++ b/src/surreal_memory/cli/commands/codebase.py
@@ -21,9 +21,16 @@ def index(
         bool, typer.Option("--status", "-s", help="Show indexing status instead of scanning")
     ] = False,
     json_output: Annotated[bool, typer.Option("--json", "-j", help="Output as JSON")] = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help="Wipe the existing code index and re-index every file, ignoring change tracking",
+        ),
+    ] = False,
 ) -> None:
     """Index a codebase into neural memory for code-aware recall."""
-    run_async(_index_async(path, extensions, status, json_output))
+    run_async(_index_async(path, extensions, status, json_output, force))
 
 
 async def _index_async(
@@ -31,6 +38,7 @@ async def _index_async(
     extensions: list[str] | None,
     status: bool,
     json_output: bool,
+    force: bool = False,
 ) -> None:
     """Async implementation of the index command."""
     from surreal_memory.core.neuron import NeuronType
@@ -81,7 +89,7 @@ async def _index_async(
     storage.disable_auto_save()
 
     typer.echo(f"Indexing {directory} ({', '.join(sorted(exts))})...")
-    results = await encoder.index_directory(directory, extensions=exts)
+    results = await encoder.index_directory(directory, extensions=exts, force=force)
     await storage.batch_save()
 
     total_neurons = sum(len(r.neurons_created) for r in results)

--- a/src/surreal_memory/cli/commands/reindex.py
+++ b/src/surreal_memory/cli/commands/reindex.py
@@ -150,7 +150,7 @@ async def _reindex_async(
     failed = 0
     for start in range(0, to_embed, batch_size):
         batch = candidates[start : start + batch_size]
-        texts = [n.content for n in batch]
+        texts = [n.embedding_text() for n in batch]
         try:
             vectors = await provider.embed_batch(texts)
         except Exception:
@@ -159,12 +159,15 @@ async def _reindex_async(
                 typer.echo(f"  batch {start}-{start + len(batch)} failed (skipped)", err=True)
             continue
 
-        for neuron, vector in zip(batch, vectors, strict=True):
-            try:
-                await storage.update_neuron(neuron.with_metadata(_embedding=vector))
-                embedded += 1
-            except Exception:
-                failed += 1
+        pairs = [(neuron.id, vector) for neuron, vector in zip(batch, vectors, strict=True)]
+        try:
+            await storage.update_neuron_embeddings(pairs)
+            embedded += len(pairs)
+        except Exception:
+            failed += len(pairs)
+            if not json_output:
+                typer.echo(f"  batch {start}-{start + len(batch)} write failed (skipped)", err=True)
+            continue
 
         if not json_output:
             typer.echo(f"  embedded {min(start + batch_size, to_embed)}/{to_embed}")

--- a/src/surreal_memory/core/neuron.py
+++ b/src/surreal_memory/core/neuron.py
@@ -88,6 +88,29 @@ class Neuron:
             ephemeral=ephemeral,
         )
 
+    def embedding_text(self) -> str:
+        """Text to feed the embedding provider — richer than `content` alone.
+
+        `content` doubles as this neuron's identity (dedup via
+        `has_neuron_by_content_hash`, exact-match lookups via
+        `find_neurons_exact_batch`) so it has to stay a short, stable key. Code
+        symbols in particular store their signature and docstring in
+        `metadata` (see `CodebaseEncoder._build_file_result`), not in
+        `content` — embedding just `content` (e.g. ``"MyClass.my_method"``)
+        gives semantic search almost nothing to match against. This composes
+        a richer string from `signature`/`docstring` when present, and
+        degrades to plain `content` when they are not, so every other neuron
+        type embeds exactly as before.
+        """
+        parts = [self.content]
+        signature = self.metadata.get("signature")
+        if signature:
+            parts.append(str(signature))
+        docstring = self.metadata.get("docstring")
+        if docstring:
+            parts.append(str(docstring))
+        return "\n".join(parts)
+
     def with_metadata(self, **kwargs: Any) -> Neuron:
         """
         Create a new Neuron with updated metadata.

--- a/src/surreal_memory/engine/codebase_encoder.py
+++ b/src/surreal_memory/engine/codebase_encoder.py
@@ -21,6 +21,7 @@ Synapse mapping:
 from __future__ import annotations
 
 import logging
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -29,6 +30,7 @@ from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.synapse import Synapse, SynapseType
 from surreal_memory.engine.encoder import EncodingResult
 from surreal_memory.extraction.codebase import CodeSymbolType, get_extractor
+from surreal_memory.utils.simhash import is_near_duplicate, simhash
 
 logger = logging.getLogger(__name__)
 
@@ -98,19 +100,21 @@ class CodebaseEncoder:
         self._storage = storage
         self._config = config
 
-    async def index_file(
+    def _build_file_result(
         self,
         file_path: Path,
+        *,
+        mtime: float | None = None,
+        content_simhash: int | None = None,
         tags: set[str] | None = None,
     ) -> EncodingResult:
-        """Index a single source file into neural graph.
+        """Parse a file and build its neurons/synapses/fiber WITHOUT persisting them.
 
-        Args:
-            file_path: Path to the source file.
-            tags: Optional tags for the fiber.
-
-        Returns:
-            EncodingResult with created neurons, synapses, and fiber.
+        Pure CPU + a single blocking read (via the extractor) — no storage I/O,
+        so many files can be built up-front and flushed together in one batch.
+        `mtime`/`content_simhash`, when given, ride along on the file neuron's
+        metadata so a later `index_directory` run can tell whether this file
+        changed without re-reading every file up front.
         """
         extractor = get_extractor(file_path.suffix)
         symbols, relationships = extractor.extract_file(file_path)
@@ -119,15 +123,20 @@ class CodebaseEncoder:
         synapses_created: list[Synapse] = []
 
         # 1. Create file neuron (SPATIAL)
+        file_metadata: dict[str, Any] = {
+            "indexed": True,
+            "symbol_count": len(symbols),
+        }
+        if mtime is not None:
+            file_metadata["mtime"] = mtime
+        if content_simhash is not None:
+            file_metadata["content_simhash"] = content_simhash
+
         file_neuron = Neuron.create(
             type=NeuronType.SPATIAL,
             content=str(file_path),
-            metadata={
-                "indexed": True,
-                "symbol_count": len(symbols),
-            },
+            metadata=file_metadata,
         )
-        await self._storage.add_neuron(file_neuron)
         neurons_created.append(file_neuron)
 
         # 2. Create symbol neurons
@@ -157,7 +166,6 @@ class CodebaseEncoder:
                 content=sym_key,
                 metadata=metadata,
             )
-            await self._storage.add_neuron(neuron)
             neurons_created.append(neuron)
             symbol_id_map[sym_key] = neuron.id
 
@@ -180,7 +188,6 @@ class CodebaseEncoder:
                 type=synapse_type,
                 weight=weight,
             )
-            await self._storage.add_synapse(synapse)
             synapses_created.append(synapse)
 
         # 4. Create co-occurrence synapses (capped to avoid O(n²) explosion)
@@ -195,7 +202,6 @@ class CodebaseEncoder:
                         type=SynapseType.CO_OCCURS,
                         weight=0.5,
                     )
-                    await self._storage.add_synapse(synapse)
                     synapses_created.append(synapse)
 
         # 5. Bundle into fiber
@@ -209,7 +215,6 @@ class CodebaseEncoder:
             summary=f"Code index: {file_path.name}",
             tags=(tags or set()) | {"code_index"},
         )
-        await self._storage.add_fiber(fiber)
 
         return EncodingResult(
             fiber=fiber,
@@ -218,45 +223,187 @@ class CodebaseEncoder:
             synapses_created=synapses_created,
         )
 
+    async def index_file(
+        self,
+        file_path: Path,
+        tags: set[str] | None = None,
+    ) -> EncodingResult:
+        """Index a single source file into neural graph, persisting immediately.
+
+        For indexing a whole directory, prefer `index_directory`: it batches
+        writes across every file into a handful of round-trips instead of one
+        set of round-trips per file.
+
+        Args:
+            file_path: Path to the source file.
+            tags: Optional tags for the fiber.
+
+        Returns:
+            EncodingResult with created neurons, synapses, and fiber.
+        """
+        result = self._build_file_result(file_path, tags=tags)
+        await self._storage.add_neurons_batch(result.neurons_created)
+        await self._storage.add_synapses_batch(result.synapses_created)
+        await self._storage.add_fibers_batch([result.fiber])
+        return result
+
+    def _collect_candidate_files(
+        self,
+        directory: Path,
+        exts: set[str],
+        excludes: set[str],
+    ) -> list[Path]:
+        """Walk `directory`, pruning excluded subdirectories in place.
+
+        `os.walk` with the `dirnames[:]` filter below never descends into an
+        excluded directory at all (`.git`, `node_modules`, N nested
+        `.claude/worktrees` checkouts, ...) — unlike the previous
+        `sorted(directory.rglob("*"))`, which materialized and `resolve()`d
+        every path in the WHOLE tree before any filter ran (measured: 33s of a
+        75s index run on this repo's own ~384k-path tree). `followlinks=True`
+        matches `rglob`'s traversal on Python < 3.13 (the oldest version this
+        package supports), so the symlink-escape check in `index_directory`
+        still has something to guard against.
+        """
+        candidates: list[Path] = []
+        for dirpath, dirnames, filenames in os.walk(directory, followlinks=True):
+            dirnames[:] = [d for d in dirnames if d not in excludes]
+            base = Path(dirpath)
+            for filename in filenames:
+                file_path = base / filename
+                if file_path.suffix in exts:
+                    candidates.append(file_path)
+        return candidates
+
+    async def _delete_previous_index(self, old_file_neuron: Neuron) -> None:
+        """Remove a changed file's stale neurons/synapses/fiber before rebuilding.
+
+        Sequential deletes, deliberately: SurrealDB raises a hard write
+        conflict under concurrent deletes to the same tables (see
+        `SurrealDBStorage.delete_neurons_batch`'s docstring) — this only ever
+        touches one file's worth of entities per call, so sequential is cheap.
+        """
+        old_fibers = await self._storage.find_fibers(contains_neuron=old_file_neuron.id, limit=1)
+        if not old_fibers:
+            return
+        old_fiber = old_fibers[0]
+        for nid in old_fiber.neuron_ids:
+            await self._storage.delete_neuron(nid)
+        for sid in old_fiber.synapse_ids:
+            await self._storage.delete_synapse(sid)
+        await self._storage.delete_fiber(old_fiber.id)
+
+    async def _clear_code_index(self) -> None:
+        """Wipe every existing `code_index` fiber and its members (for `force=True`)."""
+        while True:
+            batch = await self._storage.find_fibers(tags={"code_index"}, limit=2000)
+            if not batch:
+                return
+            for fiber in batch:
+                for nid in fiber.neuron_ids:
+                    await self._storage.delete_neuron(nid)
+                for sid in fiber.synapse_ids:
+                    await self._storage.delete_synapse(sid)
+                await self._storage.delete_fiber(fiber.id)
+
     async def index_directory(
         self,
         directory: Path,
         extensions: set[str] | None = None,
         exclude_patterns: set[str] | None = None,
         tags: set[str] | None = None,
+        *,
+        force: bool = False,
     ) -> list[EncodingResult]:
         """Index all matching files in a directory recursively.
+
+        Unchanged files (same mtime, or a touched-but-content-identical file,
+        detected by simhash) are skipped entirely: previously every run
+        re-indexed and duplicated every neuron/synapse/fiber for every file,
+        every time. Writes are batched across the whole directory rather than
+        issued per file.
 
         Args:
             directory: Root directory to scan.
             extensions: File extensions to index. Defaults to common source extensions.
             exclude_patterns: Directory names to skip.
             tags: Optional tags for all created fibers.
+            force: Wipe the existing code index first and re-index every
+                matching file, ignoring change tracking.
 
         Returns:
-            List of EncodingResult, one per indexed file.
+            List of EncodingResult, one per (re-)indexed file.
         """
         exts = extensions if extensions is not None else set(_DEFAULT_EXTENSIONS)
         excludes = exclude_patterns if exclude_patterns is not None else set(_DEFAULT_EXCLUDE)
 
+        if force:
+            await self._clear_code_index()
+
         resolved_base = directory.resolve()
+        candidates = sorted(self._collect_candidate_files(directory, exts, excludes))
+
+        existing_by_path: dict[str, Neuron] = {}
+        if not force and candidates:
+            existing_by_path = await self._storage.find_neurons_exact_batch(
+                [str(p) for p in candidates], type=NeuronType.SPATIAL
+            )
+
+        all_neurons: list[Neuron] = []
+        all_synapses: list[Synapse] = []
+        all_fibers: list[Fiber] = []
         results: list[EncodingResult] = []
-        for file_path in sorted(directory.rglob("*")):
+
+        for file_path in candidates:
             if not file_path.is_file():
                 continue
             # Validate resolved path stays within base directory (symlink escape prevention)
             if not file_path.resolve().is_relative_to(resolved_base):
                 continue
-            if file_path.suffix not in exts:
-                continue
-            if any(p in file_path.parts for p in excludes):
-                continue
+
+            old_neuron = existing_by_path.get(str(file_path))
+            mtime = file_path.stat().st_mtime
+            content_simhash: int | None = None
+
+            if old_neuron is not None:
+                old_mtime = old_neuron.metadata.get("mtime")
+                if old_mtime is not None and mtime <= float(old_mtime):
+                    continue  # unchanged: same or older mtime than last index
+
+                try:
+                    content = file_path.read_text(encoding="utf-8", errors="replace")
+                    content_simhash = simhash(content)
+                except OSError:
+                    content_simhash = None
+
+                old_simhash = old_neuron.metadata.get("content_simhash")
+                if (
+                    content_simhash is not None
+                    and old_simhash is not None
+                    and is_near_duplicate(content_simhash, int(old_simhash))
+                ):
+                    continue  # mtime touched, content unchanged
+
+                await self._delete_previous_index(old_neuron)
 
             try:
-                result = await self.index_file(file_path, tags=tags)
-                results.append(result)
+                result = self._build_file_result(
+                    file_path,
+                    mtime=mtime,
+                    content_simhash=content_simhash,
+                    tags=tags,
+                )
             except (SyntaxError, UnicodeDecodeError):
                 logger.debug("Skipping %s due to parse/decode error", file_path, exc_info=True)
                 continue
+
+            results.append(result)
+            all_neurons.extend(result.neurons_created)
+            all_synapses.extend(result.synapses_created)
+            all_fibers.append(result.fiber)
+
+        await self._storage.add_neurons_batch(all_neurons)
+        await self._storage.add_synapses_batch(all_synapses)
+        await self._storage.add_fibers_batch(all_fibers)
 
         return results

--- a/src/surreal_memory/engine/encoder.py
+++ b/src/surreal_memory/engine/encoder.py
@@ -533,7 +533,7 @@ class MemoryEncoder:
             # near this budget; anything that is pays with a slightly later vector
             # instead of a lost write. `smem reindex` back-fills.
             budget = _inline_embed_timeout()
-            embed = provider.embed_batch([n.content for n in candidates])
+            embed = provider.embed_batch([n.embedding_text() for n in candidates])
             vectors = await (asyncio.wait_for(embed, timeout=budget) if budget else embed)
         except TimeoutError:
             logger.warning(
@@ -547,16 +547,15 @@ class MemoryEncoder:
             logger.debug("Inline embedding skipped (provider unavailable)", exc_info=True)
             return
 
-        # Prefer a single batched write when the backend offers one (SurrealDB):
-        # inline embedding otherwise costs one round-trip per created neuron.
+        # Prefer a single batched write (SurrealDB collapses this into one
+        # multi-statement UPDATE per chunk): inline embedding otherwise costs
+        # one round-trip per created neuron.
         pairs = [(n.id, list(v)) for n, v in zip(candidates, vectors, strict=False)]
-        batch_update = getattr(self._storage, "update_neuron_embeddings", None)
-        if batch_update is not None:
-            try:
-                await batch_update(pairs)
-                return
-            except Exception:
-                logger.debug("Batch inline embed update failed; falling back", exc_info=True)
+        try:
+            await self._storage.update_neuron_embeddings(pairs)
+            return
+        except Exception:
+            logger.debug("Batch inline embed update failed; falling back", exc_info=True)
         for neuron, vector in zip(candidates, vectors, strict=False):
             try:
                 await self._storage.update_neuron(neuron.with_metadata(_embedding=list(vector)))

--- a/src/surreal_memory/engine/semantic_discovery.py
+++ b/src/surreal_memory/engine/semantic_discovery.py
@@ -144,7 +144,8 @@ def _auto_detect_provider() -> tuple[str, str]:
 
 
 # Module-level singleton cache — avoids reloading models per tool call (#100)
-_provider_cache: dict[tuple[str, str], Any] = {}
+# Keyed by (provider, model, endpoint) — see _create_provider's cache_key.
+_provider_cache: dict[tuple[str, str, str], Any] = {}
 
 
 def _effective_embedding(config: BrainConfig) -> tuple[bool, str, str]:
@@ -170,6 +171,29 @@ def _effective_embedding(config: BrainConfig) -> tuple[bool, str, str]:
         )
 
 
+def _effective_embedding_endpoint() -> str:
+    """Resolve the EFFECTIVE embedding endpoint (config.toml + env override).
+
+    Mirrors ``_effective_embedding``'s "effective config wins" pattern —
+    ``EmbeddingSettings.resolved_endpoint()`` prefers ``[embedding] endpoint``
+    in config.toml over ``SURREAL_MEMORY_EMBEDDING_ENDPOINT``. Without this,
+    ``_create_provider`` never read the config value at all: it constructed
+    ``OpenAIEmbedding(model=model_name)`` with no ``base_url``, so the config
+    field was silently dead — only the env var ever reached the provider.
+    Returns "" if the unified config cannot be loaded; callers already fall
+    back to reading the env var themselves in that case (see
+    ``OpenAIEmbedding.__init__``), so failing open to "no override" reproduces
+    the exact pre-existing behaviour.
+    """
+    try:
+        from surreal_memory.unified_config import get_config
+
+        return get_config().embedding.resolved_endpoint()
+    except Exception:
+        logger.debug("Could not load unified embedding config for endpoint", exc_info=True)
+        return ""
+
+
 def _create_provider(config: BrainConfig, task_type: str = "RETRIEVAL_QUERY") -> Any:
     """Create or retrieve a cached embedding provider from BrainConfig.
 
@@ -191,7 +215,11 @@ def _create_provider(config: BrainConfig, task_type: str = "RETRIEVAL_QUERY") ->
         provider_name, model_name = _auto_detect_provider()
         logger.info("Auto-detected embedding provider: %s (model: %s)", provider_name, model_name)
 
-    cache_key = (provider_name, model_name)
+    endpoint = _effective_embedding_endpoint()
+    # Endpoint rides in the cache key too: changing [embedding] endpoint in
+    # config.toml (or the env override) must return a freshly built provider
+    # pointed at the new address, not a provider cached under the old one.
+    cache_key = (provider_name, model_name, endpoint)
     if cache_key in _provider_cache:
         return _provider_cache[cache_key]
 
@@ -205,7 +233,7 @@ def _create_provider(config: BrainConfig, task_type: str = "RETRIEVAL_QUERY") ->
     elif provider_name == "openai":
         from surreal_memory.engine.embedding.openai_embedding import OpenAIEmbedding
 
-        provider = OpenAIEmbedding(model=model_name)
+        provider = OpenAIEmbedding(model=model_name, base_url=endpoint or None)
     elif provider_name == "openrouter":
         from surreal_memory.engine.embedding.openrouter_embedding import OpenRouterEmbedding
 
@@ -217,7 +245,7 @@ def _create_provider(config: BrainConfig, task_type: str = "RETRIEVAL_QUERY") ->
     elif provider_name == "ollama":
         from surreal_memory.engine.embedding.ollama_embedding import OllamaEmbedding
 
-        provider = OllamaEmbedding(model=model_name)
+        provider = OllamaEmbedding(model=model_name, **({"base_url": endpoint} if endpoint else {}))
     elif provider_name in ("bge_m3", "bge-m3"):
         from surreal_memory.engine.embedding.bge_m3_embedding import BGEM3Embedding
 

--- a/src/surreal_memory/storage/base.py
+++ b/src/surreal_memory/storage/base.py
@@ -72,6 +72,23 @@ class NeuralStorage(ABC):
         """
         ...
 
+    async def add_neurons_batch(self, neurons: list[Neuron], *, record_change: bool = True) -> int:
+        """Add many neurons. Default falls back to sequential add_neuron.
+
+        Backends should override for batch efficiency (bulk codebase indexing
+        issues thousands of neuron inserts per run). ``record_change=False``
+        is accepted for symmetry with ``add_synapses_batch`` but the default
+        fallback has no separate change-log step to skip.
+        """
+        count = 0
+        for neuron in neurons:
+            try:
+                await self.add_neuron(neuron)
+                count += 1
+            except Exception:
+                pass
+        return count
+
     @abstractmethod
     async def get_neuron(self, neuron_id: str) -> Neuron | None:
         """
@@ -207,6 +224,19 @@ class NeuralStorage(ABC):
             True if deleted, False if not found
         """
         ...
+
+    async def update_neuron_embeddings(self, pairs: list[tuple[str, list[float]]]) -> None:
+        """Write embedding vectors for many neurons.
+
+        Default falls back to sequential fetch + `update_neuron` per pair.
+        Backends should override for batch efficiency — `smem reindex` and
+        inline post-encode embedding both call this for every neuron they
+        embed, so a per-neuron round-trip scales linearly with brain size.
+        """
+        for neuron_id, vector in pairs:
+            neuron = await self.get_neuron(neuron_id)
+            if neuron is not None:
+                await self.update_neuron(neuron.with_metadata(_embedding=list(vector)))
 
     # ========== Neuron State Operations ==========
 
@@ -506,6 +536,23 @@ class NeuralStorage(ABC):
             ValueError: If fiber with same ID exists
         """
         ...
+
+    async def add_fibers_batch(self, fibers: list[Fiber], *, record_change: bool = True) -> int:
+        """Add many fibers. Default falls back to sequential add_fiber.
+
+        Backends should override for batch efficiency (bulk codebase indexing
+        issues one fiber insert per file). ``record_change=False`` is accepted
+        for symmetry with ``add_synapses_batch``/``add_neurons_batch`` but the
+        default fallback has no separate change-log step to skip.
+        """
+        count = 0
+        for fiber in fibers:
+            try:
+                await self.add_fiber(fiber)
+                count += 1
+            except Exception:
+                pass
+        return count
 
     @abstractmethod
     async def get_fiber(self, fiber_id: str) -> Fiber | None:

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -762,6 +762,65 @@ class SurrealDBStorage(
 
         return neuron.id
 
+    async def add_neurons_batch(self, neurons: list[Neuron], *, record_change: bool = True) -> int:
+        """Insert many neurons in a handful of round-trips instead of 3*N.
+
+        ``add_neuron`` costs 3 sequential round-trips per neuron: the ``neuron``
+        insert, its ``neuron_state`` row, and its own ``change_log`` insert. The
+        SDK's ``insert()`` accepts a LIST and emits one ``INSERT INTO <table>
+        $data`` for the whole list (already relied on by
+        ``_record_changes_bulk``), so this collapses N calls into
+        ``ceil(N / _BATCH_WRITE_CHUNK)`` per table. Bulk codebase indexing is
+        the primary caller — one directory scan issues thousands of these.
+        """
+        if not neurons:
+            return 0
+        brain_id = self._get_brain_id()
+        conn = self._ensure_conn()
+
+        neuron_rows: list[dict[str, Any]] = []
+        state_rows: list[dict[str, Any]] = []
+        for neuron in neurons:
+            sid = _to_surreal_id(neuron.id)
+            meta = dict(neuron.metadata)
+            embedding_vec = meta.pop("_embedding", None)
+            row: dict[str, Any] = {
+                "id": sid,
+                "brain_id": brain_id,
+                "type": neuron.type.value,
+                "content": neuron.content,
+                "content_hash": neuron.content_hash,
+                "metadata": meta,
+                "ephemeral": neuron.ephemeral,
+                "created_at": neuron.created_at,
+                "updated_at": utcnow(),
+            }
+            if embedding_vec is not None:
+                row["embedding_vec"] = list(embedding_vec)
+            neuron_rows.append(row)
+            state_rows.append(
+                {
+                    "id": f"state_{sid}",
+                    "neuron_id": neuron.id,
+                    "brain_id": brain_id,
+                    "activation_level": 0.0,
+                    "access_frequency": 0,
+                    "created_at": neuron.created_at,
+                }
+            )
+
+        for chunk in _chunked(neuron_rows):
+            await conn.insert("neuron", chunk)
+        for chunk in _chunked(state_rows):
+            try:
+                await conn.insert("neuron_state", chunk)
+            except Exception:
+                pass
+
+        if record_change:
+            await self._record_changes_bulk("neuron", "insert", neurons)
+        return len(neurons)
+
     async def get_neuron(self, neuron_id: str) -> Neuron | None:
         # Scope to the current brain: a bare record select would let a caller
         # read another brain's neuron by id. The record is still pinned in FROM.
@@ -1197,9 +1256,13 @@ class SurrealDBStorage(
         ``add_synapse`` is the #2 round-trip cost during doc-training (~70+/chunk);
         this collapses N of them into one. ``record_change=False`` (used by bulk
         training against a brain that does not delta-sync) additionally skips the
-        per-synapse ``change_log`` insert — the #1 op count. Returns the count
-        inserted (best-effort; a statement-level failure is logged, not raised,
-        matching ``add_synapse`` semantics on the RELATION table).
+        change-log entirely. When ``record_change=True`` the log rows are written
+        via ``_record_changes_bulk`` — ONE bulk insert, not one per synapse (that
+        loop was the change-log ~64%-of-wall-clock cost documented on
+        ``update_synapses_batch``, reintroduced here despite the "batch" name
+        until fixed). Returns the count inserted (best-effort; a
+        statement-level failure is logged, not raised, matching ``add_synapse``
+        semantics on the RELATION table).
         """
         from surrealdb import RecordID
 
@@ -1228,8 +1291,7 @@ class SurrealDBStorage(
         except Exception:
             logger.debug("add_synapses_batch multi-statement failed; partial", exc_info=True)
         if record_change:
-            for syn in synapses:
-                await self._record_change_internal("synapse", syn.id, "insert", syn)
+            await self._record_changes_bulk("synapse", "insert", synapses)
         return len(synapses)
 
     async def get_synapse(self, synapse_id: str) -> Synapse | None:
@@ -1595,6 +1657,58 @@ class SurrealDBStorage(
         await conn.insert("fiber", record_data)
         await self._record_change_internal("fiber", fiber.id, "insert")
         return fiber.id
+
+    async def add_fibers_batch(self, fibers: list[Fiber], *, record_change: bool = True) -> int:
+        """Insert many fibers in a handful of round-trips instead of one apiece.
+
+        Same shape as ``add_neurons_batch``: the SDK's ``insert()`` accepts a
+        LIST and emits one ``INSERT INTO fiber $data`` for the whole chunk.
+        Bulk codebase indexing is the primary caller — one fiber per file.
+        """
+        if not fibers:
+            return 0
+        brain_id = self._get_brain_id()
+        conn = self._ensure_conn()
+
+        rows: list[dict[str, Any]] = []
+        for fiber in fibers:
+            fid = _to_surreal_id(fiber.id)
+            row: dict[str, Any] = {
+                "id": fid,
+                "brain_id": brain_id,
+                "neuron_ids": list(fiber.neuron_ids),
+                "synapse_ids": list(fiber.synapse_ids),
+                "anchor_neuron_id": fiber.anchor_neuron_id,
+                "pathway": fiber.pathway,
+                "conductivity": fiber.conductivity,
+                "coherence": fiber.coherence,
+                "salience": fiber.salience,
+                "frequency": fiber.frequency,
+                "summary": fiber.summary,
+                "essence": fiber.essence,
+                "auto_tags": list(fiber.auto_tags),
+                "agent_tags": list(fiber.agent_tags),
+                "metadata": dict(fiber.metadata),
+                "compression_tier": fiber.compression_tier,
+                "pinned": fiber.pinned,
+                "created_at": fiber.created_at,
+            }
+            if fiber.last_conducted:
+                row["last_conducted"] = fiber.last_conducted
+            if fiber.time_start:
+                row["time_start"] = fiber.time_start
+            if fiber.time_end:
+                row["time_end"] = fiber.time_end
+            if fiber.last_ghost_shown_at:
+                row["last_ghost_shown_at"] = fiber.last_ghost_shown_at
+            rows.append(row)
+
+        for chunk in _chunked(rows):
+            await conn.insert("fiber", chunk)
+
+        if record_change:
+            await self._record_changes_bulk("fiber", "insert", fibers)
+        return len(fibers)
 
     async def get_fiber(self, fiber_id: str) -> Fiber | None:
         brain_id = self._get_brain_id()

--- a/tests/unit/test_bulk_batch_paths.py
+++ b/tests/unit/test_bulk_batch_paths.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.synapse import Synapse, SynapseType
 from surreal_memory.engine.pipeline_steps import _persist_synapses
@@ -97,6 +98,8 @@ def _make_storage_spy() -> Any:
     s._skip_change_log = False
     s._query = AsyncMock(return_value=[])
     s._record_change_internal = AsyncMock(return_value=None)
+    s._record_changes_bulk = AsyncMock(return_value=None)
+    s._conn = AsyncMock()  # backs _ensure_conn() for add_neurons_batch/add_fibers_batch
     return s
 
 
@@ -119,16 +122,148 @@ def test_add_synapses_batch_single_query_multi_statement():
     assert sql.rstrip().endswith(";")
 
 
-def test_add_synapses_batch_record_change_default_logs_each():
+def test_add_synapses_batch_record_change_default_logs_via_bulk():
+    """record_change=True must log via ONE _record_changes_bulk call, not N
+    _record_change_internal calls — the per-synapse change-log loop was
+    ~64% of a batched update's wall clock (see _record_changes_bulk's
+    docstring); a "batch" writer reintroducing that loop defeats its own name.
+    """
     s = _make_storage_spy()
-    asyncio.run(s.add_synapses_batch([_syn(0), _syn(1)]))  # record_change defaults True
-    assert s._record_change_internal.await_count == 2
+    syns = [_syn(0), _syn(1)]
+    asyncio.run(s.add_synapses_batch(syns))  # record_change defaults True
+    assert s._record_change_internal.await_count == 0
+    assert s._record_changes_bulk.await_count == 1
+    args = s._record_changes_bulk.await_args.args
+    assert args[0] == "synapse"
+    assert args[1] == "insert"
+    assert list(args[2]) == syns
+
+
+def test_add_synapses_batch_record_change_false_skips_log():
+    s = _make_storage_spy()
+    asyncio.run(s.add_synapses_batch([_syn(0)], record_change=False))
+    assert s._record_changes_bulk.await_count == 0
 
 
 def test_add_synapses_batch_empty_noop():
     s = _make_storage_spy()
     assert asyncio.run(s.add_synapses_batch([])) == 0
     assert s._query.await_count == 0
+
+
+# ---------------------------- neuron batch ----------------------------
+
+
+def _neuron(n: int) -> Neuron:
+    return Neuron(id=f"n{n}", type=NeuronType.CONCEPT, content=f"content-{n}", created_at=utcnow())
+
+
+def test_add_neurons_batch_single_insert_call_per_table():
+    """N neurons must cost ONE conn.insert("neuron", [...]) and ONE
+    conn.insert("neuron_state", [...]) — not 3*N round-trips."""
+    s = _make_storage_spy()
+    neurons = [_neuron(i) for i in range(4)]
+    added = asyncio.run(s.add_neurons_batch(neurons))
+    assert added == 4
+    assert s._conn.insert.await_count == 2  # one for "neuron", one for "neuron_state"
+    tables_called = {call.args[0] for call in s._conn.insert.await_args_list}
+    assert tables_called == {"neuron", "neuron_state"}
+    neuron_call = next(c for c in s._conn.insert.await_args_list if c.args[0] == "neuron")
+    assert len(neuron_call.args[1]) == 4
+
+
+def test_add_neurons_batch_logs_via_bulk_change_log():
+    s = _make_storage_spy()
+    neurons = [_neuron(0), _neuron(1)]
+    asyncio.run(s.add_neurons_batch(neurons))
+    assert s._record_changes_bulk.await_count == 1
+    args = s._record_changes_bulk.await_args.args
+    assert args[0] == "neuron"
+    assert args[1] == "insert"
+    assert list(args[2]) == neurons
+
+
+def test_add_neurons_batch_record_change_false_skips_log():
+    s = _make_storage_spy()
+    asyncio.run(s.add_neurons_batch([_neuron(0)], record_change=False))
+    assert s._record_changes_bulk.await_count == 0
+
+
+def test_add_neurons_batch_empty_noop():
+    s = _make_storage_spy()
+    assert asyncio.run(s.add_neurons_batch([])) == 0
+    assert s._conn.insert.await_count == 0
+
+
+# ---------------------------- fiber batch ----------------------------
+
+
+def _fiber(n: int) -> Fiber:
+    return Fiber.create(
+        neuron_ids={f"n{n}"},
+        synapse_ids=set(),
+        anchor_neuron_id=f"n{n}",
+        summary=f"fiber-{n}",
+    )
+
+
+def test_add_fibers_batch_single_insert_call():
+    s = _make_storage_spy()
+    fibers = [_fiber(i) for i in range(3)]
+    added = asyncio.run(s.add_fibers_batch(fibers))
+    assert added == 3
+    assert s._conn.insert.await_count == 1
+    call = s._conn.insert.await_args
+    assert call.args[0] == "fiber"
+    assert len(call.args[1]) == 3
+
+
+def test_add_fibers_batch_logs_via_bulk_change_log():
+    s = _make_storage_spy()
+    fibers = [_fiber(0)]
+    asyncio.run(s.add_fibers_batch(fibers))
+    assert s._record_changes_bulk.await_count == 1
+    args = s._record_changes_bulk.await_args.args
+    assert args[0] == "fiber"
+    assert args[1] == "insert"
+    assert list(args[2]) == fibers
+
+
+def test_add_fibers_batch_empty_noop():
+    s = _make_storage_spy()
+    assert asyncio.run(s.add_fibers_batch([])) == 0
+    assert s._conn.insert.await_count == 0
+
+
+# ---------------------------- base-class fallbacks ----------------------------
+
+
+def test_base_add_neurons_batch_fallback_is_sequential():
+    """The base default must fall back to sequential add_neuron for backends
+    that do not override (keeps non-SurrealDB backends correct)."""
+    from types import SimpleNamespace
+
+    from surreal_memory.storage.base import NeuralStorage
+
+    calls: list[str] = []
+    fake = SimpleNamespace(add_neuron=AsyncMock(side_effect=lambda n: calls.append(n.id) or n.id))
+    neurons = [_neuron(i) for i in range(3)]
+    added = asyncio.run(NeuralStorage.add_neurons_batch(fake, neurons))
+    assert added == 3
+    assert len(calls) == 3
+
+
+def test_base_add_fibers_batch_fallback_is_sequential():
+    from types import SimpleNamespace
+
+    from surreal_memory.storage.base import NeuralStorage
+
+    calls: list[str] = []
+    fake = SimpleNamespace(add_fiber=AsyncMock(side_effect=lambda f: calls.append(f.id) or f.id))
+    fibers = [_fiber(i) for i in range(3)]
+    added = asyncio.run(NeuralStorage.add_fibers_batch(fake, fibers))
+    assert added == 3
+    assert len(calls) == 3
 
 
 # ---------------------------- _persist_synapses helper ----------------------------

--- a/tests/unit/test_codebase.py
+++ b/tests/unit/test_codebase.py
@@ -267,6 +267,7 @@ class TestCodebaseEncoder:
         (cache / "c.cpython-312.py").write_text("z = 3", encoding="utf-8")
 
         mock_storage = AsyncMock()
+        mock_storage.find_neurons_exact_batch.return_value = {}
         mock_config = MagicMock()
 
         encoder = CodebaseEncoder(mock_storage, mock_config)
@@ -293,6 +294,7 @@ class TestCodebaseEncoder:
         (nested_worktree / "a.py").write_text("x = 1  # duplicate copy", encoding="utf-8")
 
         mock_storage = AsyncMock()
+        mock_storage.find_neurons_exact_batch.return_value = {}
         mock_config = MagicMock()
 
         encoder = CodebaseEncoder(mock_storage, mock_config)
@@ -345,6 +347,194 @@ class TestCodebaseEncoder:
         # Fiber should reference all neurons and synapses
         assert len(result.fiber.neuron_ids) == len(result.neurons_created)
         assert len(result.fiber.synapse_ids) == len(result.synapses_created)
+
+    @pytest.mark.asyncio
+    async def test_index_directory_prunes_excluded_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Excluded directories are pruned during the walk itself (dirnames[:]
+        filtering), not discovered-then-discarded after a full-tree walk —
+        os.walk must never even descend into them."""
+        import os as os_module
+
+        from surreal_memory.engine import codebase_encoder as codebase_encoder_module
+        from surreal_memory.engine.codebase_encoder import CodebaseEncoder
+
+        (tmp_path / "a.py").write_text("x = 1", encoding="utf-8")
+        excluded = tmp_path / "node_modules" / "deep" / "nested"
+        excluded.mkdir(parents=True)
+        (excluded / "b.py").write_text("y = 2", encoding="utf-8")
+
+        real_walk = os_module.walk
+        visited_dirs: list[str] = []
+
+        def spy_walk(top: Path, **kwargs: object) -> object:
+            for dirpath, dirnames, filenames in real_walk(top, **kwargs):
+                visited_dirs.append(str(dirpath))
+                yield dirpath, dirnames, filenames
+
+        monkeypatch.setattr(codebase_encoder_module.os, "walk", spy_walk)
+
+        mock_storage = AsyncMock()
+        mock_storage.find_neurons_exact_batch.return_value = {}
+        mock_config = MagicMock()
+        encoder = CodebaseEncoder(mock_storage, mock_config)
+        await encoder.index_directory(tmp_path)
+
+        assert not any("node_modules" in d for d in visited_dirs)
+
+    @pytest.mark.asyncio
+    async def test_index_directory_deterministic_order(self, tmp_path: Path) -> None:
+        """Results are sorted by path regardless of filesystem creation order."""
+        from surreal_memory.engine.codebase_encoder import CodebaseEncoder
+
+        # Create in reverse-alphabetical order
+        (tmp_path / "z.py").write_text("z = 1", encoding="utf-8")
+        (tmp_path / "m.py").write_text("m = 1", encoding="utf-8")
+        (tmp_path / "a.py").write_text("a = 1", encoding="utf-8")
+
+        mock_storage = AsyncMock()
+        mock_storage.find_neurons_exact_batch.return_value = {}
+        mock_config = MagicMock()
+        encoder = CodebaseEncoder(mock_storage, mock_config)
+        results = await encoder.index_directory(tmp_path)
+
+        file_order = [r.fiber.anchor_neuron_id and r.neurons_created[0].content for r in results]
+        assert file_order == sorted(file_order)
+
+    @pytest.mark.asyncio
+    async def test_index_directory_symlink_escape_rejected(self, tmp_path: Path) -> None:
+        """A symlink inside the indexed directory pointing outside it must be
+        rejected — resolve()-based containment check must survive the
+        os.walk-based traversal introduced to replace rglob()."""
+        from surreal_memory.engine.codebase_encoder import CodebaseEncoder
+
+        base = tmp_path / "repo"
+        base.mkdir()
+        (base / "a.py").write_text("x = 1", encoding="utf-8")
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        secret = outside / "secret.py"
+        secret.write_text("SECRET = 1", encoding="utf-8")
+
+        link = base / "escape.py"
+        link.symlink_to(secret)
+
+        mock_storage = AsyncMock()
+        mock_storage.find_neurons_exact_batch.return_value = {}
+        mock_config = MagicMock()
+        encoder = CodebaseEncoder(mock_storage, mock_config)
+        results = await encoder.index_directory(base)
+
+        indexed_files = [r.fiber.summary for r in results]
+        assert len(results) == 1
+        assert any("a.py" in s for s in indexed_files)
+        assert not any("escape.py" in s or "secret.py" in s for s in indexed_files)
+
+    @pytest.mark.asyncio
+    async def test_index_directory_no_duplication_on_rerun(self, tmp_path: Path) -> None:
+        """Re-running index_directory on an unchanged tree creates zero new
+        neurons/synapses/fibers — the pre-fix behaviour re-indexed (and
+        duplicated) every file on every run."""
+        from surreal_memory.core.brain import Brain
+        from surreal_memory.core.neuron import NeuronType
+        from surreal_memory.engine.codebase_encoder import CodebaseEncoder
+        from surreal_memory.storage.memory_store import InMemoryStorage
+
+        (tmp_path / "a.py").write_text("def foo(): pass", encoding="utf-8")
+        (tmp_path / "b.py").write_text("def bar(): pass", encoding="utf-8")
+
+        storage = InMemoryStorage()
+        brain = Brain.create(name="idx-test", brain_id="idx-test-brain")
+        await storage.save_brain(brain)
+        storage.set_brain(brain.id)
+
+        encoder = CodebaseEncoder(storage, brain.config)
+        first = await encoder.index_directory(tmp_path)
+        assert len(first) == 2
+
+        neurons_after_first = await storage.find_neurons(type=NeuronType.SPATIAL, limit=1000)
+        assert len(neurons_after_first) == 2
+
+        second = await encoder.index_directory(tmp_path)
+        assert second == []
+
+        neurons_after_second = await storage.find_neurons(type=NeuronType.SPATIAL, limit=1000)
+        assert len(neurons_after_second) == 2
+
+    @pytest.mark.asyncio
+    async def test_index_directory_reindexes_only_changed_file(self, tmp_path: Path) -> None:
+        """Only the modified file is rebuilt; the untouched file's neuron is
+        left completely alone (same id, same content)."""
+        import os as os_module
+        import time
+
+        from surreal_memory.core.brain import Brain
+        from surreal_memory.core.neuron import NeuronType
+        from surreal_memory.engine.codebase_encoder import CodebaseEncoder
+        from surreal_memory.storage.memory_store import InMemoryStorage
+
+        file_a = tmp_path / "a.py"
+        file_b = tmp_path / "b.py"
+        file_a.write_text("def foo(): pass", encoding="utf-8")
+        file_b.write_text("def bar(): pass", encoding="utf-8")
+
+        storage = InMemoryStorage()
+        brain = Brain.create(name="idx-test-2", brain_id="idx-test-brain-2")
+        await storage.save_brain(brain)
+        storage.set_brain(brain.id)
+
+        encoder = CodebaseEncoder(storage, brain.config)
+        await encoder.index_directory(tmp_path)
+
+        neurons_before = await storage.find_neurons(type=NeuronType.SPATIAL, limit=1000)
+        b_neuron_id_before = next(n.id for n in neurons_before if n.content == str(file_b))
+
+        # Bump mtime comfortably forward — filesystem mtime resolution can be
+        # coarse enough that two writes in the same test tick look identical.
+        file_a.write_text("def foo(): return 42", encoding="utf-8")
+        future = time.time() + 5
+        os_module.utime(file_a, (future, future))
+
+        second = await encoder.index_directory(tmp_path)
+
+        assert len(second) == 1
+        assert second[0].neurons_created[0].content == str(file_a)
+
+        neurons_after = await storage.find_neurons(type=NeuronType.SPATIAL, limit=1000)
+        assert len(neurons_after) == 2
+        b_neuron_after = next(n for n in neurons_after if n.content == str(file_b))
+        assert b_neuron_after.id == b_neuron_id_before
+
+    @pytest.mark.asyncio
+    async def test_index_directory_force_wipes_and_rebuilds(self, tmp_path: Path) -> None:
+        """force=True clears the existing code index first, then rebuilds from
+        scratch — the previous file's neuron id must NOT survive."""
+        from surreal_memory.core.brain import Brain
+        from surreal_memory.core.neuron import NeuronType
+        from surreal_memory.engine.codebase_encoder import CodebaseEncoder
+        from surreal_memory.storage.memory_store import InMemoryStorage
+
+        (tmp_path / "a.py").write_text("def foo(): pass", encoding="utf-8")
+
+        storage = InMemoryStorage()
+        brain = Brain.create(name="idx-test-3", brain_id="idx-test-brain-3")
+        await storage.save_brain(brain)
+        storage.set_brain(brain.id)
+
+        encoder = CodebaseEncoder(storage, brain.config)
+        first = await encoder.index_directory(tmp_path)
+        first_id = first[0].neurons_created[0].id
+
+        second = await encoder.index_directory(tmp_path, force=True)
+
+        assert len(second) == 1
+        assert second[0].neurons_created[0].id != first_id
+
+        neurons_after = await storage.find_neurons(type=NeuronType.SPATIAL, limit=1000)
+        assert len(neurons_after) == 1
+        assert neurons_after[0].id != first_id
 
 
 class TestRegexExtractor:

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.0.3"
+        assert surreal_memory.__version__ == "3.1.0"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_neuron.py
+++ b/tests/unit/test_neuron.py
@@ -67,6 +67,48 @@ class TestNeuron:
             neuron = Neuron.create(type=neuron_type, content=f"test_{neuron_type}")
             assert neuron.type == neuron_type
 
+    def test_embedding_text_plain_content_unaffected(self) -> None:
+        """A neuron with no signature/docstring embeds exactly as before —
+        every non-code memory neuron must be unaffected by this method."""
+        neuron = Neuron.create(type=NeuronType.ENTITY, content="Alice")
+        assert neuron.embedding_text() == "Alice"
+
+    def test_embedding_text_includes_signature_and_docstring(self) -> None:
+        """A code-symbol neuron composes content + signature + docstring —
+        content alone (e.g. 'MyClass.my_method') is too sparse to embed well."""
+        neuron = Neuron.create(
+            type=NeuronType.ACTION,
+            content="MyClass.my_method",
+            metadata={
+                "signature": "def my_method(self, x: int) -> str",
+                "docstring": "Convert x to its string form.",
+            },
+        )
+        text = neuron.embedding_text()
+        assert "MyClass.my_method" in text
+        assert "def my_method(self, x: int) -> str" in text
+        assert "Convert x to its string form." in text
+
+    def test_embedding_text_signature_only(self) -> None:
+        """A symbol with a signature but no docstring still enriches the text."""
+        neuron = Neuron.create(
+            type=NeuronType.ACTION,
+            content="greet",
+            metadata={"signature": "def greet(name: str) -> str"},
+        )
+        text = neuron.embedding_text()
+        assert text == "greet\ndef greet(name: str) -> str"
+
+    def test_embedding_text_does_not_mutate_content(self) -> None:
+        """content stays the dedup/identity key regardless of embedding_text()."""
+        neuron = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="Widget",
+            metadata={"docstring": "A UI widget."},
+        )
+        neuron.embedding_text()
+        assert neuron.content == "Widget"
+
 
 class TestNeuronState:
     """Tests for NeuronState class."""

--- a/tests/unit/test_reindex_command.py
+++ b/tests/unit/test_reindex_command.py
@@ -37,7 +37,7 @@ def _make_storage(neurons: list[Neuron]) -> MagicMock:
         return neurons[offset : offset + limit]
 
     storage.find_neurons = AsyncMock(side_effect=_find)
-    storage.update_neuron = AsyncMock()
+    storage.update_neuron_embeddings = AsyncMock()
     return storage
 
 
@@ -83,7 +83,7 @@ class TestReindexAsync:
             await _reindex_async(
                 brain="", dry_run=True, all_neurons=False, batch_size=64, json_output=False
             )
-        storage.update_neuron.assert_not_called()
+        storage.update_neuron_embeddings.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_embeds_only_missing(self) -> None:
@@ -95,8 +95,12 @@ class TestReindexAsync:
             await _reindex_async(
                 brain="", dry_run=False, all_neurons=False, batch_size=64, json_output=False
             )
-        # Only the two unembedded neurons get updated.
-        assert storage.update_neuron.await_count == 2
+        # Both unembedded neurons land in ONE update_neuron_embeddings call —
+        # not two update_neuron round-trips.
+        storage.update_neuron_embeddings.assert_awaited_once()
+        pairs = storage.update_neuron_embeddings.await_args.args[0]
+        assert len(pairs) == 2
+        assert {p[1][0] for p in pairs} == {1.0, 2.0}
         provider.embed_batch.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -109,7 +113,8 @@ class TestReindexAsync:
             await _reindex_async(
                 brain="", dry_run=False, all_neurons=True, batch_size=64, json_output=False
             )
-        assert storage.update_neuron.await_count == 2
+        storage.update_neuron_embeddings.assert_awaited_once()
+        assert len(storage.update_neuron_embeddings.await_args.args[0]) == 2
 
     @pytest.mark.asyncio
     async def test_disabled_effective_config_exits(self) -> None:
@@ -122,18 +127,20 @@ class TestReindexAsync:
             await _reindex_async(
                 brain="", dry_run=False, all_neurons=False, batch_size=64, json_output=False
             )
-        storage.update_neuron.assert_not_called()
+        storage.update_neuron_embeddings.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_fail_soft_per_neuron(self) -> None:
+    async def test_fail_soft_per_batch(self) -> None:
+        """A write failure for one embedding batch must not abort the run —
+        with batched writes the fail-soft unit is a batch, not a neuron."""
         storage = _make_storage([_neuron("a"), _neuron("b")])
-        storage.update_neuron = AsyncMock(side_effect=[None, RuntimeError("db error")])
+        storage.update_neuron_embeddings = AsyncMock(side_effect=[None, RuntimeError("db error")])
         provider = MagicMock()
-        provider.embed_batch = AsyncMock(return_value=[[1.0], [2.0]])
+        provider.embed_batch = AsyncMock(return_value=[[1.0]])
         p1, p2, p3, p4 = _patches(storage, provider)
-        # Must not raise despite the second update failing.
+        # batch_size=1 forces two separate write batches for the two neurons.
         with p1, p2, p3, p4:
             await _reindex_async(
-                brain="", dry_run=False, all_neurons=False, batch_size=64, json_output=False
+                brain="", dry_run=False, all_neurons=False, batch_size=1, json_output=False
             )
-        assert storage.update_neuron.await_count == 2
+        assert storage.update_neuron_embeddings.await_count == 2

--- a/tests/unit/test_semantic_discovery.py
+++ b/tests/unit/test_semantic_discovery.py
@@ -360,6 +360,10 @@ class TestProviderCache:
                 return_value=(True, "sentence_transformer", "test-model"),
             ),
             patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding_endpoint",
+                return_value="",
+            ),
+            patch(
                 "surreal_memory.engine.embedding.sentence_transformer.SentenceTransformerEmbedding",
             ) as mock_st,
         ):
@@ -396,6 +400,10 @@ class TestProviderCache:
                 side_effect=_effective,
             ),
             patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding_endpoint",
+                return_value="",
+            ),
+            patch(
                 "surreal_memory.engine.embedding.sentence_transformer.SentenceTransformerEmbedding",
                 side_effect=lambda **kw: MagicMock(name=f"ST({kw})"),
             ) as mock_st,
@@ -428,6 +436,10 @@ class TestProviderCache:
                 return_value=(True, "gemini", "gemini-embedding-001"),
             ),
             patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding_endpoint",
+                return_value="",
+            ),
+            patch(
                 "surreal_memory.engine.embedding.gemini_embedding.GeminiEmbedding",
             ) as mock_gemini,
             patch(
@@ -437,6 +449,136 @@ class TestProviderCache:
             _create_provider(stale)
             mock_gemini.assert_called_once()
             mock_st.assert_not_called()
+
+        _provider_cache.clear()
+
+    def test_openai_provider_receives_configured_endpoint(self) -> None:
+        """The previously-dead [embedding] endpoint config field must now
+        reach OpenAIEmbedding as base_url (fix for #6 in the index-perf plan:
+        _create_provider never called resolved_endpoint())."""
+        from surreal_memory.engine.semantic_discovery import _create_provider
+
+        config = BrainConfig(embedding_provider="openai", embedding_model="text-embed")
+        with (
+            patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding",
+                return_value=(True, "openai", "text-embed"),
+            ),
+            patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding_endpoint",
+                return_value="http://127.0.0.1:11435/v1",
+            ),
+            patch(
+                "surreal_memory.engine.embedding.openai_embedding.OpenAIEmbedding",
+            ) as mock_openai,
+        ):
+            _create_provider(config)
+            mock_openai.assert_called_once_with(
+                model="text-embed", base_url="http://127.0.0.1:11435/v1"
+            )
+
+        _provider_cache.clear()
+
+    def test_openai_provider_no_endpoint_configured(self) -> None:
+        """No config/env endpoint set → base_url=None (provider falls back to
+        its own env check), NOT an empty string."""
+        from surreal_memory.engine.semantic_discovery import _create_provider
+
+        config = BrainConfig(embedding_provider="openai", embedding_model="text-embed")
+        with (
+            patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding",
+                return_value=(True, "openai", "text-embed"),
+            ),
+            patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding_endpoint",
+                return_value="",
+            ),
+            patch(
+                "surreal_memory.engine.embedding.openai_embedding.OpenAIEmbedding",
+            ) as mock_openai,
+        ):
+            _create_provider(config)
+            mock_openai.assert_called_once_with(model="text-embed", base_url=None)
+
+        _provider_cache.clear()
+
+    def test_ollama_provider_receives_configured_endpoint(self) -> None:
+        from surreal_memory.engine.semantic_discovery import _create_provider
+
+        config = BrainConfig(embedding_provider="ollama", embedding_model="nomic-embed-text")
+        with (
+            patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding",
+                return_value=(True, "ollama", "nomic-embed-text"),
+            ),
+            patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding_endpoint",
+                return_value="http://127.0.0.1:11434",
+            ),
+            patch(
+                "surreal_memory.engine.embedding.ollama_embedding.OllamaEmbedding",
+            ) as mock_ollama,
+        ):
+            _create_provider(config)
+            mock_ollama.assert_called_once_with(
+                model="nomic-embed-text", base_url="http://127.0.0.1:11434"
+            )
+
+        _provider_cache.clear()
+
+    def test_ollama_provider_no_endpoint_uses_default(self) -> None:
+        """No configured endpoint → base_url kwarg is omitted entirely, so
+        OllamaEmbedding's own module-level default (OLLAMA_BASE_URL) applies —
+        its constructor requires a str, never None."""
+        from surreal_memory.engine.semantic_discovery import _create_provider
+
+        config = BrainConfig(embedding_provider="ollama", embedding_model="nomic-embed-text")
+        with (
+            patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding",
+                return_value=(True, "ollama", "nomic-embed-text"),
+            ),
+            patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding_endpoint",
+                return_value="",
+            ),
+            patch(
+                "surreal_memory.engine.embedding.ollama_embedding.OllamaEmbedding",
+            ) as mock_ollama,
+        ):
+            _create_provider(config)
+            mock_ollama.assert_called_once_with(model="nomic-embed-text")
+
+        _provider_cache.clear()
+
+    def test_cache_keys_by_endpoint_too(self) -> None:
+        """Same provider/model, different endpoint → different cache entry,
+        so editing [embedding] endpoint doesn't return a stale provider."""
+        from unittest.mock import MagicMock
+
+        from surreal_memory.engine.semantic_discovery import _create_provider
+
+        config = BrainConfig(embedding_provider="openai", embedding_model="text-embed")
+        endpoints = iter(["http://host-a/v1", "http://host-b/v1"])
+        with (
+            patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding",
+                return_value=(True, "openai", "text-embed"),
+            ),
+            patch(
+                "surreal_memory.engine.semantic_discovery._effective_embedding_endpoint",
+                side_effect=lambda: next(endpoints),
+            ),
+            patch(
+                "surreal_memory.engine.embedding.openai_embedding.OpenAIEmbedding",
+                side_effect=lambda **kw: MagicMock(name=f"openai({kw})"),
+            ) as mock_openai,
+        ):
+            p1 = _create_provider(config)
+            p2 = _create_provider(config)
+            assert p1 is not p2
+            assert mock_openai.call_count == 2
 
         _provider_cache.clear()
 

--- a/tests/unit/test_storage_parity.py
+++ b/tests/unit/test_storage_parity.py
@@ -103,7 +103,6 @@ _KNOWN_ASYMMETRIC_ONLY = frozenset(
         "initialize",
         "list_brain_names",
         "prune_old_events",
-        "update_neuron_embeddings",
     }
 )
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

`smem index` re-indexed (and duplicated) every neuron/synapse/fiber on every run, and its directory walk materialized the whole tree — including `.git`, `.venv`, and nested `.claude/worktrees` checkouts — before filtering any of it. Both are fixed, plus a batch-write pass across the whole codebase-indexing path and two related embedding fixes found while working on it.

- **Directory walk**: `os.walk` with in-place directory pruning replaces `sorted(directory.rglob("*"))` — excluded directories are never descended into instead of being walked then discarded. Symlink-escape protection unchanged.
- **No more duplication on re-run**: `CodebaseEncoder` now tracks each file's mtime + a content simhash on the file's own neuron. Unchanged files are skipped entirely; a touched-but-identical file is skipped via the simhash check; a genuinely changed file has its previous neurons/synapses/fiber removed before rebuilding. New `smem index --force` bypasses this for a full rebuild.
- **Batched writes**: new `add_neurons_batch`/`add_fibers_batch` on `NeuralStorage` (sequential fallback + SurrealDB multi-statement override) replace 3 round-trips/neuron and 2/fiber. `add_synapses_batch`'s own change-log write was logging per-synapse despite the "batch" name — fixed to one bulk insert.
- **`smem reindex` batches embedding writes**: `update_neuron_embeddings` promoted from an ad hoc `getattr`-checked SurrealDB-only method to a proper `NeuralStorage` interface method with a sequential fallback, so `reindex.py` can call it directly.
- **Dead config field fixed**: `[embedding] endpoint` in `config.toml` never reached `_create_provider` — only the `SURREAL_MEMORY_EMBEDDING_ENDPOINT` env var did. Both `openai` and `ollama` providers now receive the resolved endpoint, and the provider cache key includes it so changing the endpoint doesn't return a stale cached provider.
- **Richer code-symbol embeddings**: `Neuron.embedding_text()` composes `content` with the symbol's `signature`/`docstring` from metadata when present. `content` itself (dedup/identity key) is untouched; only the text handed to the embedding provider changes.

Version bumped to 3.1.0 (MINOR — new `--force` flag, new storage interface methods, all backward compatible) across `pyproject.toml`, `__init__.py`, the version-pin test, and all three npm packages + their lockfiles.

## Verification

- `make verify`-equivalent: lint + format-check + mypy + `check_dead_modules.py` + security all clean; full non-stress suite 6802 passed (only known live-SurrealDB/xdist-timing errors, confirmed transient by re-running in isolation); coverage 70.58% (gate 67%); `mkdocs build --strict` clean.
- Live end-to-end run against a dedicated test brain (deleted afterward, cascade across all brain-scoped tables — verified zero orphans, only `default` remains):
  - First `smem index` on a ~735-file repo: 35.7s (down from a measured ~75s baseline on the unfixed code).
  - Second run on the unchanged tree: 0 files indexed, 0 new neurons — the duplication bug is gone.
  - Adding one file → only that file indexed. Modifying one file → only that file's entities rebuilt; the untouched file's neuron id is unchanged.
  - `smem reindex`: 19878 embedded, 0 failed, using the local endpoint resolved from `config.toml` (confirms the dead-endpoint fix).
  - Confirmed `embedding_text()` measurably improves semantic match quality: cosine similarity 0.534 (enriched: content+signature+docstring) vs 0.403 (content-only) against a docstring-derived query.

## Test plan

- [x] `make verify` equivalent (lint, format, mypy, dead-modules, security)
- [x] Full non-stress test suite (6802 passed)
- [x] Coverage gate (70.58% ≥ 67%)
- [x] `mkdocs build --strict`
- [x] Live end-to-end verification against a dedicated (deleted) test brain
- [x] DoD: test brain fully cascade-deleted, `default` brain unaffected