### PR TITLE
fix: make the S310 suppression independent of the ruff version

### DIFF
--- a/src/surreal_memory/mcp/version_check_handler.py
+++ b/src/surreal_memory/mcp/version_check_handler.py
@@ -211,7 +211,9 @@ async def _fetch_latest_version() -> str | None:
         try:
             if not _PYPI_URL.startswith("https://"):
                 return None
-            req = urllib.request.Request(
+            # S310 anchors on this construction under ruff < 0.16 and on the open below
+            # from 0.16 on, so the suppression sits here and tolerates being unused.
+            req = urllib.request.Request(  # noqa: S310, RUF100
                 _PYPI_URL,
                 headers={"Accept": "application/json"},
             )


### PR DESCRIPTION
Hello again, Toni.

Four releases in a single day — 3.0.0 through 3.0.3, and the SQLite backend gone with them.
We moved our own production install onto 3.0.3 the same week and it has been steady since, which
is rather the point: `#143`, `#144` and `#145` are the reason we could. That cannot have been a
restful couple of days, so: thank you. Genuinely.

Three small things surfaced while we were migrating. This is the smallest of the three, and the
least interesting — a one-line lint suppression. The other two follow separately.

## Summary

- `ruff check src/ tests/` passes on ruff 0.16.x and reports one error on ruff 0.15.x, on a
  file the contributor did not touch.
- One line changes: the `noqa` on the `urllib.request.Request(...)` construction now lists
  `RUF100` alongside `S310`, so the same tree is clean under both.
- No configuration changes and no second suppression to keep in sync.

## Why

The two ruff versions anchor `S310` in different places. Before 0.16 the diagnostic starts on
the `urllib.request.Request(...)` construction at line 214; from 0.16 the rule was narrowed to
the open itself at line 218, which is where the existing suppression already sits — `#96` put it
there deliberately and it is still the accurate anchor.

That leaves a gap at the older anchor. Adding a plain `# noqa: S310` at line 214 fixes 0.15 and
makes 0.16 report *that* one as unused (`RUF100`), so the two demands look mutually exclusive.
They are not: naming `RUF100` in the same directive covers both cases. 0.15 uses the `S310`
suppression and leaves the unused `RUF100` alone; 0.16 leaves both alone.

CI pins `ruff==0.16.0`, so `main` is never at risk — this is purely about the contributor who
happens to have a 0.15.x in their environment, opens a file they have never touched, and finds an
error sitting in it. A small papercut, but an easy one to remove.

## Changes

- `src/surreal_memory/mcp/version_check_handler.py` — `# noqa: S310, RUF100` on the `Request(...)`
  construction, plus two comment lines explaining why both codes are listed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Tests

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` passes locally — **6719 passed, 119 skipped,
      1 xfailed**.
- [x] `ruff check src/ tests/` clean — on **both** versions, which is the point of the change:

      ruff 0.15.20  ->  All checks passed!      (before: Found 1 error, S310 at line 214)
      ruff 0.16.1   ->  All checks passed!      (before: All checks passed!)

- [x] `mypy src/ --ignore-missing-imports` clean — `Success: no issues found in 351 source files`.
- [x] `ruff format --check src/ tests/` — `709 files already formatted`.
- [x] Manual check: the branch applies cleanly onto a pristine `v3.0.3` tree
      (`git apply --cached --check` against a `read-tree`d index).
- [ ] Unit tests added/updated — not applicable; this changes a lint suppression, not behaviour.
      `tests/unit/test_version_check.py` continues to pass unchanged.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective — the proof is the two ruff runs above;
      there is no runtime behaviour to assert on.
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly — not applicable.
- [ ] I have updated CHANGELOG.md — deliberately not: this is a lint suppression with no
      user-visible effect, matching how `#133`, `#136`, `#137` and `#140` were handled. Happy to
      add an entry if you would rather have one.

## Related Issues

None. Complements `#96`, which pinned ruff in CI and removed the then-dead suppression at
line 214; this restores it in a form that does not depend on the installed version.

## Verified by

@RobertSigmundsson
