### PR TITLE
fix: smem info and the dashboard stop reporting five fields as always-empty on SurrealDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — `smem info` and the dashboard stop reporting five fields as always-empty on SurrealDB
+
+### Fixed
+
+- **`SurrealDBStorage.get_enhanced_stats()` never computed five of the fields its callers
+  read** (`cli/commands/info.py`, `server/routes/brain.py`) — `today_fibers_count`,
+  `newest_memory`, `oldest_memory`, `hot_neurons`, `neuron_type_breakdown`. Every caller reads
+  them through `.get(key, default)`, so on SurrealDB — the only backend that ships — the answer
+  was always 0/null/empty, indistinguishable from a genuinely empty brain. All five are now
+  computed, matching `InMemoryStorage.get_enhanced_stats()`.
+- **A second, separable bug in the same function**: the backend computed the neuron type
+  breakdown under the key `neuron_types`; every caller read `neuron_type_breakdown`. The names
+  never matched, so the result — the single most expensive query in the function, by its own
+  code comment (~2.6s on a 64k-neuron brain) — was discarded on arrival every time. Renamed.
+
 ## [3.0.3] — 2026-08-03 — `smem watch` no longer crashes on SurrealDB; `smem index` no longer indexes itself 24x over
 
 ### Fixed

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -2090,10 +2090,62 @@ class SurrealDBStorage(
             synapse_stats["avg_weight"] = round(total_weight / total_count, 4)
         synapse_stats["total_reinforcements"] = total_reinforcements
 
+        # The remaining four fields mirror InMemoryStorage.get_enhanced_stats
+        # (storage/memory_store.py) so both backends report the same shape.
+        # Independent queries, run concurrently like get_stats does above.
+        today = utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        today_rows, hot_state_rows, oldest_rows, newest_rows = await asyncio.gather(
+            self._query(
+                "SELECT count() AS c FROM fiber "
+                "WHERE brain_id = $bid AND created_at >= $today GROUP ALL",
+                bid=brain_id,
+                today=today.isoformat(),
+            ),
+            self._query(
+                "SELECT * FROM neuron_state WHERE brain_id = $bid "
+                "ORDER BY access_frequency DESC LIMIT 10",
+                bid=brain_id,
+            ),
+            self._query(
+                "SELECT created_at FROM fiber WHERE brain_id = $bid "
+                "ORDER BY created_at ASC LIMIT 1",
+                bid=brain_id,
+            ),
+            self._query(
+                "SELECT created_at FROM fiber WHERE brain_id = $bid "
+                "ORDER BY created_at DESC LIMIT 1",
+                bid=brain_id,
+            ),
+        )
+        today_fibers_count = int(today_rows[0].get("c", 0)) if today_rows else 0
+
+        hot_states = [_row_to_neuron_state(r) for r in hot_state_rows]
+        hot_neurons_map = await self.get_neurons_batch([s.neuron_id for s in hot_states])
+        hot_neurons: list[dict[str, Any]] = []
+        for state in hot_states:
+            neuron = hot_neurons_map.get(state.neuron_id)
+            if neuron:
+                hot_neurons.append(
+                    {
+                        "neuron_id": state.neuron_id,
+                        "content": neuron.content,
+                        "type": neuron.type.value,
+                        "activation_level": state.activation_level,
+                        "access_frequency": state.access_frequency,
+                    }
+                )
+
+        oldest_dt = _parse_datetime(oldest_rows[0].get("created_at")) if oldest_rows else None
+        newest_dt = _parse_datetime(newest_rows[0].get("created_at")) if newest_rows else None
+
         return {
             **stats,
-            "neuron_types": type_counts,
+            "neuron_type_breakdown": type_counts,
             "synapse_stats": synapse_stats,
+            "today_fibers_count": today_fibers_count,
+            "hot_neurons": hot_neurons,
+            "oldest_memory": oldest_dt.isoformat() if oldest_dt else None,
+            "newest_memory": newest_dt.isoformat() if newest_dt else None,
         }
 
     # ================================================================

--- a/tests/unit/test_surrealdb_enhanced_stats.py
+++ b/tests/unit/test_surrealdb_enhanced_stats.py
@@ -5,11 +5,19 @@ per-type counts. Without it, ``DiagnosticsEngine`` computed ``diversity = 0``
 and ``recall_confidence = 0`` on the SurrealDB backend (while the SQLite
 backend computed real values), so the dashboard and the ``smem`` CLI reported
 different grades for the very same brain — the "Grade F vs D" divergence.
+
+It must also return the same five fields ``InMemoryStorage.get_enhanced_stats``
+computes (``today_fibers_count``, ``newest_memory``, ``oldest_memory``,
+``hot_neurons``, ``neuron_type_breakdown``) under the *same* key names its
+callers (``cli/commands/info.py``, ``server/routes/brain.py``) actually read —
+on SurrealDB, the only backend that ships, those five were previously always
+0/null/empty regardless of the data present.
 """
 
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import Any
 
 from surreal_memory.storage.surrealdb.store import SurrealDBStorage
@@ -20,8 +28,17 @@ def _make_store_with_scripted_query() -> SurrealDBStorage:
     store = SurrealDBStorage.__new__(SurrealDBStorage)
     store._current_brain_id = "test-brain"
 
+    # Keyed by the underscore form: get_neurons_batch runs each id through
+    # _to_surreal_id (dash -> underscore) before it reaches "FROM neuron:{sid}".
+    neurons_by_id = {
+        "hot_1": {"id": "hot_1", "type": "entity", "content": "most accessed"},
+        "hot_2": {"id": "hot_2", "type": "concept", "content": "second most accessed"},
+    }
+
     async def fake_query(sql: str, **_params: Any) -> list[dict[str, Any]]:
         s = sql.lower()
+        if "from fiber" in s and "created_at >=" in s and "group all" in s:
+            return [{"c": 7}]
         if "from neuron" in s and "count()" in s and "group all" in s:
             return [{"c": 100}]
         if "from synapse" in s and "count()" in s and "group all" in s:
@@ -36,6 +53,20 @@ def _make_store_with_scripted_query() -> SurrealDBStorage:
                 {"type": "after", "cnt": 100, "avg_w": 0.3, "total_r": 2},
                 {"type": "co_occurs", "cnt": 50, "avg_w": 0.9, "total_r": 1},
             ]
+        if "from neuron_state" in s and "order by access_frequency desc" in s:
+            return [
+                {"neuron_id": "hot-1", "activation_level": 0.9, "access_frequency": 42},
+                {"neuron_id": "hot-2", "activation_level": 0.4, "access_frequency": 17},
+            ]
+        if "from neuron:" in s:
+            m = re.search(r"from neuron:(\S+)", s)
+            nid = m.group(1) if m else ""
+            row = neurons_by_id.get(nid)
+            return [row] if row else []
+        if "from fiber" in s and "order by created_at asc" in s:
+            return [{"created_at": "2026-07-01T00:00:00+00:00"}]
+        if "from fiber" in s and "order by created_at desc" in s:
+            return [{"created_at": "2026-08-03T09:57:30.954674+00:00"}]
         return []
 
     store._query = fake_query  # type: ignore[assignment,method-assign]
@@ -63,3 +94,71 @@ def test_enhanced_stats_synapse_stats_yields_nonzero_diversity() -> None:
     stats = asyncio.run(store.get_enhanced_stats("test-brain"))
     diversity = DiagnosticsEngine._compute_diversity(stats["synapse_stats"])
     assert diversity > 0.0
+
+
+def test_enhanced_stats_reports_neuron_type_breakdown_under_the_key_callers_read() -> None:
+    """The backend computed this under ``neuron_types``; every caller (CLI info,
+    the dashboard's brain route) reads ``neuron_type_breakdown`` — the names
+    never matched, so the ~2.6s query it took to build was discarded on arrival.
+    """
+    store = _make_store_with_scripted_query()
+    stats = asyncio.run(store.get_enhanced_stats("test-brain"))
+
+    assert "neuron_type_breakdown" in stats
+    assert stats["neuron_type_breakdown"] == {"memory": 100}
+    assert "neuron_types" not in stats
+
+
+def test_enhanced_stats_reports_today_fibers_count() -> None:
+    store = _make_store_with_scripted_query()
+    stats = asyncio.run(store.get_enhanced_stats("test-brain"))
+
+    assert stats["today_fibers_count"] == 7
+
+
+def test_enhanced_stats_reports_hot_neurons_ordered_by_access_frequency() -> None:
+    store = _make_store_with_scripted_query()
+    stats = asyncio.run(store.get_enhanced_stats("test-brain"))
+
+    hot = stats["hot_neurons"]
+    assert [h["neuron_id"] for h in hot] == ["hot-1", "hot-2"]
+    assert hot[0]["access_frequency"] == 42
+    assert hot[0]["content"] == "most accessed"
+    assert hot[0]["type"] == "entity"
+    assert hot[1]["access_frequency"] == 17
+
+
+def test_enhanced_stats_reports_oldest_and_newest_memory() -> None:
+    """``_parse_datetime`` strips tzinfo ("naive for consistency across the
+    codebase" — store.py's own docstring), so the isoformat output carries no
+    UTC offset even though the scripted rows do. Matches
+    ``InMemoryStorage.get_enhanced_stats``, which formats its own naive
+    ``utcnow()``-based timestamps the same way.
+    """
+    store = _make_store_with_scripted_query()
+    stats = asyncio.run(store.get_enhanced_stats("test-brain"))
+
+    assert stats["oldest_memory"] == "2026-07-01T00:00:00"
+    assert stats["newest_memory"] == "2026-08-03T09:57:30.954674"
+
+
+def test_enhanced_stats_on_an_empty_brain_reports_none_not_a_crash() -> None:
+    """No fibers at all -> oldest/newest must be None, hot_neurons empty — not
+    an IndexError from indexing an empty query result.
+    """
+    store = SurrealDBStorage.__new__(SurrealDBStorage)
+    store._current_brain_id = "empty-brain"
+
+    async def empty_query(sql: str, **_params: Any) -> list[dict[str, Any]]:
+        s = sql.lower()
+        if "count()" in s and "group all" in s:
+            return [{"c": 0}]
+        return []
+
+    store._query = empty_query  # type: ignore[assignment,method-assign]
+    stats = asyncio.run(store.get_enhanced_stats("empty-brain"))
+
+    assert stats["oldest_memory"] is None
+    assert stats["newest_memory"] is None
+    assert stats["hot_neurons"] == []
+    assert stats["today_fibers_count"] == 0


### PR DESCRIPTION
## Summary

- `SurrealDBStorage.get_enhanced_stats()` now computes the five fields its callers already
  read — `today_fibers_count`, `newest_memory`, `oldest_memory`, `hot_neurons`,
  `neuron_type_breakdown` — matching `InMemoryStorage.get_enhanced_stats()`.
- Renames the neuron-type-breakdown output key from `neuron_types` to `neuron_type_breakdown`,
  the name every caller actually reads.

## Why

On the only backend that ships, `smem info` and the dashboard's brain endpoint reported zero
fibers today, no newest/oldest memory, and no hot neurons — always, regardless of how much data
the brain actually held. The cause is a dict default doing the swallowing rather than an
exception: `get_enhanced_stats()` never set those five keys, and every caller reads them via
`.get(key, default)`, so a missing key and a genuinely empty brain produce an identical, silent
answer. A second, separable bug lived in the same function: the neuron-type breakdown was
computed under the key `neuron_types`; every caller reads `neuron_type_breakdown`. The names
never matched, so the single most expensive query in the function — by its own code comment,
~2.6s on a 64k-neuron brain — was thrown away on arrival, every time. We are happy to send this
as a PR rather than an issue first: implementing the five in the SurrealDB mixin is mechanical
once the `InMemoryStorage` shape exists to follow, and the key rename is one line.

Worth adding, because it explains why this stayed hidden rather than being caught by the net
you already built: `tests/unit/test_storage_parity.py` — the ratchet `#139` added so that
"adding a capability to one backend and forgetting the others now fails here instead of going
dark in production" — compares the backends at *method* granularity. `get_enhanced_stats`
exists on both, so the ratchet is green; the divergence is one level finer, in the keys of the
dict that method returns. That is not a criticism of the ratchet, which does exactly what its
docstring claims — just the reason this particular gap outlived it.

## Changes

- `storage/surrealdb/store.py` — `get_enhanced_stats()`: renames the `neuron_types` output key
  to `neuron_type_breakdown`; adds `today_fibers_count` (fiber count on/after today's UTC
  midnight), `hot_neurons` (top 10 `neuron_state` rows by `access_frequency`, joined to their
  neurons via the existing `get_neurons_batch` pipelined fetch), and `oldest_memory` /
  `newest_memory` (earliest/latest fiber `created_at`, via the existing `_parse_datetime`
  helper). The four new queries run concurrently via `asyncio.gather`, alongside the function's
  existing synapse-stats query — matching the concurrency pattern `get_stats()` already uses one
  call up.
- `tests/unit/test_surrealdb_enhanced_stats.py` — five new tests covering each new field, the
  key rename (and that the old `neuron_types` key is gone), and an empty-brain case (no fibers
  at all must produce `None`/`[]`/`0`, not a crash).
- `CHANGELOG.md` — new `## [Unreleased]` entry.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Tests

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` passes locally — **6724 passed, 119 skipped,
      1 xfailed** (baseline on a clean `v3.0.3` checkout is 6719/119/1; the +5 are exactly this
      branch's five new tests — zero regressions elsewhere).
- [x] `ruff check src/ tests/` clean on 0.16.1 (`All checks passed!`). On 0.15.20 the tree still
      reports the pre-existing `S310` in `mcp/version_check_handler.py` — untouched by this
      branch, a separate one-line fix.
- [x] `mypy src/ --ignore-missing-imports` clean — `Success: no issues found in 351 source
      files`.
- [x] `ruff format --check src/ tests/` — `709 files already formatted`.
- [x] `python scripts/check_dead_modules.py --strict` — `No unreachable modules.`
- [x] Verified the key rename doesn't collide with any other reader of a `neuron_types` key:
      repo-wide grep finds two unrelated fields of the same name (a `BrainTransplantFilter`
      attribute, and a per-day `DailyStatsEntry` field fed by its own separate `find_neurons`
      query) — neither reads this function's return value.
- [x] Applies cleanly onto a pristine `v3.0.3` tree (`git apply --cached --check` against a
      freshly `read-tree`'d index).
- [x] Empty-brain case exercised directly (own test): no fibers at all yields `None` for
      oldest/newest, `[]` for hot_neurons, `0` for today's count — not a crash.
- [x] Verified end-to-end against a live server + live SurrealDB 3.2.0 (not just unit tests):
      seeded 5 neurons / 3 fibers, then both `GET /brain/{id}/stats` and `smem stats` returned
      the real values — `hot_neurons` (5, correctly ordered by `access_frequency`),
      `today_fibers_count: 3`, `neuron_type_breakdown` matching the seed's type split, real
      `oldest_memory`/`newest_memory` timestamps. Reproduces exactly the shape the original bug
      report showed as broken.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly — not applicable; no documented API surface
      changes shape, only previously-silent defaults become real values.
- [x] I have updated CHANGELOG.md

## Related Issues

None. We considered filing an issue first, but the bug, its cause and its fix all fit in one
page and one PR — filing one just to close it same-day felt like overhead this repo's own
history doesn't practise (`#139`/`#145` shipped the same way, no preceding issue).

## Verified by

@RobertSigmundsson
