### PR TITLE
fix: remaining follow-ups from #150-#154 — aiosqlite dependency, doc-count sync

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Forward-looking vision. What's next, what's possible, where we're going.
 > ZERO LLM dependency — pure algorithmic, regex, graph-based.
 
-**Current state**: v3.3.1 — 57 MCP tools, 6900+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
+**Current state**: v3.3.1 — 57 MCP tools, 7000+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
 
 **Storage**: SurrealDB is the only persistent backend — schema v9 — and `storage_backend`
 defaults to it. `#141` removed the SQLite backend entirely; selecting `storage_backend = "sqlite"`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,18 @@ dependencies = [
 
     "typer>=0.9.0,<0.26",
     "aiohttp>=3.9.0",
-    "aiosqlite>=0.19.0",
     "rich>=13.0.0",
     "typing_extensions>=4.0",
 ]
 
 [project.optional-dependencies]
+# Only surreal_memory/engine/db_introspector.py imports this, lazily, for
+# `smem_train_db`'s SQLite dialect — reading an external .db file to mine
+# training signal from it. Not the project's own storage backend (SurrealDB
+# is), so it does not belong in the unconditional install.
+sqlite-import = [
+    "aiosqlite>=0.19.0",
+]
 server = [
     "fastapi>=0.100",
     "uvicorn[standard]>=0.23",
@@ -112,7 +118,7 @@ integration = [
     "surreal-memory[chromadb,mem0]",
 ]
 all = [
-    "surreal-memory[server,surrealdb,embeddings-gemini,nlp,integration,langchain]",
+    "surreal-memory[server,surrealdb,sqlite-import,embeddings-gemini,nlp,integration,langchain]",
 ]
 dev = [
     "pytest>=7.0",
@@ -125,6 +131,10 @@ dev = [
     "pytest-timeout>=2.2",
     "httpx>=0.24",
     "click>=8.0",
+    # The db_introspector and doctor test suites, plus conftest's autouse
+    # leak-guard fixture, import this unconditionally — not gated behind a
+    # skip. A dev install without it fails collection, not just those tests.
+    "aiosqlite>=0.19.0",
 ]
 docs = [
     "mkdocs>=1.5",

--- a/src/surreal_memory/cli/doctor.py
+++ b/src/surreal_memory/cli/doctor.py
@@ -421,7 +421,7 @@ def _check_brain() -> dict[str, Any]:
 
 def _check_dependencies() -> dict[str, Any]:
     """Check core dependencies are importable."""
-    required = ["aiosqlite", "typer"]
+    required = ["typer"]
     missing = []
 
     for dep in required:

--- a/tests/unit/test_dx_wizard.py
+++ b/tests/unit/test_dx_wizard.py
@@ -33,6 +33,24 @@ class TestDoctor:
             assert result["status"] == "fail"
             assert "Missing" in result["detail"]
 
+    def test_check_dependencies_does_not_require_aiosqlite(self) -> None:
+        """`aiosqlite` moved to the optional `sqlite-import` extra (#154.6) —
+        it powers `smem_train_db`'s SQLite dialect, not the SurrealDB backend
+        every install actually runs on. A bare install must not FAIL doctor
+        over a package it does not need."""
+        from surreal_memory.cli.doctor import _check_dependencies
+
+        def fail_only_aiosqlite(name: str) -> None:
+            if name == "aiosqlite":
+                raise ImportError(name)
+
+        with patch(
+            "surreal_memory.cli.doctor.importlib.import_module", side_effect=fail_only_aiosqlite
+        ):
+            result = _check_dependencies()
+
+        assert result["status"] == "ok"
+
     def test_check_embedding_disabled(self) -> None:
         from surreal_memory.cli.doctor import _check_embedding_provider
 

--- a/tests/unit/test_release_gates.py
+++ b/tests/unit/test_release_gates.py
@@ -222,6 +222,39 @@ class TestSchemaVersionTruth:
         assert "sqlite_schema.py not found" not in truth.errors
 
 
+class TestAiosqliteIsOptional:
+    """#154.6: `aiosqlite` only powers `smem_train_db`'s SQLite dialect
+    (`engine/db_introspector.py`, a lazy, try/except-guarded import) — not the
+    SurrealDB backend every install actually runs on. It does not belong in
+    the unconditional install."""
+
+    def test_not_in_core_dependencies(self) -> None:
+        import tomllib
+
+        data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+
+        assert not any("aiosqlite" in dep for dep in data["project"]["dependencies"])
+
+    def test_available_as_its_own_extra(self) -> None:
+        import tomllib
+
+        data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+        extras = data["project"]["optional-dependencies"]
+
+        assert any("aiosqlite" in dep for dep in extras.get("sqlite-import", []))
+
+    def test_dev_extra_still_carries_it(self) -> None:
+        """conftest's autouse leak-guard fixture imports it unconditionally —
+        a dev install without it fails test collection, not just the tests
+        that exercise it."""
+        import tomllib
+
+        data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+        extras = data["project"]["optional-dependencies"]
+
+        assert any("aiosqlite" in dep for dep in extras["dev"])
+
+
 class TestScannerStaysInsideTheRepo:
     """`sync_refs` walks *.md from the repo root; vendored trees are not ours."""
 


### PR DESCRIPTION
## Status of #64, #150–#154 (verified against code, not assumed from the earlier commit title)

`20dbe5f6` ("fix: address 6 open issues (#64, #150-#154) and bump to v3.3.0", #157) fixed the substance of all six but never closed the GitHub issues — they still show OPEN. Verified each independently against current `main` before writing anything:

| Issue | Verified fixed in code? |
|---|---|
| #64 (stop-word acronym collision) | ✅ — `keywords.py:648-653`: ALL-CAPS tokens survive the stop-word filter, gated by `w.isupper()` and length ≥ 2, exactly the rule the issue's own follow-up comment asked for |
| #150 (`check_dead_modules` silent on a removed import) | ✅ — `check_dead_modules.py` now tracks `broken: dict[str, list[str]]`, a missing-module → importer map, separate from the reachability list |
| #151 (`smem_drift` always "clean"; session summaries silently dropped) | ✅ — the whole broken call path is gone: `smem_drift` MCP tool removed (CHANGELOG 3.3.0, "BREAKING"), and `save_session_summary`/`record_tag_cooccurrence`/`get_tag_cooccurrence`/`get_tag_fiber_counts` have zero references left in `src/` |
| #152 (GET handlers mutating the active brain) | ✅ — `hub.py`'s two `@router.get` handlers (`hub_status`, `list_devices`) call neither `set_brain`; only the three `@router.post` handlers do |
| #153 (no CI job against real SurrealDB) | ✅ — `ci.yml` has `integration: name: Integration (SurrealDB)` with `SURREALDB_URL` wired up |
| #154.1–2 (`get_tool_stats` no `days` param, SurrealDB-only interface method) | ✅ — `days: int = 30` on both storage backends and the `NeuralStorage` base |
| #154.3 (`_query` unwrap heuristic) | ✅ — new `_query_values()` gives `SELECT VALUE` call sites an honestly-typed entry point; the one previously-unsafe top-level call site (`get_connected_neuron_ids`) now uses it |
| #154.4 (migration guide silent on `schema_version` 40→9) | ✅ — `docs/guides/migrating-to-3.0.md:145-151` has the sentence, plus "watch `version`, not `schema_version`" |
| #154.5 (brain-files panel shows a path that doesn't exist) | ✅ — `BrainFileInfo.path` is `str \| None`; the route sets it to `None` when `db_path.exists()` is false |
| #154.6 (`aiosqlite` hard dependency; misnamed helper) | Half-done → **completed by this PR** (see below). Rename (`ensure_aiosqlite_or_exit_cli` → `ensure_sqlite_or_exit_cli`, checks `sqlite3`) was already in |
| #154.7 (`AGENTS.md` self-contradiction) | **Deliberately not touched** — see below |

## What this PR actually adds

**#154.6, the remaining half — `aiosqlite` out of the unconditional install.** Verified before moving anything: the only production import is `engine/db_introspector.py`'s lazy, `try/except ImportError`-guarded one, for `smem_train_db`'s SQLite dialect (reading an external `.db` file to mine training signal — not this project's own storage, which is SurrealDB). Every other file that mentions `aiosqlite` does so only in a comment or docstring.

- `pyproject.toml`: removed from `dependencies`; added as its own `sqlite-import` extra; added to `dev` (`conftest.py`'s autouse leak-guard fixture and several test files import it unconditionally, not behind a skip — a dev install without it fails test *collection*, not just those tests); added to `all`.
- `doctor.py::_check_dependencies`: dropped `aiosqlite` from the hard-required list, so a bare install no longer FAILs the doctor check over a package it doesn't need.
- Two new tests (`TestAiosqliteIsOptional` in `test_release_gates.py`, plus a doctor-specific regression in `test_dx_wizard.py`) pin both halves so this can't quietly regress.

**Doc-count sync** — `sync_refs.py --fix` after all the above, so the test-count reference in ROADMAP matches what the suite now collects.

## #154.7 — deliberately not touched

`AGENTS.md` protects itself: *"Modify `NOTICE`, `AGENTS.md`, `CONTRIBUTING.md`, `SECURITY.md` without first opening a discussion issue and getting a maintainer's explicit OK."* The original issue's own author raised this rather than patching it, for the same reason. I'm doing the same — flagging it here rather than editing it. The contradiction, if you want it fixed: `Hard Rule #2` (the newer of the two, per its own text) forbids AI-attribution footers in commits/PRs; the PR template two sections later still asks for `## Verified by\n\n@handle — built with <agent name + version>.`, which is exactly what the hard rule forbids.

## Also fixed this session, landed separately

The sync_refs "schema v0" / `sqlite_schema.py not found` issue you asked me to look at first ended up bundled into #162's squash-merge rather than its own PR — I had it as a local commit on `main` when I rebased #158 on top, and didn't catch the scope mixing before pushing. Full detail survived in the squash commit body (`git show 1107ad5e`), and everything was tested together, but it's not the clean separation I'd normally keep. Flagging it rather than leaving it silent. Summary of what landed: `scripts/sync_refs.py` was reading `SCHEMA_VERSION` from `storage/sqlite_schema.py`, which `#141` deleted along with the SQLite backend — every run reported `schema_version=0`. Fixed to read `storage/surrealdb/schema.py` instead; also corrected two stale docs that assumed SQLite was still a selectable backend (`ROADMAP.md`'s Storage paragraph, `unified_config.py::get_shared_storage`'s docstring) — `storage_backend` defaults to `surrealdb` and selecting `"sqlite"` is now a hard `ValueError`.

#158 (@RobertSigmundsson's `get_enhanced_stats` fix) is also merged as of this session (#162), rebased past 3.3.1 with its own `## [3.3.2]` CHANGELOG entry and version bump.

## Verification

- `pre_ship.py --only versions` — all 16 files carry 3.3.2 (no bump needed here — same version #162 already shipped)
- `pre_ship.py` full run — 10/10 sections PASS (the one `mypy` FAIL is a pre-existing, unrelated environment gap — `google.genai` stub resolution differs between `uv run --extra dev` and CI's `pip install -e ".[dev]"`; reproduces identically on `main` with none of this branch's changes)
- `pytest tests/ -m "not stress" -n auto` — **6959 passed**, 4 skipped, 1 xfailed, 0 failed (16 errors are live-SurrealDB setups with no reachable instance in this shell, covered by the `Integration (SurrealDB)` CI job)
- `smem brain list` / direct SurrealDB query after the full local run: only `default`, zero orphaned test brains

## Merge

Not merging this one myself — happy to if you'd rather I did, but wanted you to see the AGENTS.md item and the #162 scope-mixing note before it lands.