### PR TITLE
test: keep the project-root test inside its fixture when TMPDIR is under $HOME

### DIFF
--- a/tests/unit/test_surface_path_and_decay.py
+++ b/tests/unit/test_surface_path_and_decay.py
@@ -49,8 +49,11 @@ class TestProjectRootDetection:
 
     def test_relocated_global_config_dir_is_not_a_project_root(self, tmp_path: Path) -> None:
         """SURREAL_MEMORY_DIR elsewhere must not promote its parent either."""
-        home = tmp_path / "home"
-        home.mkdir()
+        # detect_project_root walks up from cwd and stops at Path.home(), so the patched
+        # home has to be an ancestor of the patched cwd. With home outside the fixture the
+        # walk leaves tmp_path and picks up whatever markers sit above it -- which is every
+        # run where TMPDIR is under $HOME, since ~/.surrealmemory is itself a marker.
+        home = tmp_path
         data_dir = tmp_path / "srv" / "data"
         global_dir = data_dir / ".surrealmemory"
         global_dir.mkdir(parents=True)


### PR DESCRIPTION
Second of the three small things from our 3.0.3 migration. Test-only, and it cost us a
puzzled half-hour before we spotted what was going on — which is usually a sign it is worth
fixing for whoever hits it next.

## Summary

- One unit test fails on any machine whose `TMPDIR` sits under the home directory, because the
  code under test walks out of the fixture and into the real filesystem.
- Two lines of the fixture change; the assertion is untouched.
- Test-only. No production code changes.

## Why

`detect_project_root()` walks up from `Path.cwd()` and stops only when it reaches `Path.home()`
(`src/surreal_memory/surface/resolver.py:195-205`):

```python
for _ in range(20):
    if current != home and _is_project_root(current, global_dir):
        return current
    parent = current.parent
    if parent == current or current == home:
        break
```

`test_relocated_global_config_dir_is_not_a_project_root` patches cwd to `tmp_path/srv/data` and
home to `tmp_path/home`. That home is a *sibling* of the walk, not an ancestor of it, so the walk
never meets it. It climbs out of `tmp_path`, into the real home directory, finds a marker there
and returns it:

```
    assert detect_project_root() is None
E   AssertionError: assert PosixPath('<$HOME>') is None
```

The marker it finds is usually `.surrealmemory` — checked first in the marker list, and created
in the home directory by this tool itself — or `package.json`. Removing one does not help,
because the walk then matches the other.

`pytest` puts `tmp_path` under `TMPDIR`, so whether the test passes depends entirely on whether
the developer's `TMPDIR` happens to be outside their home directory. The sibling test at line 48
is unaffected because its cwd *is* the patched home, so it breaks out on the first iteration.

## Changes

- `tests/unit/test_surface_path_and_decay.py` — anchor the patched `home` at `tmp_path` so the
  walk terminates inside the fixture, with a comment stating why. The assertion, the global-dir
  patching and what the test proves are all unchanged.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Tests

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` passes locally — and now under both worlds:

      TMPDIR=/tmp             ->  6719 passed, 119 skipped, 1 xfailed
      TMPDIR under $HOME      ->  6719 passed, 119 skipped, 1 xfailed   (before: 1 failed)

      the single test file:
      TMPDIR under $HOME, before  ->  1 failed, 22 passed
      TMPDIR under $HOME, after   ->  23 passed
      TMPDIR=/tmp, after          ->  23 passed

- [x] `ruff check src/ tests/` clean on 0.16.1. On 0.15.20 the tree still reports the
      pre-existing `S310` in `mcp/version_check_handler.py`, which this branch does not touch.
- [x] `mypy src/ --ignore-missing-imports` clean — `Success: no issues found in 351 source files`.
- [x] **Verified in both directions**, because a test that cannot fail proves nothing. With the
      global-config-dir guard in `surface/resolver.py` deliberately removed —

      ```python
      if marker == _NM_DIR and global_dir is not None:
          try:
              if marker_path.resolve() == global_dir:
                  continue
      ```

      — the fixed test fails again under **both** `TMPDIR` settings (`1 failed, 1 passed`), and
      passes again once the guard is restored (`2 passed`). So the fix did not make it
      vacuously green; it still catches the regression it was written for.
- [x] Manual check: applies cleanly onto a pristine `v3.0.3` tree.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective — the change *is* to a test; its power is
      demonstrated by the guard-removal run above.
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly — not applicable.
- [ ] I have updated CHANGELOG.md — deliberately not: test-only, no user-visible effect,
      matching `#137` and `#140`. Say the word and I will add one.

## Related Issues

None.

## Verified by

@RobertSigmundsson
