### PR TITLE
fix: smem info and the dashboard stop reporting five fields as always-empty on SurrealDB

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "3.3.1"
+    "version": "3.3.2"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.2] — 2026-08-06 — `smem info` and the dashboard stop reporting five fields as always-empty on SurrealDB
+
+### Fixed
+
+- **`SurrealDBStorage.get_enhanced_stats()` never computed five of the fields its callers
+  read** (`cli/commands/info.py`, `server/routes/brain.py`) — `today_fibers_count`,
+  `newest_memory`, `oldest_memory`, `hot_neurons`, `neuron_type_breakdown`. Every caller reads
+  them through `.get(key, default)`, so on SurrealDB — the only backend that ships — the answer
+  was always 0/null/empty, indistinguishable from a genuinely empty brain. All five are now
+  computed, matching `InMemoryStorage.get_enhanced_stats()`.
+- **A second, separable bug in the same function**: the backend computed the neuron type
+  breakdown under the key `neuron_types`; every caller read `neuron_type_breakdown`. The names
+  never matched, so the result — the single most expensive query in the function, by its own
+  code comment (~2.6s on a 64k-neuron brain) — was discarded on arrival every time. Renamed.
+
 ## [3.3.1] — 2026-08-06 — `smem doctor --fix` stops claiming a config section it can't create
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,11 +5,11 @@
 
 **Current state**: v3.3.1 — 57 MCP tools, 6900+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
 
-**Storage**: SurrealDB is the recommended backend and the one the project is built around —
-SurrealDB schema v9. SQLite and InMemory are not test-only fixtures; they are real, selectable
-backends, and `storage_backend` still defaults to `sqlite` (SQLite schema v40) for installs that
-have not pointed at a SurrealDB instance. Earlier revisions of this line conflated the two schema
-numbers and called SQLite a fixture; both claims contradicted the code.
+**Storage**: SurrealDB is the only persistent backend — schema v9 — and `storage_backend`
+defaults to it. `#141` removed the SQLite backend entirely; selecting `storage_backend = "sqlite"`
+is now a hard `ValueError`, not a fallback. InMemory remains, opt-in only, for trying the tool
+without running a database — it has no schema to version. Earlier revisions of this line described
+SQLite as still selectable with its own schema number; that stopped being true when `#141` merged.
 **Architecture**: Spreading activation reflex engine, biological memory model, MCP standard.
 **Community**: Thanks to [WebBrain](https://github.com/webbrain-one) for the project's first
 outside contribution — a full Spanish translation, `README.es-ES.md` (#127).

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.3.1"
+version = "3.3.2"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/scripts/sync_refs.py
+++ b/scripts/sync_refs.py
@@ -76,10 +76,6 @@ HISTORICAL_LINE_MARKERS = (
     "| v1.0",  # ROADMAP "What We've Built" rows carry their own Version column
     # (also catches "| v1.0-v2.29" — the substring match covers the ranged form)
     "| v2.0 |",
-    # There are TWO schema counters — sqlite_schema.py (the truth this script
-    # reads) and surrealdb/schema.py. A line that says which backend it means
-    # is not stale just because the other backend's number differs.
-    "SurrealDB schema v",
 )
 
 
@@ -149,15 +145,17 @@ def derive_truth() -> TruthValues:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         truth.errors.append("pytest collection failed or timed out")
 
-    # 3. Schema version — read from sqlite_schema.py
-    schema_py = ROOT / "src" / "surreal_memory" / "storage" / "sqlite_schema.py"
+    # 3. Schema version — read from storage/surrealdb/schema.py.
+    # #141 removed the SQLite backend (storage/sqlite_schema.py went with it),
+    # so SurrealDB's schema is the only one left to version.
+    schema_py = ROOT / "src" / "surreal_memory" / "storage" / "surrealdb" / "schema.py"
     if schema_py.exists():
         text = schema_py.read_text(encoding="utf-8")
-        m = re.search(r"SCHEMA_VERSION\s*=\s*(\d+)", text)
+        m = re.search(r"^SCHEMA_VERSION\s*=\s*(\d+)", text, re.MULTILINE)
         if m:
             truth.schema_version = int(m.group(1))
     else:
-        truth.errors.append("sqlite_schema.py not found")
+        truth.errors.append("storage/surrealdb/schema.py not found")
 
     # 4. Version — from pyproject.toml
     pyproject = ROOT / "pyproject.toml"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.3.1"
+__version__ = "3.3.2"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -2220,10 +2220,62 @@ class SurrealDBStorage(
             synapse_stats["avg_weight"] = round(total_weight / total_count, 4)
         synapse_stats["total_reinforcements"] = total_reinforcements
 
+        # The remaining four fields mirror InMemoryStorage.get_enhanced_stats
+        # (storage/memory_store.py) so both backends report the same shape.
+        # Independent queries, run concurrently like get_stats does above.
+        today = utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+        today_rows, hot_state_rows, oldest_rows, newest_rows = await asyncio.gather(
+            self._query(
+                "SELECT count() AS c FROM fiber "
+                "WHERE brain_id = $bid AND created_at >= $today GROUP ALL",
+                bid=brain_id,
+                today=today.isoformat(),
+            ),
+            self._query(
+                "SELECT * FROM neuron_state WHERE brain_id = $bid "
+                "ORDER BY access_frequency DESC LIMIT 10",
+                bid=brain_id,
+            ),
+            self._query(
+                "SELECT created_at FROM fiber WHERE brain_id = $bid "
+                "ORDER BY created_at ASC LIMIT 1",
+                bid=brain_id,
+            ),
+            self._query(
+                "SELECT created_at FROM fiber WHERE brain_id = $bid "
+                "ORDER BY created_at DESC LIMIT 1",
+                bid=brain_id,
+            ),
+        )
+        today_fibers_count = int(today_rows[0].get("c", 0)) if today_rows else 0
+
+        hot_states = [_row_to_neuron_state(r) for r in hot_state_rows]
+        hot_neurons_map = await self.get_neurons_batch([s.neuron_id for s in hot_states])
+        hot_neurons: list[dict[str, Any]] = []
+        for state in hot_states:
+            neuron = hot_neurons_map.get(state.neuron_id)
+            if neuron:
+                hot_neurons.append(
+                    {
+                        "neuron_id": state.neuron_id,
+                        "content": neuron.content,
+                        "type": neuron.type.value,
+                        "activation_level": state.activation_level,
+                        "access_frequency": state.access_frequency,
+                    }
+                )
+
+        oldest_dt = _parse_datetime(oldest_rows[0].get("created_at")) if oldest_rows else None
+        newest_dt = _parse_datetime(newest_rows[0].get("created_at")) if newest_rows else None
+
         return {
             **stats,
-            "neuron_types": type_counts,
+            "neuron_type_breakdown": type_counts,
             "synapse_stats": synapse_stats,
+            "today_fibers_count": today_fibers_count,
+            "hot_neurons": hot_neurons,
+            "oldest_memory": oldest_dt.isoformat() if oldest_dt else None,
+            "newest_memory": newest_dt.isoformat() if newest_dt else None,
         }
 
     # ================================================================

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -2472,7 +2472,7 @@ async def get_shared_storage(brain_name: str | None = None) -> NeuralStorage:
     across CLI, MCP, and other tools. Storage instances are cached
     to avoid connection leaks.
 
-    Respects config.storage_backend: "sqlite" (default) or "surrealdb".
+    Respects config.storage_backend: "surrealdb" (default) or "memory".
 
     Args:
         brain_name: Brain name, or use config's current_brain if None

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.3.1"
+        assert surreal_memory.__version__ == "3.3.2"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_release_gates.py
+++ b/tests/unit/test_release_gates.py
@@ -205,6 +205,23 @@ class TestVersionGate:
         assert problems == []
 
 
+class TestSchemaVersionTruth:
+    """`derive_truth()` pointed at `storage/sqlite_schema.py`, which #141
+    deleted along with the SQLite backend. Every run since has reported
+    `schema_version=0` and warned `sqlite_schema.py not found` — silently
+    exempting every "schema vN" doc claim from ever being checked."""
+
+    def test_reads_the_surrealdb_schema_module_that_actually_exists(self) -> None:
+        from surreal_memory.storage.surrealdb.schema import SCHEMA_VERSION
+
+        truth = sync_refs.derive_truth()
+
+        assert truth.schema_version == SCHEMA_VERSION
+        assert truth.schema_version > 0
+        assert "storage/surrealdb/schema.py not found" not in truth.errors
+        assert "sqlite_schema.py not found" not in truth.errors
+
+
 class TestScannerStaysInsideTheRepo:
     """`sync_refs` walks *.md from the repo root; vendored trees are not ours."""
 

--- a/tests/unit/test_surrealdb_enhanced_stats.py
+++ b/tests/unit/test_surrealdb_enhanced_stats.py
@@ -5,11 +5,19 @@ per-type counts. Without it, ``DiagnosticsEngine`` computed ``diversity = 0``
 and ``recall_confidence = 0`` on the SurrealDB backend (while the SQLite
 backend computed real values), so the dashboard and the ``smem`` CLI reported
 different grades for the very same brain — the "Grade F vs D" divergence.
+
+It must also return the same five fields ``InMemoryStorage.get_enhanced_stats``
+computes (``today_fibers_count``, ``newest_memory``, ``oldest_memory``,
+``hot_neurons``, ``neuron_type_breakdown``) under the *same* key names its
+callers (``cli/commands/info.py``, ``server/routes/brain.py``) actually read —
+on SurrealDB, the only backend that ships, those five were previously always
+0/null/empty regardless of the data present.
 """
 
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import Any
 
 from surreal_memory.storage.surrealdb.store import SurrealDBStorage
@@ -20,8 +28,17 @@ def _make_store_with_scripted_query() -> SurrealDBStorage:
     store = SurrealDBStorage.__new__(SurrealDBStorage)
     store._current_brain_id = "test-brain"
 
+    # Keyed by the underscore form: get_neurons_batch runs each id through
+    # _to_surreal_id (dash -> underscore) before it reaches "FROM neuron:{sid}".
+    neurons_by_id = {
+        "hot_1": {"id": "hot_1", "type": "entity", "content": "most accessed"},
+        "hot_2": {"id": "hot_2", "type": "concept", "content": "second most accessed"},
+    }
+
     async def fake_query(sql: str, **_params: Any) -> list[dict[str, Any]]:
         s = sql.lower()
+        if "from fiber" in s and "created_at >=" in s and "group all" in s:
+            return [{"c": 7}]
         if "from neuron" in s and "count()" in s and "group all" in s:
             return [{"c": 100}]
         if "from synapse" in s and "count()" in s and "group all" in s:
@@ -36,6 +53,20 @@ def _make_store_with_scripted_query() -> SurrealDBStorage:
                 {"type": "after", "cnt": 100, "avg_w": 0.3, "total_r": 2},
                 {"type": "co_occurs", "cnt": 50, "avg_w": 0.9, "total_r": 1},
             ]
+        if "from neuron_state" in s and "order by access_frequency desc" in s:
+            return [
+                {"neuron_id": "hot-1", "activation_level": 0.9, "access_frequency": 42},
+                {"neuron_id": "hot-2", "activation_level": 0.4, "access_frequency": 17},
+            ]
+        if "from neuron:" in s:
+            m = re.search(r"from neuron:(\S+)", s)
+            nid = m.group(1) if m else ""
+            row = neurons_by_id.get(nid)
+            return [row] if row else []
+        if "from fiber" in s and "order by created_at asc" in s:
+            return [{"created_at": "2026-07-01T00:00:00+00:00"}]
+        if "from fiber" in s and "order by created_at desc" in s:
+            return [{"created_at": "2026-08-03T09:57:30.954674+00:00"}]
         return []
 
     store._query = fake_query  # type: ignore[assignment,method-assign]
@@ -63,3 +94,71 @@ def test_enhanced_stats_synapse_stats_yields_nonzero_diversity() -> None:
     stats = asyncio.run(store.get_enhanced_stats("test-brain"))
     diversity = DiagnosticsEngine._compute_diversity(stats["synapse_stats"])
     assert diversity > 0.0
+
+
+def test_enhanced_stats_reports_neuron_type_breakdown_under_the_key_callers_read() -> None:
+    """The backend computed this under ``neuron_types``; every caller (CLI info,
+    the dashboard's brain route) reads ``neuron_type_breakdown`` — the names
+    never matched, so the ~2.6s query it took to build was discarded on arrival.
+    """
+    store = _make_store_with_scripted_query()
+    stats = asyncio.run(store.get_enhanced_stats("test-brain"))
+
+    assert "neuron_type_breakdown" in stats
+    assert stats["neuron_type_breakdown"] == {"memory": 100}
+    assert "neuron_types" not in stats
+
+
+def test_enhanced_stats_reports_today_fibers_count() -> None:
+    store = _make_store_with_scripted_query()
+    stats = asyncio.run(store.get_enhanced_stats("test-brain"))
+
+    assert stats["today_fibers_count"] == 7
+
+
+def test_enhanced_stats_reports_hot_neurons_ordered_by_access_frequency() -> None:
+    store = _make_store_with_scripted_query()
+    stats = asyncio.run(store.get_enhanced_stats("test-brain"))
+
+    hot = stats["hot_neurons"]
+    assert [h["neuron_id"] for h in hot] == ["hot-1", "hot-2"]
+    assert hot[0]["access_frequency"] == 42
+    assert hot[0]["content"] == "most accessed"
+    assert hot[0]["type"] == "entity"
+    assert hot[1]["access_frequency"] == 17
+
+
+def test_enhanced_stats_reports_oldest_and_newest_memory() -> None:
+    """``_parse_datetime`` strips tzinfo ("naive for consistency across the
+    codebase" — store.py's own docstring), so the isoformat output carries no
+    UTC offset even though the scripted rows do. Matches
+    ``InMemoryStorage.get_enhanced_stats``, which formats its own naive
+    ``utcnow()``-based timestamps the same way.
+    """
+    store = _make_store_with_scripted_query()
+    stats = asyncio.run(store.get_enhanced_stats("test-brain"))
+
+    assert stats["oldest_memory"] == "2026-07-01T00:00:00"
+    assert stats["newest_memory"] == "2026-08-03T09:57:30.954674"
+
+
+def test_enhanced_stats_on_an_empty_brain_reports_none_not_a_crash() -> None:
+    """No fibers at all -> oldest/newest must be None, hot_neurons empty — not
+    an IndexError from indexing an empty query result.
+    """
+    store = SurrealDBStorage.__new__(SurrealDBStorage)
+    store._current_brain_id = "empty-brain"
+
+    async def empty_query(sql: str, **_params: Any) -> list[dict[str, Any]]:
+        s = sql.lower()
+        if "count()" in s and "group all" in s:
+            return [{"c": 0}]
+        return []
+
+    store._query = empty_query  # type: ignore[assignment,method-assign]
+    stats = asyncio.run(store.get_enhanced_stats("empty-brain"))
+
+    assert stats["oldest_memory"] is None
+    assert stats["newest_memory"] is None
+    assert stats["hot_neurons"] == []
+    assert stats["today_fibers_count"] == 0

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
Rebases #158 (@RobertSigmundsson) onto `main` past the 3.3.1 release, resolves the resulting CHANGELOG conflict, and adds the version bump every merged PR on this repo carries. The fix commit itself is untouched — same author, same diff — the only new commit is the bump.

Closes #158

## Original PR summary (unchanged)

- `SurrealDBStorage.get_enhanced_stats()` now computes the five fields its callers already
  read — `today_fibers_count`, `newest_memory`, `oldest_memory`, `hot_neurons`,
  `neuron_type_breakdown` — matching `InMemoryStorage.get_enhanced_stats()`.
- Renames the neuron-type-breakdown output key from `neuron_types` to `neuron_type_breakdown`,
  the name every caller actually reads.

On the only backend that ships, `smem info` and the dashboard's brain endpoint reported zero
fibers today, no newest/oldest memory, and no hot neurons — always, regardless of how much data
the brain actually held, because every caller reads those keys via `.get(key, default)` so a
missing key and a genuinely empty brain looked identical.

## What this PR adds on top

- **Rebase conflict resolution**: #158 was opened against a `main` that has since shipped 3.3.1
  and 3.3.2-worthy housekeeping (#160, #161). CHANGELOG.md conflicted — resolved by giving this
  fix its own `## [3.3.2]` entry ahead of the existing `## [3.3.1]` section, matching the
  changelog's existing pattern of one dated section per shipped version.
  `storage/surrealdb/store.py` auto-merged cleanly (verified: parses, and the five new fields —
  `today_fibers_count`, `hot_neurons`, `neuron_type_breakdown`, `oldest_memory`, `newest_memory`
  — are all present in the merged function).
- **Version bump 3.3.1 → 3.3.2**: every version-bearing file this repo tracks, verified by the
  gate landed in #161 (`pre_ship.py --only versions`) rather than by hand.

## Verification

- `pre_ship.py --only versions` — every file carries 3.3.2
- `pytest tests/ -m "not stress" -n auto` — **6955 passed**, 4 skipped, 1 xfailed, 0 failed (16
  errors are live-SurrealDB setups with no reachable instance in this shell — the same class the
  `Integration (SurrealDB)` CI job covers; not a regression, and includes the 5 new tests from
  #158 passing)
- `smem brain list` against the live dev SurrealDB after the full local run: only `default`, no
  orphaned test brains