### PR TITLE
ci: gate version consistency on every PR, and stop doc refs from drifting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,25 @@ on:
     branches: [main, master]
 
 jobs:
+  # Release 3.3.1 bumped pyproject.toml alone. Nothing here compared it to the
+  # other version-bearing files, so the skew only surfaced in the release
+  # workflow — after the tag existed, where the failure mode is a dead release
+  # instead of a red PR. This job runs the same gate the release runs, on every
+  # push and PR. It is stdlib-only and needs no install, so it costs ~10s.
+  versions:
+    name: Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check every version-bearing file agrees
+        run: python scripts/pre_ship.py --only versions
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -109,6 +128,12 @@ jobs:
       - name: Check REST reference is up-to-date
         run: python scripts/gen_api_docs.py --check
 
+      # Counts scattered through prose (tool count, test count, schema version)
+      # drift silently — nothing regenerates them. Exits non-zero on drift;
+      # `python scripts/sync_refs.py --fix` rewrites them.
+      - name: Check scattered references are up-to-date
+        run: python scripts/sync_refs.py
+
       # mkdocs is not a project dependency — the site is built from these
       # plugins only. Strict mode turns every dead link into a failure, which
       # is the point: it had silently broken and nothing was running it.
@@ -198,7 +223,7 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test]
+    needs: [versions, lint, typecheck, test]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,35 +21,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check tag matches source version
+      # Shares one implementation with the `Version Consistency` job in ci.yml,
+      # so this can only fail on something CI could not have known: a tag that
+      # disagrees with a tree that is internally consistent. The previous
+      # inline version compared the tag against pyproject.toml and __init__.py
+      # only — it never saw the npm manifests the publish jobs below read.
+      - name: Check tag matches every version-bearing file
         run: |
-          TAG="${GITHUB_REF#refs/tags/v}"
-          PYPROJECT=$(python3 -c "
-          import re, pathlib
-          text = pathlib.Path('pyproject.toml').read_text()
-          m = re.search(r'^version\s*=\s*\"([^\"]+)\"', text, re.M)
-          print(m.group(1))
-          ")
-          INIT=$(python3 -c "
-          import re, pathlib
-          text = pathlib.Path('src/surreal_memory/__init__.py').read_text()
-          m = re.search(r'^__version__\s*=\s*\"([^\"]+)\"', text, re.M)
-          print(m.group(1))
-          ")
-
-          echo "Tag version:        $TAG"
-          echo "pyproject.toml:     $PYPROJECT"
-          echo "__init__.py:        $INIT"
-
-          if [ "$TAG" != "$PYPROJECT" ]; then
-            echo "::error::Tag v$TAG does not match pyproject.toml version $PYPROJECT"
-            exit 1
-          fi
-          if [ "$TAG" != "$INIT" ]; then
-            echo "::error::Tag v$TAG does not match __init__.py version $INIT"
-            exit 1
-          fi
-          echo "Version $TAG is consistent across all sources."
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "Tag: $TAG"
+          python3 scripts/pre_ship.py --only versions --expect "$TAG"
 
   # ── Gate: run full CI before publishing ─────────────────────────
   ci:

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -127,7 +127,7 @@ Todo lo demás — sesiones, carga de contexto, seguimiento de hábitos, manteni
 
 ```
                     ┌──────────────────────────────┐
-                    │       MCP Server (58 tools)   │
+                    │       MCP Server (57 tools)   │
                     └──────────┬───────────────────┘
                                │
                     ┌──────────▼───────────────────┐

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Forward-looking vision. What's next, what's possible, where we're going.
 > ZERO LLM dependency — pure algorithmic, regex, graph-based.
 
-**Current state**: v2.20.0 — 58 MCP tools, 7,267 tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
+**Current state**: v3.3.1 — 57 MCP tools, 6900+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
 
 **Storage**: SurrealDB is the recommended backend and the one the project is built around —
 SurrealDB schema v9. SQLite and InMemory are not test-only fixtures; they are real, selectable

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -53,7 +53,7 @@ multi-model (document + graph + vector) engine as the production storage backend
 Entry points for users and applications:
 
 - **CLI** - Command-line interface (`smem` commands)
-- **MCP Server** - Model Context Protocol for Claude integration (58 tools)
+- **MCP Server** - Model Context Protocol for Claude integration (57 tools)
 - **REST API** - FastAPI-based HTTP server, backs the web dashboard at `/ui`
 
 ### Engine Layer

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -215,7 +215,7 @@ src/surreal_memory/
 │   ├── surrealdb/ # SurrealDB backend (primary — 163 methods across 10 mixins)
 │   ├── sqlite_*.py# SQLite/InMemory backends (test fixtures only — not the production backend)
 │   └── surrealdb/ # SurrealDB backend (recommended)
-├── mcp/           # MCP server for Claude (58 tools, ~30 handler files)
+├── mcp/           # MCP server for Claude (57 tools, ~30 handler files)
 ├── server/        # FastAPI REST server + dashboard static files
 ├── cli/           # Command-line interface (smem / surreal-memory)
 ├── plugins/       # Community plugin (bypasses Pro feature gates)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -3,7 +3,7 @@
 This guide walks you through Surreal-Memory setup and usage in 5 minutes.
 
 !!! tip "3 tools you need"
-    Surreal-Memory has 58 tools, but you only need three: **`smem_remember`**, **`smem_recall`**, and **`smem_health`**. The agent handles the other 55 automatically. See [all tools](../guides/mcp-server.md#available-tools).
+    Surreal-Memory has 57 tools, but you only need three: **`smem_remember`**, **`smem_recall`**, and **`smem_health`**. The agent handles the other 54 automatically. See [all tools](../guides/mcp-server.md#available-tools).
 
 ## Why Surreal-Memory?
 

--- a/docs/guides/pro-quickstart.md
+++ b/docs/guides/pro-quickstart.md
@@ -186,10 +186,10 @@ Sync uses **Merkle delta** — only changes are transmitted. A brain with 100K n
 | Recall method | Keyword matching | Semantic similarity + graph traversal |
 | Consolidation | Keyword overlap | Embedding similarity via HNSW neighbours |
 | Compression | Text-level trimming | 5-tier vector lifecycle |
-| MCP tools | 58 tools | the same 58 tools |
+| MCP tools | 57 tools | the same 57 tools |
 | Setup | Built-in, zero config | Requires SurrealDB instance |
 
-All 58 MCP tools work with both backends. Switching does **not** move your data:
+All 57 MCP tools work with both backends. Switching does **not** move your data:
 the two backends are separate stores, so export from one and import into the
 other — see [Migrating to 3.0](migrating-to-3.0.md).
 

--- a/docs/landing/pro.md
+++ b/docs/landing/pro.md
@@ -118,7 +118,7 @@ Deploy with the provided Worker template. No managed service dependency.
 
 | Interface | Description |
 |-----------|-------------|
-| **MCP Server** | 58 tools for Claude, GPT, and other agents. Recall, store, consolidate, query. |
+| **MCP Server** | 57 tools for Claude, GPT, and other agents. Recall, store, consolidate, query. |
 | **Web Dashboard** | Browser-based brain inspector. Visualize neurons, fibers, and graph topology. |
 | **VS Code Extension** | Inline memory panel. Recall context without leaving the editor. |
 | **CLI** | Full control from the terminal. `smem recall`, `smem remember`, `smem consolidate`, etc. |
@@ -160,7 +160,7 @@ Surreal-Memory vs. alternatives:
 
 ## MCP Tools
 
-58 tools registered automatically. Key tools by category:
+57 tools registered automatically. Key tools by category:
 
 **Recall:**
 - `smem_recall` -- query memories with configurable depth and confidence

--- a/docs/promo/devto-article.md
+++ b/docs/promo/devto-article.md
@@ -68,7 +68,7 @@ Memories have a full lifecycle modelled on human cognition:
 
 ## 56 MCP Tools
 
-Surreal-Memory exposes **58 tools** via the [Model Context Protocol](https://modelcontextprotocol.io/). The 3-tool core drives daily use; the rest fire automatically or on demand:
+Surreal-Memory exposes **57 tools** via the [Model Context Protocol](https://modelcontextprotocol.io/). The 3-tool core drives daily use; the rest fire automatically or on demand:
 
 | Tool | What it does |
 |------|-------------|
@@ -156,7 +156,7 @@ If you need a lightweight SQLite-backed version, the upstream project is the rig
 
 ## Numbers
 
-- **58 MCP tools** — 3-tool core, 53 fire automatically or on demand
+- **57 MCP tools** — 3-tool core, 53 fire automatically or on demand
 - **7200+ unit tests**, 67%+ CI coverage
 - **15 memory types**: fact, decision, error, insight, preference, workflow, todo, and more
 - **41 synapse types**: `CAUSED_BY`, `LEADS_TO`, `RESOLVED_BY`, `CONTRADICTS`, and 37 more

--- a/docs/promo/discord-anthropic.md
+++ b/docs/promo/discord-anthropic.md
@@ -17,7 +17,7 @@ smem-mcp  # starts the MCP server
 ```
 
 **What you get:**
-- **58 MCP tools** — 3-tool core (remember / recall / health), the rest fire automatically
+- **57 MCP tools** — 3-tool core (remember / recall / health), the rest fire automatically
 - **SurrealDB backend** — document + graph + vector HNSW in one database, no separate vector store
 - **$0.00/query** — no LLM/embedding API calls for core encode + recall; no API keys required for core ops
 - Memory lifecycle: Ebbinghaus decay, Hebbian reinforcement, sleep consolidation (ENRICH / PRUNE / MERGE / DREAM)

--- a/docs/promo/hackernews.md
+++ b/docs/promo/hackernews.md
@@ -12,7 +12,7 @@ Core idea: memories are stored as typed neurons connected by 41 typed synapses (
 
 No embedding API calls needed for core recall — it's pure algorithmic graph traversal. Embeddings are optional for semantic (vector) search (supports Ollama, sentence-transformers, Gemini, OpenAI). Core encode + recall costs $0.00 per query.
 
-Backed by SurrealDB's multi-model engine (document + graph + vector HNSW in one database — no separate vector store). 58 MCP tools, 7200+ tests, 67%+ CI coverage, Python 3.11+, MIT.
+Backed by SurrealDB's multi-model engine (document + graph + vector HNSW in one database — no separate vector store). 57 MCP tools, 7200+ tests, 67%+ CI coverage, Python 3.11+, MIT.
 
 All Pro-tier features (HNSW vector search, smart merge, 5-tier compression, sleep consolidation) are free via the bundled community plugin — no license keys.
 

--- a/docs/promo/reddit-claudeai.md
+++ b/docs/promo/reddit-claudeai.md
@@ -1,6 +1,6 @@
 # Reddit r/ClaudeAI Post
 
-**Title:** I built a persistent memory system for Claude Code that works like a brain — Surreal-Memory (open source, 58 MCP tools, $0/query)
+**Title:** I built a persistent memory system for Claude Code that works like a brain — Surreal-Memory (open source, 57 MCP tools, $0/query)
 
 **Body:**
 
@@ -16,7 +16,7 @@ When you remember "Alice", it doesn't just find text containing "Alice". It acti
 
 ## What it does
 
-- **58 MCP tools**: 3-tool core (`smem_remember`, `smem_recall`, `smem_health`) — the other 53 fire automatically
+- **57 MCP tools**: 3-tool core (`smem_remember`, `smem_recall`, `smem_health`) — the other 53 fire automatically
 - **Spreading activation retrieval**: memories surface through association, not search
 - **41 synapse types** (`CAUSED_BY`, `LEADS_TO`, `CONTRADICTS`, `RESOLVED_BY`) — causal reasoning, not just similarity
 - **15 memory types**: fact, decision, error, insight, preference, workflow, todo, and more
@@ -49,7 +49,7 @@ Works with Claude Code, Cursor, Windsurf, VS Code, Cline, Zed, and Gemini CLI.
 
 ## Numbers
 
-- **58 MCP tools** · **7200+ unit tests** · **67%+ CI coverage**
+- **57 MCP tools** · **7200+ unit tests** · **67%+ CI coverage**
 - **$0.00/query** — no API calls for core encode + recall
 - 15 memory types · 41 synapse types
 - Python 3.11+ · async · MIT license

--- a/docs/promo/reddit-localllama.md
+++ b/docs/promo/reddit-localllama.md
@@ -28,7 +28,7 @@ This gives you multi-hop causal reasoning. "Why did the outage happen?" traces: 
 - **Graph**: 15 memory types (fact, decision, error, insight, preference, workflow, todo, ...), 41 synapse types, fiber bundles for episodic grouping
 - **Retrieval**: Spreading activation with configurable decay, threshold, and max hops
 - **Lifecycle**: Ebbinghaus decay, Hebbian reinforcement, sleep consolidation (ENRICH/PRUNE/MERGE/DREAM), 5-tier compression
-- **MCP server**: 58 tools (3-tool core: smem_remember, smem_recall, smem_health), stdio + HTTP, works with Claude Code, Cursor, Windsurf, Cline, Zed, Gemini CLI
+- **MCP server**: 57 tools (3-tool core: smem_remember, smem_recall, smem_health), stdio + HTTP, works with Claude Code, Cursor, Windsurf, Cline, Zed, Gemini CLI
 - **Pro features**: cone/HNSW vector search, smart merge, directional compression — all FREE via the bundled community plugin, no license keys
 - **Tests**: 7200+ unit tests, 67%+ CI coverage, mypy + ruff + pytest
 

--- a/docs/promo/vs-neural-memory.md
+++ b/docs/promo/vs-neural-memory.md
@@ -15,7 +15,7 @@ This page explains what was inherited and what changed so you can make an inform
 - 41 explicit synapse types (`CAUSED_BY`, `LEADS_TO`, `RESOLVED_BY`, `CONTRADICTS`, …) for causal reasoning
 - 15 memory types (`fact`, `decision`, `error`, `insight`, `preference`, `workflow`, `todo`, …)
 - Memory lifecycle: decay (Ebbinghaus curve), Hebbian reinforcement, sleep-consolidation phases
-- The 58-tool MCP surface — including the 3-tool core (`smem_remember`, `smem_recall`, `smem_health`)
+- The 57-tool MCP surface — including the 3-tool core (`smem_remember`, `smem_recall`, `smem_health`)
 
 ---
 

--- a/integrations/surreal-memory/SKILL.md
+++ b/integrations/surreal-memory/SKILL.md
@@ -122,7 +122,7 @@ If you prefer MCP over the plugin, add to `~/.openclaw/mcp.json`:
 }
 ```
 
-On Windows, use `"python"` (not `"python3"`). This gives you all 58 MCP tools but without the auto-context/auto-capture hooks.
+On Windows, use `"python"` (not `"python3"`). This gives you all 57 MCP tools but without the auto-context/auto-capture hooks.
 
 ### 3. Verify
 

--- a/integrations/surrealmemory/README.md
+++ b/integrations/surrealmemory/README.md
@@ -54,7 +54,7 @@ Add to `~/.openclaw/openclaw.json`:
 
 **v1.7.0+**: The plugin dynamically fetches **all tools** from the MCP server at startup. Whatever version of `surreal-memory` you have installed, the plugin automatically exposes every tool it provides — no plugin update needed when new tools are added.
 
-With `surreal-memory>=4.6.0`, this includes **58 tools**:
+With `surreal-memory>=4.6.0`, this includes **57 tools**:
 
 | Category | Tools |
 |----------|-------|

--- a/scripts/pre_ship.py
+++ b/scripts/pre_ship.py
@@ -20,6 +20,7 @@ Usage:
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 import subprocess
@@ -62,60 +63,113 @@ def warn(name: str, detail: str = "") -> None:
 # ── 1. Version Consistency ──────────────────────────────────────
 
 
+NPM_PACKAGE_DIRS = (
+    "integrations/surrealmemory",
+    "integrations/surreal-memory-client",
+    "vscode-extension",
+)
+
+
+def _read_version(path: Path, pattern: str) -> str:
+    if not path.exists():
+        return "NOT_FOUND"
+    m = re.search(pattern, path.read_text(), re.MULTILINE)
+    return m.group(1) if m else "NOT_FOUND"
+
+
+def _lockfile_versions(path: Path) -> tuple[str, str]:
+    """A lockfile states the package version twice — at the root and under
+    `packages.""`. npm rewrites both, so both have to move together."""
+    if not path.exists():
+        return "NOT_FOUND", "NOT_FOUND"
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return "UNPARSEABLE", "UNPARSEABLE"
+    return (
+        data.get("version", "NOT_FOUND"),
+        data.get("packages", {}).get("", {}).get("version", "NOT_FOUND"),
+    )
+
+
+def collect_versions(root: Path = ROOT) -> dict[str, str]:
+    """Every file carrying the release version, mapped to what it claims.
+
+    Keep this exhaustive. A file missing from here can go stale with no gate
+    noticing — which is exactly how 3.3.1 published nothing. Reads files
+    directly (stdlib only, no installed package), so a bare checkout can run it.
+    """
+    versions: dict[str, str] = {
+        "pyproject.toml": _read_version(root / "pyproject.toml", r'^version\s*=\s*"([^"]+)"'),
+        "src/surreal_memory/__init__.py": _read_version(
+            root / "src/surreal_memory/__init__.py", r'^__version__\s*=\s*"([^"]+)"'
+        ),
+        "tests/unit/test_health_fixes.py": _read_version(
+            root / "tests/unit/test_health_fixes.py", r'__version__\s*==\s*"([^"]+)"'
+        ),
+        ".claude-plugin/plugin.json": _read_version(
+            root / ".claude-plugin/plugin.json", r'"version"\s*:\s*"([^"]+)"'
+        ),
+    }
+
+    # marketplace.json carries it twice: catalogue metadata, then the plugin entry.
+    marketplace = root / ".claude-plugin/marketplace.json"
+    found = (
+        re.findall(r'"version"\s*:\s*"([^"]+)"', marketplace.read_text())
+        if marketplace.exists()
+        else []
+    )
+    versions[".claude-plugin/marketplace.json (metadata)"] = found[0] if found else "NOT_FOUND"
+    versions[".claude-plugin/marketplace.json (plugins)"] = (
+        found[1] if len(found) > 1 else "NOT_FOUND"
+    )
+
+    versions["integrations/surrealmemory/openclaw.plugin.json"] = _read_version(
+        root / "integrations/surrealmemory/openclaw.plugin.json", r'"version"\s*:\s*"([^"]+)"'
+    )
+
+    # npm manifests are not cosmetic: the publish jobs read these, so a stale
+    # one does not fail the gate — it tries to republish a taken version.
+    for pkg in NPM_PACKAGE_DIRS:
+        versions[f"{pkg}/package.json"] = _read_version(
+            root / pkg / "package.json", r'"version"\s*:\s*"([^"]+)"'
+        )
+        lock_root, lock_packages = _lockfile_versions(root / pkg / "package-lock.json")
+        versions[f"{pkg}/package-lock.json (root)"] = lock_root
+        versions[f'{pkg}/package-lock.json (packages."")'] = lock_packages
+
+    return versions
+
+
+def verify_versions(root: Path = ROOT, expected: str | None = None) -> tuple[bool, list[str]]:
+    """Confirm every version-bearing file agrees.
+
+    `expected` pins them to a release tag, which catches the case no
+    file-to-file comparison can: a tag ahead of a tree that is internally
+    consistent. Returns (ok, problems) so callers decide how to report.
+    """
+    versions = collect_versions(root)
+    canonical = (expected or versions["pyproject.toml"]).lstrip("v")
+    problems = [
+        f"{label}: {value} (expected {canonical})"
+        for label, value in versions.items()
+        if value != canonical
+    ]
+    return not problems, problems
+
+
 def check_versions() -> None:
     print("\n1. Version Consistency")
 
-    version_files: dict[str, str | None] = {
-        "pyproject.toml": None,
-        "src/surreal_memory/__init__.py": None,
-        ".claude-plugin/plugin.json": None,
-        ".claude-plugin/marketplace.json (metadata)": None,
-        ".claude-plugin/marketplace.json (plugins)": None,
-        "tests/unit/test_health_fixes.py": None,
-    }
+    versions = collect_versions()
+    canonical = versions["pyproject.toml"]
+    all_match, problems = verify_versions()
 
-    # pyproject.toml
-    text = (ROOT / "pyproject.toml").read_text()
-    m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
-    canonical = m.group(1) if m else "NOT_FOUND"
-    version_files["pyproject.toml"] = canonical
-
-    # __init__.py
-    text = (ROOT / "src/surreal_memory/__init__.py").read_text()
-    m = re.search(r'__version__\s*=\s*"([^"]+)"', text)
-    version_files["src/surreal_memory/__init__.py"] = m.group(1) if m else "NOT_FOUND"
-
-    # plugin.json
-    text = (ROOT / ".claude-plugin/plugin.json").read_text()
-    m = re.search(r'"version"\s*:\s*"([^"]+)"', text)
-    version_files[".claude-plugin/plugin.json"] = m.group(1) if m else "NOT_FOUND"
-
-    # marketplace.json (2 occurrences)
-    text = (ROOT / ".claude-plugin/marketplace.json").read_text()
-    versions = re.findall(r'"version"\s*:\s*"([^"]+)"', text)
-    version_files[".claude-plugin/marketplace.json (metadata)"] = (
-        versions[0] if len(versions) > 0 else "NOT_FOUND"
-    )
-    version_files[".claude-plugin/marketplace.json (plugins)"] = (
-        versions[1] if len(versions) > 1 else "NOT_FOUND"
-    )
-
-    # test_health_fixes.py
-    text = (ROOT / "tests/unit/test_health_fixes.py").read_text()
-    m = re.search(r'__version__\s*==\s*"([^"]+)"', text)
-    version_files["tests/unit/test_health_fixes.py"] = m.group(1) if m else "NOT_FOUND"
-
-    # NOT checked: tests/unit/test_markdown_export.py. Its `"version"` field is the
-    # brain-snapshot schema version in a test fixture, not the package version, so
-    # matching it against the release version was a permanent false failure.
-
-    all_match = all(v == canonical for v in version_files.values())
-    check(f"All {len(version_files)} files match", all_match, f"Expected {canonical}")
+    check(f"All {len(versions)} files match", all_match, f"Expected {canonical}")
 
     if not all_match:
-        for path, ver in version_files.items():
-            status = "ok" if ver == canonical else f"MISMATCH: {ver}"
-            print(f"           {path}: {status}")
+        for problem in problems:
+            print(f"           MISMATCH: {problem}")
 
     # CHANGELOG has entry for this version
     changelog = (ROOT / "CHANGELOG.md").read_text()
@@ -422,15 +476,63 @@ def check_refs(fix: bool = False) -> None:
 # ── Main ────────────────────────────────────────────────────────
 
 
+def run_version_gate(expected: str | None = None) -> int:
+    """The gate CI and the release workflow share.
+
+    Prints GitHub Actions annotations so a skew shows up on the file list of a
+    pull request, not just in a log nobody opens.
+    """
+    ok, problems = verify_versions(expected=expected)
+    target = (expected or collect_versions()["pyproject.toml"]).lstrip("v")
+
+    if ok:
+        print(f"Every version-bearing file carries {target}.")
+        return 0
+
+    print(f"::error::Version skew — a release tagged v{target} would publish nothing.")
+    for problem in problems:
+        print(f"::error::{problem}")
+    print("\nBump every file to the same version (see CLAUDE.md 'Releases'), or run:")
+    print("  python scripts/pre_ship.py --only versions")
+    return 1
+
+
 def main() -> int:
-    fix = "--fix" in sys.argv
+    parser = argparse.ArgumentParser(
+        description="Pre-ship verification for surreal-memory.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--fix", action="store_true", help="Auto-fix what can be fixed (ruff, stale refs)"
+    )
+    parser.add_argument(
+        "--only",
+        choices=["versions"],
+        help=(
+            "Run a single gate and exit. `versions` is stdlib-only and needs no "
+            "installed package, so CI and the release workflow can call it on a "
+            "bare checkout in seconds."
+        ),
+    )
+    parser.add_argument(
+        "--expect",
+        metavar="VERSION",
+        help=(
+            "Require every file to carry this exact version (the release tag). "
+            "A leading 'v' is stripped, so both v3.3.1 and 3.3.1 work."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.only == "versions":
+        return run_version_gate(args.expect)
 
     print("=" * 60)
     print("  Surreal-Memory — Pre-Ship Verification")
     print("=" * 60)
 
     check_versions()
-    check_ruff(fix=fix)
+    check_ruff(fix=args.fix)
     check_mypy()
     check_imports()
     check_tests()
@@ -438,7 +540,7 @@ def main() -> int:
     check_cognitive()
     check_plugin()
     check_docs()
-    check_refs(fix=fix)
+    check_refs(fix=args.fix)
 
     print("\n" + "=" * 60)
     if failures:

--- a/scripts/sync_refs.py
+++ b/scripts/sync_refs.py
@@ -47,6 +47,23 @@ SKIP_DIRS = {
     # "correcting" those quotes would destroy the very thing they record.
     "qa",
     ".goal",
+    # Session handoff journal — gitignored, and its entries are timestamped
+    # records of what was true that day. "5645 tests" under a 2026-07-11
+    # heading is a fact about July, not drift to correct.
+    ".remember",
+    # Trees that are not ours to document. A worktree holds another branch's
+    # copy of this repo, and a virtualenv holds other projects' READMEs
+    # outright. Matched at any depth by _should_skip.
+    ".claude",
+    ".venv",
+    "venv",
+    "site-packages",
+    ".tox",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "build",
+    "dist",
 }
 
 # Lines that legitimately carry a NUMBER THAT IS NOT OURS, or not ours *now*.
@@ -175,18 +192,18 @@ def derive_truth() -> TruthValues:
 
 def _should_skip(path: Path) -> bool:
     """Check if file should be skipped."""
-    rel = path.relative_to(ROOT).as_posix()
+    rel = path.relative_to(ROOT)
 
     # Skip historical files
-    if rel in SKIP_FILES:
+    if rel.as_posix() in SKIP_FILES:
         return True
 
-    # Skip non-shipped directories
-    for skip_dir in SKIP_DIRS:
-        if rel.startswith(skip_dir + "/") or rel == skip_dir:
-            return True
-
-    return False
+    # Match on path SEGMENTS, not on a leading prefix. The prefix check only
+    # caught these directories at the repo root, so `dashboard/node_modules/`
+    # and `.claude/worktrees/*/.venv/**/site-packages/` sailed through — a scan
+    # reported ~1136 findings in other projects' READMEs, and `--fix` would have
+    # rewritten files outside this repository.
+    return bool(SKIP_DIRS.intersection(rel.parts))
 
 
 def scan_stale_refs(truth: TruthValues) -> list[RefFinding]:

--- a/tests/unit/test_release_gates.py
+++ b/tests/unit/test_release_gates.py
@@ -1,0 +1,235 @@
+"""Gates that stop a version-skew release from being tagged, and keep the
+doc-reference scanner inside the repo.
+
+Both of these exist because of a real failure. Release 3.3.1 bumped
+`pyproject.toml` alone; the release workflow compared the tag against
+`pyproject.toml` and `__init__.py`, failed, and skipped all eight publish
+jobs. CI stayed green throughout, because the only version assertion in the
+suite pinned `__version__` against a string that had been left stale too — so
+the two wrong values agreed with each other.
+
+The npm coverage matters for a second reason: the npm publish jobs read
+`package.json`, so a stale one there does not fail the gate, it republishes an
+already-taken version.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_script(name: str) -> ModuleType:
+    """Import a top-level script from scripts/ that is not an installed module."""
+    path = REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"_script_{name}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pre_ship = _load_script("pre_ship")
+sync_refs = _load_script("sync_refs")
+
+
+NPM_PACKAGES = (
+    "integrations/surrealmemory",
+    "integrations/surreal-memory-client",
+    "vscode-extension",
+)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _fake_repo(root: Path, version: str = "9.9.9", **overrides: str) -> Path:
+    """Build a minimal tree carrying every version string the release reads.
+
+    `overrides` takes the same labels `collect_versions` returns, so a test can
+    skew exactly one file and assert the gate notices.
+    """
+
+    def v(label: str) -> str:
+        return overrides.get(label, version)
+
+    _write(root / "pyproject.toml", f'[project]\nname = "x"\nversion = "{v("pyproject.toml")}"\n')
+    _write(
+        root / "src/surreal_memory/__init__.py",
+        f'__version__ = "{v("src/surreal_memory/__init__.py")}"\n',
+    )
+    _write(
+        root / "tests/unit/test_health_fixes.py",
+        f'assert surreal_memory.__version__ == "{v("tests/unit/test_health_fixes.py")}"\n',
+    )
+    _write(
+        root / ".claude-plugin/plugin.json",
+        json.dumps({"name": "x", "version": v(".claude-plugin/plugin.json")}),
+    )
+    _write(
+        root / ".claude-plugin/marketplace.json",
+        json.dumps(
+            {
+                "version": v(".claude-plugin/marketplace.json (metadata)"),
+                "plugins": [{"version": v(".claude-plugin/marketplace.json (plugins)")}],
+            }
+        ),
+    )
+    for pkg in NPM_PACKAGES:
+        _write(
+            root / pkg / "package.json",
+            json.dumps({"name": pkg, "version": v(f"{pkg}/package.json")}),
+        )
+        _write(
+            root / pkg / "package-lock.json",
+            json.dumps(
+                {
+                    "name": pkg,
+                    "version": v(f"{pkg}/package-lock.json (root)"),
+                    "packages": {
+                        "": {"version": v(f'{pkg}/package-lock.json (packages."")')},
+                        "node_modules/events": {"version": "3.3.0"},
+                    },
+                }
+            ),
+        )
+    _write(
+        root / "integrations/surrealmemory/openclaw.plugin.json",
+        json.dumps(
+            {
+                "id": "surrealmemory",
+                "version": v("integrations/surrealmemory/openclaw.plugin.json"),
+            }
+        ),
+    )
+    return root
+
+
+class TestCollectVersions:
+    """`collect_versions` is the single source of truth both gates read."""
+
+    def test_reads_every_versioned_file_and_agrees_when_consistent(self, tmp_path: Path) -> None:
+        versions = pre_ship.collect_versions(_fake_repo(tmp_path, "9.9.9"))
+
+        assert set(versions.values()) == {"9.9.9"}
+        assert "NOT_FOUND" not in versions.values()
+
+    def test_flags_the_init_skew_that_killed_3_3_1(self, tmp_path: Path) -> None:
+        root = _fake_repo(tmp_path, "3.3.1", **{"src/surreal_memory/__init__.py": "3.3.0"})
+
+        versions = pre_ship.collect_versions(root)
+
+        assert versions["src/surreal_memory/__init__.py"] == "3.3.0"
+        assert versions["pyproject.toml"] == "3.3.1"
+
+    def test_covers_the_test_pin_that_agreed_with_the_stale_value(self, tmp_path: Path) -> None:
+        root = _fake_repo(tmp_path, "3.3.1", **{"tests/unit/test_health_fixes.py": "3.3.0"})
+
+        assert pre_ship.collect_versions(root)["tests/unit/test_health_fixes.py"] == "3.3.0"
+
+    @pytest.mark.parametrize("pkg", NPM_PACKAGES)
+    def test_covers_npm_package_json(self, tmp_path: Path, pkg: str) -> None:
+        """A stale package.json republishes a taken version instead of failing."""
+        label = f"{pkg}/package.json"
+        root = _fake_repo(tmp_path, "3.3.1", **{label: "3.3.0"})
+
+        assert pre_ship.collect_versions(root)[label] == "3.3.0"
+
+    @pytest.mark.parametrize("pkg", NPM_PACKAGES)
+    def test_covers_both_lockfile_roots(self, tmp_path: Path, pkg: str) -> None:
+        label = f'{pkg}/package-lock.json (packages."")'
+        root = _fake_repo(tmp_path, "3.3.1", **{label: "3.3.0"})
+
+        versions = pre_ship.collect_versions(root)
+
+        assert versions[label] == "3.3.0"
+        assert versions[f"{pkg}/package-lock.json (root)"] == "3.3.1"
+
+    def test_ignores_dependency_versions_inside_lockfiles(self, tmp_path: Path) -> None:
+        """`events@3.3.0` in node_modules is an unrelated package, not our version."""
+        versions = pre_ship.collect_versions(_fake_repo(tmp_path, "3.3.1"))
+
+        assert "3.3.0" not in versions.values()
+
+    def test_covers_the_openclaw_manifest_that_drifted_since_2_20_1(self, tmp_path: Path) -> None:
+        label = "integrations/surrealmemory/openclaw.plugin.json"
+        root = _fake_repo(tmp_path, "3.3.1", **{label: "2.20.1"})
+
+        assert pre_ship.collect_versions(root)[label] == "2.20.1"
+
+    def test_missing_file_reports_not_found_rather_than_crashing(self, tmp_path: Path) -> None:
+        root = _fake_repo(tmp_path, "3.3.1")
+        (root / "vscode-extension/package.json").unlink()
+
+        assert pre_ship.collect_versions(root)["vscode-extension/package.json"] == "NOT_FOUND"
+
+
+class TestVersionGate:
+    """The gate both CI and the release workflow call."""
+
+    def test_passes_when_every_file_agrees(self, tmp_path: Path) -> None:
+        ok, problems = pre_ship.verify_versions(_fake_repo(tmp_path, "3.3.1"))
+
+        assert ok is True
+        assert problems == []
+
+    def test_fails_and_names_the_skewed_file(self, tmp_path: Path) -> None:
+        root = _fake_repo(tmp_path, "3.3.1", **{"src/surreal_memory/__init__.py": "3.3.0"})
+
+        ok, problems = pre_ship.verify_versions(root)
+
+        assert ok is False
+        assert any("src/surreal_memory/__init__.py" in p and "3.3.0" in p for p in problems)
+
+    def test_expected_version_catches_a_tag_ahead_of_every_file(self, tmp_path: Path) -> None:
+        """v3.3.2 tagged on a tree that still says 3.3.1 everywhere."""
+        ok, problems = pre_ship.verify_versions(_fake_repo(tmp_path, "3.3.1"), expected="3.3.2")
+
+        assert ok is False
+        assert any("3.3.2" in p for p in problems)
+
+    def test_expected_version_passes_when_the_tag_matches(self, tmp_path: Path) -> None:
+        ok, problems = pre_ship.verify_versions(_fake_repo(tmp_path, "3.3.1"), expected="3.3.1")
+
+        assert ok is True
+        assert problems == []
+
+
+class TestScannerStaysInsideTheRepo:
+    """`sync_refs` walks *.md from the repo root; vendored trees are not ours."""
+
+    @pytest.mark.parametrize(
+        "relative",
+        [
+            ".claude/worktrees/agent-1/CHANGELOG.md",
+            ".claude/worktrees/agent-1/.venv/lib/python3.13/site-packages/litellm/README.md",
+            "dashboard/node_modules/some-dep/README.md",
+            ".venv/lib/python3.13/site-packages/pkg/ARCHITECTURE.md",
+            "vscode-extension/node_modules/dep/readme.md",
+            # Gitignored session journal: timestamped records of what was true
+            # that day, not documentation that drifted.
+            ".remember/today-2026-07-11.done.md",
+        ],
+    )
+    def test_skips_vendored_and_worktree_paths_at_any_depth(self, relative: str) -> None:
+        assert sync_refs._should_skip(sync_refs.ROOT / relative) is True
+
+    @pytest.mark.parametrize(
+        "relative",
+        ["README.md", "docs/guides/pro-quickstart.md", "ROADMAP.md"],
+    )
+    def test_still_scans_real_documentation(self, relative: str) -> None:
+        assert sync_refs._should_skip(sync_refs.ROOT / relative) is False
+
+    def test_still_honours_the_historical_skip_list(self) -> None:
+        assert sync_refs._should_skip(sync_refs.ROOT / "CHANGELOG.md") is True


### PR DESCRIPTION
Follow-up to #160, which fixed the 3.3.1 release by hand. This stops the same failure from reaching a tag again, and clears the doc drift found along the way.

## The gap

3.3.1 published nothing. `pyproject.toml` was bumped alone, `Validate version` failed on the mismatch, and all eight publish jobs were skipped. **Nothing in CI compared those files** — the skew only became visible after the tag existed, which is the one point where the failure mode is a dead release instead of a red pull request.

`scripts/pre_ship.py` already caught exactly this, but was wired to nothing. It only helped if someone remembered to run it.

## Version gate

- `collect_versions()` / `verify_versions()` — one list of every version-bearing file, shared by both gates.
- **Now covers what it never did:** the three `package.json` files and *both* roots of each `package-lock.json` (top-level `version` and `packages.""`). Not cosmetic — the npm publish jobs read these, so a stale one does not fail the gate, it tries to republish a version that is already taken. Coverage: **6 files → 16**.
- `--only versions` runs that gate alone. Stdlib-only, no installed package needed, so it runs on a bare checkout in ~10s. `--expect <tag>` pins every file to a release tag (leading `v` tolerated).
- `ci.yml` gains a **Version Consistency** job on every push and PR; `build` now depends on it.
- `release.yml`'s `Validate version` calls the same code instead of its own inline bash copy, so the two gates cannot drift apart. It can now only fail on something CI could not have known: a tag disagreeing with an internally consistent tree.

Reproducing the original failure against this gate:

```
$ python3 scripts/pre_ship.py --only versions --expect v3.3.2
::error::Version skew — a release tagged v3.3.2 would publish nothing.
::error::pyproject.toml: 3.3.1 (expected 3.3.2)
...
$ echo $?
1
```

## Doc references

`sync_refs.py` matched its skip list against a **leading path prefix**, so it only ever skipped those directories at the repo root. Nested ones sailed straight through — a scan reported **~1136 findings** inside `dashboard/node_modules/` and `.claude/worktrees/*/.venv/**/site-packages/`, i.e. other projects' READMEs. `--fix` would have rewritten files outside this repository entirely.

Now matches on path **segments**, and skips vendored trees plus the gitignored `.remember` journal (timestamped session records, not drift). Findings: 1136 → 22, none outside the repo. `Docs Freshness` now runs it.

Applied the 22 real ones: `58 tools` → `57 tools` across 15 files, and the matching `other 55` → `other 54`.

Separately, ROADMAP's `Current state` line claimed **v2.20.0 and 7,267 tests**; the tree is 3.3.1 and collects 6988. The scanner never flagged the count because comma-grouped counts are only corrected *upward* — deliberately, so it does not walk numbers backwards.

## Verification

- `scripts/pre_ship.py` — all 10 sections PASS, including the two that were failing before this branch (`Fast Unit Tests`, `Scattered Reference Sync`)
- `pytest tests/ -m "not stress" -n auto` — **6947 passed**, 4 skipped, 1 xfailed, 0 failed (18 errors are live-SurrealDB setups with no reachable instance in this shell; the `Integration (SurrealDB)` job covers them)
- `tests/unit/test_release_gates.py` — 26 new tests: the gate catches the exact 3.3.1 skew *including the test pin that agreed with the stale value*, npm manifests and both lockfile roots are in scope, dependency versions inside lockfiles (`events@3.3.0`, `lie@3.3.0`) are left alone, and the scanner stays inside the repo
- Both workflow files parsed and their job graphs asserted; the release gate replayed against the real `refs/tags/v3.3.1`

## Known, not addressed here

`sync_refs` reports `schema v0` and warns `sqlite_schema.py not found` — the file went away when the project became SurrealDB-only, so schema drift is currently unchecked rather than checked-and-passing. It is a warning, not a failure, so it does not gate anything. Left for a separate change.