### PR TITLE
fix: bump every version-bearing file to 3.3.1 so the release gate passes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "2.20.1"
+    "version": "3.3.1"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "2.20.1",
+      "version": "3.3.1",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "2.20.1",
+  "version": "3.3.1",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "2.20.1",
+  "version": "3.3.1",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 
 __all__ = [
     "__version__",

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.3.0"
+        assert surreal_memory.__version__ == "3.3.1"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Why

The 3.3.1 release never shipped. `pyproject.toml` was bumped to 3.3.1, but nothing else was — so the Release workflow's `Validate version` job failed on:

```
Tag version:        3.3.1
pyproject.toml:     3.3.1
__init__.py:        3.3.0
::error::Tag v3.3.1 does not match __init__.py version 3.3.0
```

Every downstream job (`CI checks`, `Build`, `Publish to PyPI`, both npm packages, VS Code, ClawHub, `Create GitHub Release`) is gated on `validate`, so all eight were skipped. PyPI and npm are still serving 3.3.0.

CI on the release PR stayed green because `TestVersionBump` pins `__version__` against an exact string — and that pin had also been left at 3.3.0, so the two stale values agreed with each other. Nothing in CI compares `pyproject.toml` to `__init__.py`; only the release workflow does, and by then the tag already exists.

## What changed

Bumped to 3.3.1 — no code changes, version strings only:

- `src/surreal_memory/__init__.py` and the exact-string pin in `tests/unit/test_health_fixes.py::TestVersionBump`
- `integrations/surrealmemory`, `integrations/surreal-memory-client`, `vscode-extension` — `package.json` plus both lockfile roots (top-level `version` and `packages.""`). These matter beyond the gate: the npm publish jobs read these files, so leaving them at 3.3.0 would republish an already-taken version.

Also swept up three manifests that had drifted since 2.20.1 and were failing `scripts/pre_ship.py` section 8 independently of this release: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (both entries), `integrations/surrealmemory/openclaw.plugin.json`.

`CHANGELOG.md` already had its `[3.3.1]` entry.

## Verification

- `scripts/pre_ship.py` — version consistency across all 6 tracked files PASS, `CHANGELOG has [3.3.1]` PASS, OpenClaw plugin version consistency now PASS (was failing)
- `pytest tests/unit/ -m "not stress" -n auto` — 6789 passed, 57 skipped
- ruff check / ruff format / mypy — PASS
- Every touched JSON re-parsed; lockfile `version` and `packages."".version` asserted equal in all three packages
- Verified the sweep did not touch dependency versions: `events@3.3.0` and `lie@3.3.0` inside lockfiles are unrelated upstream packages and were left alone

## Note for whoever tags next

`scripts/pre_ship.py` catches exactly this class of mistake, but it is not wired into CI or the release workflow — it only helps if run by hand before tagging. Making `Validate version` (or a CI job) run the same consistency check would turn this failure mode into a red PR instead of a dead release.