### PR TITLE
feat: connectivity honesty — score on the organic subgraph (3.5.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "3.4.0"
+    "version": "3.5.0"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] — 2026-08-13 — connectivity honesty: code-index excluded from the metric
+
+### Changed — connectivity is now scored on the organic subgraph
+
+- **Code-index neurons and edges no longer inflate connectivity.** `structural_neuron_count`
+  (code-index neurons, `metadata.indexed = true`) is now a live indexed aggregate, and
+  `connectivity` divides the organic synapse count by the organic neuron count. The
+  numerator counts a synapse only when **both** endpoints are organic (the code-index
+  synapse types `contains` / `co_occurs` / `is_a` / `related_to` are shared with the
+  organic encoder, so they are filtered by endpoint, not by type). `activation_efficiency`,
+  `consolidation_ratio` and `freshness` likewise exclude structural/code-index volume.
+  `orphan_rate`, `diversity` and `recall_confidence` are unchanged.
+
+> **The pre-change purity score is NOT comparable to the post-change one — and unlike the
+> 2.15.0 alias fix, it moves the OTHER way.** 2.15.0 dropped alias edges and *lowered*
+> purity (the brain had less connectivity than advertised). 3.5.0 drops code-index edges
+> and *raises* purity on code-heavy brains: the organic memory graph was healthier than the
+> code-index-inflated denominator suggested. A brain that reported a thin-graph grade purely
+> because half its neurons were code-index leaves will jump. Do not read this as new
+> connectivity — it is the same graph, measured honestly.
+
+### Changed — codebase indexer
+
+- **Co-occurrence edges are now capped by an edge budget, not a symbol count.** Files with
+  more than 5 symbols previously got **zero** co-occurrence edges (the `<= 5` guard skipped
+  the whole block); now every file gets up to 20, choosing the closest symbol pairs by line
+  proximity.
+- **Import edges now connect.** The relationship target for `from M import N` and
+  `import X as Y` was the dotted module path / original name, which never matched the
+  encoder's symbol-id key — so import synapses were silently dropped. The target is now the
+  imported symbol name.
+
+### Added
+
+- `structural_neuron_count` and `connectivity_neuron_count` surfaced on the health report
+  and the dashboard payload, so a purity move the raw counts can't explain is attributable.
+- `_is_structural_neuron(metadata)` helper on `DiagnosticsEngine` — the single extension
+  point for future structural-neuron classes.
+
 ## [3.4.0] — 2026-08-13 — dedup honesty, native drift detection, and a 3D graph
 
 ### Added

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.4.0"
+version = "3.5.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/codebase_encoder.py
+++ b/src/surreal_memory/engine/codebase_encoder.py
@@ -53,6 +53,15 @@ _RELATION_TO_SYNAPSE: dict[str, tuple[SynapseType, float]] = {
     "co_occurs": (SynapseType.CO_OCCURS, 0.5),
 }
 
+# run 013 (K5): cap the NUMBER of co-occurrence EDGES per file, not the number
+# of symbols. The previous `max_co_occurs = 5` check skipped co-occurrence
+# entirely for any file with more than 5 symbols — i.e. almost every real file
+# — so large files contributed zero intra-file structure to the graph. This
+# budget keeps the O(n²) worst case bounded while always emitting SOME edges:
+# pairs are ordered by line proximity (symbols defined near each other co-occur
+# more meaningfully) and the closest pairs win the budget.
+_MAX_CO_OCCUR_EDGES = 20
+
 _DEFAULT_EXTENSIONS: frozenset[str] = frozenset(
     {
         ".py",
@@ -190,19 +199,29 @@ class CodebaseEncoder:
             )
             synapses_created.append(synapse)
 
-        # 4. Create co-occurrence synapses (capped to avoid O(n²) explosion)
+        # 4. Create co-occurrence synapses, capped by an EDGE budget (run 013 K5).
+        #    Previously a file with >5 symbols got ZERO co-occurrence edges; now
+        #    every file gets up to _MAX_CO_OCCUR_EDGES, choosing the closest pairs
+        #    by line number (nearby symbols co-occur more meaningfully than ones
+        #    hundreds of lines apart).
         symbol_neurons = neurons_created[1:]  # Skip file neuron
-        max_co_occurs = 5  # Max files: create all pairs; large files: skip
-        if len(symbol_neurons) <= max_co_occurs:
+        if symbol_neurons:
+            pairs = []
             for i, neuron_a in enumerate(symbol_neurons):
+                line_a = int(neuron_a.metadata.get("line_start", 0))
                 for neuron_b in symbol_neurons[i + 1 :]:
-                    synapse = Synapse.create(
-                        source_id=neuron_a.id,
-                        target_id=neuron_b.id,
-                        type=SynapseType.CO_OCCURS,
-                        weight=0.5,
-                    )
-                    synapses_created.append(synapse)
+                    line_b = int(neuron_b.metadata.get("line_start", 0))
+                    pairs.append((abs(line_a - line_b), neuron_a, neuron_b))
+            # Closest pairs first; ties broken by neuron id for determinism.
+            pairs.sort(key=lambda p: (p[0], p[1].id, p[2].id))
+            for _dist, neuron_a, neuron_b in pairs[:_MAX_CO_OCCUR_EDGES]:
+                synapse = Synapse.create(
+                    source_id=neuron_a.id,
+                    target_id=neuron_b.id,
+                    type=SynapseType.CO_OCCURS,
+                    weight=0.5,
+                )
+                synapses_created.append(synapse)
 
         # 5. Bundle into fiber
         neuron_ids = {n.id for n in neurons_created}

--- a/src/surreal_memory/engine/diagnostics.py
+++ b/src/surreal_memory/engine/diagnostics.py
@@ -293,6 +293,13 @@ class BrainHealthReport:
     # raw table total. Kept separate so a dashboard can show both without guessing.
     semantic_synapse_count: int = 0
 
+    # Structural (code-index) neuron count and the organic remainder used as the
+    # connectivity denominator (run 013). A dashboard needs both to explain why
+    # `connectivity` moved independently of `synapse_count`: the denominator
+    # changed, not the graph.
+    structural_neuron_count: int = 0
+    connectivity_neuron_count: int = 0
+
     # Maturation visibility (run 010 / D2): consolidation_ratio alone cannot
     # explain itself -- these two answer "what does the stage breakdown look
     # like" and "of the fibers not yet semantic, which gate is blocking them".
@@ -336,6 +343,10 @@ def build_health_payload(report: BrainHealthReport, *, brain: str) -> dict[str, 
         "neuron_count": report.neuron_count,
         "synapse_count": report.synapse_count,
         "fiber_count": report.fiber_count,
+        # run 013: connectivity is scored on the organic subgraph. Exposing both
+        # counts lets a dashboard explain a purity move that the raw counts can't.
+        "structural_neuron_count": report.structural_neuron_count,
+        "connectivity_neuron_count": report.connectivity_neuron_count,
         "contradiction_count": report.contradiction_count,
         "conflict_rate": report.conflict_rate,
         "warnings": [
@@ -413,6 +424,15 @@ class DiagnosticsEngine:
     # in_row / in_column stay for the same reason — table structure links content to
     # content. The test is "does traversing this edge return meaning?", not "did a
     # human type it?".
+    #
+    # NOTE (run 013): the code-index synapse TYPES (contains / co_occurs / is_a /
+    # related_to) are NOT added here. They are shared with the organic encoder —
+    # consolidation, dream, enrichment, db_knowledge and others all emit them
+    # between organic neurons — so excluding by type would drop real semantic
+    # edges. The code-index edges are filtered instead by ENDPOINT: a synapse is
+    # structural when either endpoint is an indexed neuron. See
+    # _count_organic_synapses / connectivity_neuron_count (K2/K3) and
+    # DECISIONS.md variant (c).
     _STRUCTURAL_SYNAPSE_TYPES: frozenset[str] = frozenset(
         {
             SynapseType.ALIAS.value,
@@ -422,6 +442,22 @@ class DiagnosticsEngine:
             SynapseType.SOURCE_OF.value,
         }
     )
+
+    @staticmethod
+    def _is_structural_neuron(metadata: dict[str, Any] | None) -> bool:
+        """Central predicate: is this neuron structural (code-index plumbing)?
+
+        The single place to extend when a new class of non-memory neuron lands.
+        Today the only structural neurons are code-index leaves emitted by
+        ``CodebaseIndexer`` (``metadata["indexed"] = True``). Connectivity and
+        activation score against the organic remainder
+        (``connectivity_neuron_count = neuron_count - structural_neuron_count``);
+        the synapse-side filter is endpoint-based (variant c, DECISIONS.md):
+        a synapse counts only when BOTH endpoints are organic.
+        """
+        if not metadata:
+            return False
+        return bool(metadata.get("indexed"))
 
     def __init__(self, storage: NeuralStorage) -> None:
         self._storage = storage
@@ -456,6 +492,14 @@ class DiagnosticsEngine:
         neuron_count: int = enhanced.get("neuron_count", 0)
         synapse_count: int = enhanced.get("synapse_count", 0)
         fiber_count: int = enhanced.get("fiber_count", 0)
+        # Structural (code-index) neuron count — maintained as a live indexed
+        # aggregate by the storage backend (see get_stats). Used to score
+        # connectivity on the organic subgraph: a code-index neuron is a leaf
+        # in a per-file tree, never the endpoint of a memory the user cares
+        # about, so including it in the denominator deflates connectivity.
+        # See DECISIONS.md (run 013, K1) — variant (c): both endpoints organic.
+        structural_neuron_count: int = enhanced.get("structural_neuron_count", 0)
+        connectivity_neuron_count = max(0, neuron_count - structural_neuron_count)
 
         # Early return for empty brain
         if neuron_count == 0 or fiber_count == 0:
@@ -494,25 +538,47 @@ class DiagnosticsEngine:
 
         (
             fibers,
-            consolidation_ratio,
             activation_efficiency,
             connected,
             stage_distribution,
             semantic_gate_blockers,
         ) = await asyncio.gather(
             self._storage.get_fibers(limit=10000),
-            self._compute_consolidation_ratio(fiber_count),
-            self._compute_activation_efficiency(neuron_count),
+            # run 013: activation efficiency is scored against the ORGANIC brain
+            # — indexed neurons are never recalled (access_frequency stays 0), so
+            # including them deflates the ratio on code-heavy brains.
+            self._compute_activation_efficiency(connectivity_neuron_count),
             _connected_or_none(),
             _stage_distribution_or_none(),
             _semantic_gate_blockers_or_none(),
         )
 
+        # run 013: consolidation ratio over the ORGANIC fiber count. Computed
+        # after the gather because it depends on `fibers` (the code_index tag
+        # filter), which the gather just returned. Code-index fibers never
+        # mature, so including them deflated the ratio on code-heavy brains.
+        organic_fiber_count = sum(1 for f in fibers if "code_index" not in (f.tags or set()))
+        consolidation_ratio = await self._compute_consolidation_ratio(
+            fiber_count, organic_fiber_count
+        )
+
         # Score connectivity on the semantic graph only — see _STRUCTURAL_SYNAPSE_TYPES.
         semantic_synapse_count = self._count_semantic_synapses(synapse_count, synapse_stats)
-        connectivity = self._compute_connectivity(semantic_synapse_count, neuron_count)
+        # K2/K3 (run 013): connectivity is scored on the ORGANIC subgraph.
+        # Denominator = organic neuron count (K2). Numerator = organic synapse
+        # count: both endpoints non-indexed AND type not structural (variant c,
+        # DECISIONS.md). The endpoint filter is what makes this honest — the
+        # code-index synapse types (contains/co_occurs/is_a/related_to) are
+        # shared with the organic encoder, so a type-only filter would drop real
+        # semantic edges. Falls back to the type-filtered count when the backend
+        # cannot answer the endpoint join (older backends / mocks).
+        organic_synapse_count = int(synapse_stats.get("organic_synapse_count", -1))
+        if organic_synapse_count < 0:
+            organic_synapse_count = semantic_synapse_count
+        connectivity = self._compute_connectivity(organic_synapse_count, connectivity_neuron_count)
         diversity = self._compute_diversity(synapse_stats)
-        freshness = self._compute_freshness(fibers)
+        # run 013: freshness on the organic fiber set only.
+        freshness = self._compute_freshness(fibers, organic_only=True)
         orphan_rate = await self._compute_orphan_rate(neuron_count, fibers, connected=connected)
         recall_confidence = self._compute_recall_confidence(synapse_stats)
 
@@ -547,7 +613,9 @@ class DiagnosticsEngine:
 
         # Generate warnings and recommendations. The ratio quoted to the user must be
         # the one the score was computed from, otherwise the text and the bar disagree.
-        raw_connectivity = semantic_synapse_count / max(neuron_count, 1)
+        # Use the organic numerator AND denominator so the quoted ratio matches the
+        # 0-1 score, which is also computed on the organic subgraph (run 013).
+        raw_connectivity = organic_synapse_count / max(connectivity_neuron_count, 1)
         warnings, recommendations = self._generate_diagnostics(
             neuron_count=neuron_count,
             synapse_count=synapse_count,
@@ -576,6 +644,8 @@ class DiagnosticsEngine:
         by_type = synapse_stats.get("by_type", {})
         penalty_metrics = {
             "neuron_count": neuron_count,
+            "structural_neuron_count": structural_neuron_count,
+            "connectivity_neuron_count": connectivity_neuron_count,
             "synapse_count": synapse_count,
             "semantic_synapse_count": semantic_synapse_count,
             "fiber_count": fiber_count,
@@ -607,6 +677,8 @@ class DiagnosticsEngine:
             contradiction_count=contradicts_count,
             conflict_rate=round(conflict_rate, 4),
             semantic_synapse_count=semantic_synapse_count,
+            structural_neuron_count=structural_neuron_count,
+            connectivity_neuron_count=connectivity_neuron_count,
             stage_distribution=stage_distribution,
             semantic_gate_blockers=semantic_gate_blockers,
         )
@@ -681,8 +753,16 @@ class DiagnosticsEngine:
         return min(1.0, entropy / max_entropy)
 
     @staticmethod
-    def _compute_freshness(fibers: list[Any]) -> float:
-        """Compute fraction of fibers accessed/created in last 7 days."""
+    def _compute_freshness(fibers: list[Any], organic_only: bool = False) -> float:
+        """Compute fraction of fibers accessed/created in last 7 days.
+
+        run 013: when ``organic_only`` is set, code-index fibers are excluded —
+        a bulk re-index touches every source file and stamps them all recent,
+        which otherwise reports a brain with 20k indexed fibers as maximally
+        fresh even when no real memory was stored in a week.
+        """
+        if organic_only:
+            fibers = [f for f in fibers if "code_index" not in (f.tags or set())]
         if not fibers:
             return 0.0
 
@@ -691,14 +771,23 @@ class DiagnosticsEngine:
         fresh_count = sum(1 for f in fibers if (f.last_conducted or f.created_at) >= cutoff)
         return fresh_count / len(fibers)
 
-    async def _compute_consolidation_ratio(self, fiber_count: int) -> float:
-        """Compute fraction of fibers that reached SEMANTIC stage."""
-        if fiber_count == 0:
+    async def _compute_consolidation_ratio(
+        self, fiber_count: int, organic_fiber_count: int | None = None
+    ) -> float:
+        """Compute fraction of fibers that reached SEMANTIC stage.
+
+        run 013: scores against the ORGANIC fiber count when available —
+        code-index fibers never mature past their initial stage, so including
+        them in the denominator deflates the ratio on code-heavy brains.
+        Falls back to the total when the organic count is unknown.
+        """
+        denom = organic_fiber_count if organic_fiber_count is not None else fiber_count
+        if denom == 0:
             return 0.0
         semantic_records = await self._storage.find_maturations(
             stage=MemoryStage.SEMANTIC,
         )
-        return len(semantic_records) / fiber_count
+        return len(semantic_records) / denom
 
     async def _compute_orphan_rate(
         self,

--- a/src/surreal_memory/extraction/codebase.py
+++ b/src/surreal_memory/extraction/codebase.py
@@ -214,7 +214,16 @@ class PythonExtractor:
     def _extract_import(
         self, node: ast.Import | ast.ImportFrom, file_path: str
     ) -> tuple[list[CodeSymbol], list[CodeRelationship]]:
-        """Extract import symbols."""
+        """Extract import symbols.
+
+        run 013 (K5) fix: the relationship ``target`` is the symbol NAME that was
+        created (``alias.asname or alias.name``), NOT the dotted module path. The
+        encoder keys symbol neurons by that same name, so the previous code — which
+        set the target to ``alias.name`` for ``import X as Y`` and to
+        ``f"{module}.{alias.name}"`` for ``from M import N`` — never matched a key
+        in ``symbol_id_map`` and the import edge was silently dropped. The symbol
+        neuron IS the import; the edge must point at it.
+        """
         symbols: list[CodeSymbol] = []
         relationships: list[CodeRelationship] = []
 
@@ -231,17 +240,12 @@ class PythonExtractor:
                     )
                 )
                 relationships.append(
-                    CodeRelationship(
-                        source=file_path,
-                        target=alias.name,
-                        relation="imports",
-                    )
+                    CodeRelationship(source=file_path, target=name, relation="imports")
                 )
         else:
             module = node.module or ""
             for alias in node.names:
                 name = alias.asname or alias.name
-                full_target = f"{module}.{alias.name}" if module else alias.name
                 symbols.append(
                     CodeSymbol(
                         name=name,
@@ -252,12 +256,11 @@ class PythonExtractor:
                     )
                 )
                 relationships.append(
-                    CodeRelationship(
-                        source=file_path,
-                        target=full_target,
-                        relation="imports",
-                    )
+                    CodeRelationship(source=file_path, target=name, relation="imports")
                 )
+            # module is retained implicitly via the symbol's presence; the previous
+            # dotted target (f"{module}.{alias.name}") is what broke the edge.
+            _ = module  # documented: no longer used as a relationship target
 
         return symbols, relationships
 

--- a/src/surreal_memory/mcp/maintenance_handler.py
+++ b/src/surreal_memory/mcp/maintenance_handler.py
@@ -137,14 +137,21 @@ class MaintenanceHandler:
         fiber_count = stats.get("fiber_count", 0)
         neuron_count = stats.get("neuron_count", 0)
         synapse_count = stats.get("synapse_count", 0)
+        # run 013: structural/code-index neuron count from the live aggregate
+        # (K2). The connectivity denominator is the organic remainder.
+        structural_neuron_count = stats.get("structural_neuron_count", 0)
+        connectivity_neuron_count = max(0, neuron_count - structural_neuron_count)
 
-        # Connectivity describes the semantic graph, never write volume. alias rows
-        # are dedup pointers written once per repeated mention and audit edges point
-        # at agents/sources, so on a real brain 89% of the table was plumbing — enough
-        # to keep both the enrich hint and the auto-dream trigger below silent on a
-        # graph that actually held 1.4 semantic edges/neuron. The exclusion set lives
-        # in DiagnosticsEngine so this pulse and smem_health can never disagree.
+        # Connectivity describes the semantic ORGANIC graph, never write volume
+        # and never code-index volume. alias rows are dedup pointers, audit edges
+        # point at agents/sources, and code-index edges link two indexed neurons in
+        # one source file — on a real brain 89% of the table was plumbing. Counted
+        # against the full neuron total that plumbing kept both the enrich hint and
+        # the auto-dream trigger below silent on a graph that held 1.4 real
+        # edges/neuron. The exclusion lives in DiagnosticsEngine + the storage
+        # organic_synapse_count so this pulse and smem_health can never disagree.
         semantic_synapse_count = synapse_count
+        organic_synapse_count = synapse_count
         try:
             from surreal_memory.engine.diagnostics import DiagnosticsEngine
 
@@ -154,15 +161,29 @@ class MaintenanceHandler:
                 enhanced = await storage.get_enhanced_stats(brain_id, include_neuron_types=False)
             except TypeError:
                 enhanced = await storage.get_enhanced_stats(brain_id)
+            syn_stats = enhanced.get("synapse_stats", {})
             semantic_synapse_count = DiagnosticsEngine._count_semantic_synapses(
-                synapse_count, enhanced.get("synapse_stats", {})
+                synapse_count, syn_stats
             )
+            # organic_synapse_count = both-endpoints-organic AND non-structural type
+            # (variant c). Falls back to the type-filtered count when the backend
+            # cannot answer the endpoint join — over-reporting connectivity only
+            # ever withholds a hint, never invents a false alarm.
+            osc = syn_stats.get("organic_synapse_count")
+            if osc is not None:
+                organic_synapse_count = int(osc)
+            else:
+                organic_synapse_count = semantic_synapse_count
         except Exception:
             # Keep the pulse alive on the raw total. That can only over-report
             # connectivity (fewer hints), never invent a false low-connectivity alarm.
             logger.debug("Health pulse: synapse type breakdown unavailable", exc_info=True)
 
-        connectivity = semantic_synapse_count / neuron_count if neuron_count > 0 else 0.0
+        connectivity = (
+            organic_synapse_count / connectivity_neuron_count
+            if connectivity_neuron_count > 0
+            else 0.0
+        )
 
         # Estimate orphan ratio: neurons not covered by fibers
         # Heuristic: each fiber typically creates ~5 neurons
@@ -287,10 +308,12 @@ class MaintenanceHandler:
 
         Dream exploration discovers hidden connections via random spreading
         activation. Only fires when:
-        - connectivity < 1.5 SEMANTIC synapses/neuron (alias and audit edges do
-          not count — a brain whose edges are all dedup plumbing needs dream MORE,
-          not less, so counting them here suppressed the trigger that was meant
-          to rescue exactly that brain)
+        - connectivity < 1.5 ORGANIC synapses/neuron — both endpoints organic,
+          code-index edges excluded (run 013). A brain whose ORGANIC memory
+          graph is thin needs dream MORE not less; the old code-index-inflated
+          total both invented false alarms on healthy organic brains and masked
+          the real thin ones. The 1.5 threshold is the same — it now reads the
+          honest organic number.
         - neuron_count >= 50
         - dream cooldown has expired (default 24h)
         """
@@ -501,7 +524,7 @@ def _evaluate_thresholds(
         hints.append(
             HealthHint(
                 message=f"Low connectivity ({connectivity:.1f} semantic synapses/neuron, "
-                "healthy: 3-8 per neuron; alias and audit edges excluded). "
+                "healthy: 3-8 per neuron; alias, audit and code-index edges excluded). "
                 "Consider running consolidation with enrich strategy.",
                 severity=HintSeverity.LOW,
                 recommended_strategy="enrich",

--- a/src/surreal_memory/mcp/stats_handler.py
+++ b/src/surreal_memory/mcp/stats_handler.py
@@ -190,23 +190,34 @@ class StatsHandler:
         except Exception:
             logger.debug("Activation check failed (non-critical)", exc_info=True)
 
-        # Low connectivity hint. Counted on the semantic graph only, using the same
-        # exclusion set as smem_health — alias/audit rows scale with write volume,
-        # not with what is known, so including them made this hint quote a ratio
-        # (13.5/neuron on a real brain) that contradicted the health report's 1.4
-        # for the same brain. Falls back to the raw total when a caller passes plain
-        # get_stats() output with no by_type breakdown.
-        if neuron_count > 0:
-            from surreal_memory.engine.diagnostics import DiagnosticsEngine
+        # Low connectivity hint. Counted on the ORGANIC semantic graph, using the
+        # same exclusion as smem_health (run 013): code-index edges (indexed↔indexed
+        # within one source file) and alias/audit rows are structural — including
+        # them made this hint quote a ratio (13.5/neuron on a real brain) that
+        # contradicted the health report's 1.4 for the same brain, and fired false
+        # alarms on code-heavy brains whose organic graph was healthy. The organic
+        # count comes from synapse_stats; connectivity_neuron_count is the organic
+        # remainder of the neuron total. Falls back to the type-filtered count over
+        # the full neuron total when the backend cannot answer the endpoint join.
+        from surreal_memory.engine.diagnostics import DiagnosticsEngine
 
-            semantic_synapse_count = DiagnosticsEngine._count_semantic_synapses(
-                synapse_count, stats.get("synapse_stats", {})
+        structural_neuron_count = int(stats.get("structural_neuron_count", 0))
+        connectivity_neuron_count = max(0, neuron_count - structural_neuron_count)
+        syn_stats = stats.get("synapse_stats", {})
+        organic_synapse_count = syn_stats.get("organic_synapse_count")
+        if organic_synapse_count is None:
+            organic_synapse_count = DiagnosticsEngine._count_semantic_synapses(
+                synapse_count, syn_stats
             )
-            connectivity = semantic_synapse_count / neuron_count
-            if connectivity < 2.0 and neuron_count >= 20:
+            organic_denom = neuron_count
+        else:
+            organic_denom = connectivity_neuron_count
+        if organic_denom > 0:
+            connectivity = int(organic_synapse_count) / organic_denom
+            if connectivity < 2.0 and organic_denom >= 20:
                 hints.append(
                     f"Low connectivity ({connectivity:.1f} semantic synapses/neuron, "
-                    "healthy: 3-8 per neuron; alias and audit edges excluded). "
+                    "healthy: 3-8 per neuron; alias, audit and code-index edges excluded). "
                     "Store memories with context like 'X because Y' to build richer links."
                 )
 

--- a/src/surreal_memory/storage/memory_store.py
+++ b/src/surreal_memory/storage/memory_store.py
@@ -466,8 +466,12 @@ class InMemoryStorage(
     # ========== Statistics ==========
 
     async def get_stats(self, brain_id: str) -> dict[str, int]:
+        structural = sum(
+            1 for n in self._neurons[brain_id].values() if bool(n.metadata.get("indexed"))
+        )
         return {
             "neuron_count": len(self._neurons[brain_id]),
+            "structural_neuron_count": structural,
             "synapse_count": len(self._synapses[brain_id]),
             "fiber_count": len(self._fibers[brain_id]),
             "project_count": len(self._projects[brain_id]),
@@ -518,10 +522,24 @@ class InMemoryStorage(
         }
         by_type: dict[str, list[float]] = {}
         total_reinforcements = 0
+        # run 013: organic-subgraph synapse count (variant c — both endpoints
+        # non-indexed AND type not structural). Mirrors the SurrealDB endpoint
+        # join; keep the structural-type set in sync with DiagnosticsEngine.
+        _structural = {"alias", "stored_by", "verified_at", "approved_by", "source_of"}
+        indexed_ids = {
+            nid for nid, n in self._neurons[brain_id].items() if bool(n.metadata.get("indexed"))
+        }
+        organic_synapse_count = 0
         for synapse in self._synapses[brain_id].values():
             t = synapse.type.value
             by_type.setdefault(t, []).append(synapse.weight)
             total_reinforcements += synapse.reinforced_count
+            if (
+                t not in _structural
+                and synapse.source_id not in indexed_ids
+                and synapse.target_id not in indexed_ids
+            ):
+                organic_synapse_count += 1
 
         all_weights: list[float] = []
         for t, weights in by_type.items():
@@ -536,6 +554,7 @@ class InMemoryStorage(
         if all_weights:
             synapse_stats["avg_weight"] = round(sum(all_weights) / len(all_weights), 4)
         synapse_stats["total_reinforcements"] = total_reinforcements
+        synapse_stats["organic_synapse_count"] = organic_synapse_count
 
         # Memory time range
         fibers = list(self._fibers[brain_id].values())

--- a/src/surreal_memory/storage/surrealdb/schema.py
+++ b/src/surreal_memory/storage/surrealdb/schema.py
@@ -53,6 +53,10 @@ DEFINE FIELD lifecycle_state ON neuron TYPE string DEFAULT 'active';
 DEFINE FIELD frozen          ON neuron TYPE bool DEFAULT false;
 DEFINE FIELD last_accessed_at ON neuron TYPE option<datetime>;
 DEFINE INDEX idx_neuron_brain    ON neuron FIELDS brain_id;
+-- Accelerates the structural_neuron_count aggregate (COUNT WHERE metadata.indexed = true)
+-- used by DiagnosticsEngine to score connectivity on the organic subgraph only.
+-- Without this index the count full-scans the neuron table on every get_stats call.
+DEFINE INDEX IF NOT EXISTS idx_neuron_indexed ON neuron FIELDS metadata.indexed;
 DEFINE INDEX idx_neuron_type     ON neuron FIELDS brain_id, type;
 DEFINE INDEX idx_neuron_hash     ON neuron FIELDS brain_id, content_hash;
 DEFINE INDEX idx_neuron_content  ON neuron FIELDS brain_id, content;

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -2181,11 +2181,20 @@ class SurrealDBStorage(
 
     async def get_stats(self, brain_id: str) -> dict[str, int]:
         # Inline the (validated) brain_id so the count() aggregates use the
-        # brain_id index instead of a full scan — see _brain_literal. The three
+        # brain_id index instead of a full scan — see _brain_literal. The
         # scans are independent, so run them concurrently.
         lit = _brain_literal(brain_id)
-        neuron_rows, synapse_rows, fiber_rows = await asyncio.gather(
+        neuron_rows, indexed_rows, synapse_rows, fiber_rows = await asyncio.gather(
             self._query(f"SELECT count() AS c FROM neuron WHERE brain_id = {lit} GROUP ALL"),
+            # Structural (code-index) neurons — metadata.indexed is set only by
+            # CodebaseIndexer. The idx_neuron_indexed index keeps this an indexed
+            # equality, not a scan. structural_neuron_count lets the diagnostics
+            # engine score connectivity on the organic subgraph without a separate
+            # metadata scan per call-site.
+            self._query(
+                f"SELECT count() AS c FROM neuron "
+                f"WHERE brain_id = {lit} AND metadata.indexed = true GROUP ALL"
+            ),
             self._query(f"SELECT count() AS c FROM synapse WHERE brain_id = {lit} GROUP ALL"),
             self._query(f"SELECT count() AS c FROM fiber WHERE brain_id = {lit} GROUP ALL"),
         )
@@ -2197,6 +2206,7 @@ class SurrealDBStorage(
 
         return {
             "neuron_count": _count(neuron_rows),
+            "structural_neuron_count": _count(indexed_rows),
             "synapse_count": _count(synapse_rows),
             "fiber_count": _count(fiber_rows),
         }
@@ -2268,6 +2278,35 @@ class SurrealDBStorage(
         if total_count > 0:
             synapse_stats["avg_weight"] = round(total_weight / total_count, 4)
         synapse_stats["total_reinforcements"] = total_reinforcements
+
+        # run 013 (connectivity honesty): count synapses on the ORGANIC subgraph
+        # — both endpoints non-indexed AND type not in the structural set
+        # (alias/audit). This is the variant-(c) numerator for connectivity:
+        # the type breakdown above is global, so a code-heavy brain's by_type is
+        # dominated by code-index edges that never carried a memory. The
+        # endpoint join uses the native RELATION in/out fields, each an indexed
+        # equality on the neuron record link. The structural type list is
+        # duplicated from DiagnosticsEngine._STRUCTURAL_SYNAPSE_TYPES to avoid a
+        # storage→engine circular import; keep the two in sync (a single source
+        # of truth would require a shared module — deferred, the set is stable).
+        _structural = ("alias", "stored_by", "verified_at", "approved_by", "source_of")
+        # Inline brain_id (validated by _brain_literal) so the planner uses the
+        # brain_id index — a parameterized $bid falls back to a full scan on the
+        # synapse table (see _brain_literal docstring). $stypes is a list param,
+        # which does not affect the brain_id index pick. Consistent with K2.
+        lit = _brain_literal(brain_id)
+        organic_rows = await self._query(
+            f"SELECT count() AS c FROM synapse "
+            f"WHERE brain_id = {lit} "
+            f"AND in.metadata.indexed != true "
+            f"AND out.metadata.indexed != true "
+            f"AND type NOT IN $stypes "
+            f"GROUP ALL",
+            stypes=list(_structural),
+        )
+        synapse_stats["organic_synapse_count"] = (
+            int(organic_rows[0].get("c", 0)) if organic_rows else 0
+        )
 
         # The remaining four fields mirror InMemoryStorage.get_enhanced_stats
         # (storage/memory_store.py) so both backends report the same shape.

--- a/tests/unit/test_codebase.py
+++ b/tests/unit/test_codebase.py
@@ -150,11 +150,15 @@ class TestPythonExtractor:
         assert "os" in import_names
         assert "Path" in import_names
 
-        # Check import relationships
+        # Check import relationships. run 013 (K5): the relationship target is
+        # the imported SYMBOL name (the neuron the encoder creates), not the
+        # dotted module path — so "from pathlib import Path" yields target
+        # "Path", not "pathlib.Path". The dotted form never matched the encoder's
+        # symbol_id_map key, so the import edge was silently dropped before.
         import_rels = [r for r in relationships if r.relation == "imports"]
         import_targets = {r.target for r in import_rels}
         assert "os" in import_targets
-        assert "pathlib.Path" in import_targets
+        assert "Path" in import_targets
 
     def test_extract_constants(self, extractor: PythonExtractor, sample_file: Path) -> None:
         """Finds SCREAMING_SNAKE top-level assigns."""

--- a/tests/unit/test_connectivity_consistency.py
+++ b/tests/unit/test_connectivity_consistency.py
@@ -239,7 +239,8 @@ class TestHintsStateTheUnit:
 
         assert "semantic synapses/neuron" in hint
         assert "3-8 per neuron" in hint
-        assert "alias and audit edges excluded" in hint
+        # run 013: exclusion set now also names code-index edges.
+        assert "code-index edges excluded" in hint
         # "target: 3+" sat next to a number that could be a 0-1 score.
         assert "target: 3+" not in hint
 
@@ -256,7 +257,8 @@ class TestHintsStateTheUnit:
 
         assert "semantic synapses/neuron" in message
         assert "3-8 per neuron" in message
-        assert "alias and audit edges excluded" in message
+        # run 013: exclusion set now also names code-index edges.
+        assert "code-index edges excluded" in message
         # Alert routing keys off this prefix — keep it recognisable.
         assert message.startswith("Low connectivity (")
 

--- a/tests/unit/test_connectivity_indexer_k5.py
+++ b/tests/unit/test_connectivity_indexer_k5.py
@@ -1,0 +1,129 @@
+"""K5 (run 013) — codebase indexer fixes.
+
+1. co_occurrence edge cap (codebase_encoder._build_file_result): previously a
+   file with >5 symbols got ZERO co-occurrence edges; now every file gets up to
+   _MAX_CO_OCCUR_EDGES (20), closest pairs by line proximity first.
+2. import-key fix (extraction/codebase._extract_import): the relationship target
+   is the imported SYMBOL name, not the dotted module path — so the encoder's
+   symbol_id_map lookup now matches and the import edge actually connects.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from surreal_memory.core.synapse import SynapseType
+from surreal_memory.engine.codebase_encoder import _MAX_CO_OCCUR_EDGES, CodebaseEncoder
+from surreal_memory.extraction.codebase import PythonExtractor
+
+
+@pytest.fixture
+def extractor() -> PythonExtractor:
+    return PythonExtractor()
+
+
+class TestCoOccurEdgeCap:
+    @pytest.mark.asyncio
+    async def test_large_file_gets_co_occurs_edges(self, tmp_path: Path) -> None:
+        """A file with 12 symbols (>5) must still get co-occurrence edges.
+
+        Pre-fix this file got zero — the `<= 5` guard skipped the whole block.
+        """
+        funcs = "\n".join(f"    def f{i}(self) -> int:\n        return {i}\n" for i in range(12))
+        source = f"""\
+            class Big:
+            {funcs}
+"""
+        # textwrap.dedent above mangles the leading spaces; build cleanly instead
+        body = "".join(f"    def f{i}(self) -> int:\n        return {i}\n\n" for i in range(12))
+        source = "class Big:\n\n" + body
+        f = tmp_path / "big.py"
+        f.write_text(source, encoding="utf-8")
+
+        from unittest.mock import MagicMock
+
+        encoder = CodebaseEncoder(MagicMock(), MagicMock())
+        result = encoder._build_file_result(f)
+        co_occurs = [s for s in result.synapses_created if s.type == SynapseType.CO_OCCURS]
+        assert len(co_occurs) > 0, "large file got zero co-occurrence edges"
+        assert len(co_occurs) <= _MAX_CO_OCCUR_EDGES
+
+    @pytest.mark.asyncio
+    async def test_small_file_keeps_all_pairs(self, tmp_path: Path) -> None:
+        """A 4-symbol file keeps all C(4,2)=6 pairs (well under the budget)."""
+        source = textwrap.dedent("""\
+            class A:
+                def a1(self) -> None: pass
+                def a2(self) -> None: pass
+            def b() -> None: pass
+        """)
+        f = tmp_path / "small.py"
+        f.write_text(source, encoding="utf-8")
+
+        from unittest.mock import MagicMock
+
+        encoder = CodebaseEncoder(MagicMock(), MagicMock())
+        result = encoder._build_file_result(f)
+        co_occurs = [s for s in result.synapses_created if s.type == SynapseType.CO_OCCURS]
+        # 4 symbol neurons → 6 pairs; all under the 20-edge budget.
+        assert len(co_occurs) == 6
+
+
+class TestImportKeyFix:
+    def test_from_import_target_is_symbol_name(
+        self, extractor: PythonExtractor, tmp_path: Path
+    ) -> None:
+        """`from pathlib import Path` → relationship target "Path" (the neuron).
+
+        Previously the target was "pathlib.Path", which never matched the
+        encoder's symbol_id_map key ("Path"), so the edge was dropped.
+        """
+        source = "from pathlib import Path\n"
+        f = tmp_path / "imp.py"
+        f.write_text(source, encoding="utf-8")
+        _, relationships = extractor.extract_file(f)
+        import_rels = [r for r in relationships if r.relation == "imports"]
+        assert len(import_rels) == 1
+        assert import_rels[0].target == "Path"
+
+    def test_import_as_target_is_asname(self, extractor: PythonExtractor, tmp_path: Path) -> None:
+        """`import numpy as np` → target "np" (the symbol created), not "numpy"."""
+        source = "import numpy as np\n"
+        f = tmp_path / "imp.py"
+        f.write_text(source, encoding="utf-8")
+        _, relationships = extractor.extract_file(f)
+        import_rels = [r for r in relationships if r.relation == "imports"]
+        assert len(import_rels) == 1
+        assert import_rels[0].target == "np"
+
+    @pytest.mark.asyncio
+    async def test_import_edge_connects_to_symbol_neuron(self, tmp_path: Path) -> None:
+        """End-to-end: the import synapse survives the symbol_id_map resolution.
+
+        The encoder resolves relationships against symbol_id_map (keyed by the
+        symbol name). With the target now matching the name, the file→import
+        synapse is created instead of silently dropped.
+        """
+        source = textwrap.dedent("""\
+            import os
+            from pathlib import Path
+
+            def main() -> None:
+                pass
+        """)
+        f = tmp_path / "imp.py"
+        f.write_text(source, encoding="utf-8")
+
+        from unittest.mock import MagicMock
+
+        encoder = CodebaseEncoder(MagicMock(), MagicMock())
+        result = encoder._build_file_result(f)
+        # "imports" maps to RELATED_TO. At least one file→import edge should
+        # resolve (os and Path both have symbol neurons).
+        related = [s for s in result.synapses_created if s.type == SynapseType.RELATED_TO]
+        assert len(related) >= 2, (
+            f"expected ≥2 import (RELATED_TO) edges resolving, got {len(related)}"
+        )

--- a/tests/unit/test_connectivity_numerator.py
+++ b/tests/unit/test_connectivity_numerator.py
@@ -1,0 +1,163 @@
+"""K3 (run 013) — connectivity numerator: endpoint-based organic filtering.
+
+Variant (c) (DECISIONS.md): a synapse counts toward connectivity only when BOTH
+endpoints are organic. The code-index synapse TYPES (contains / co_occurs / is_a /
+related_to) are shared with the organic encoder, so the filter is endpoint-based,
+not type-based. This pins the numerator and the per-metric organic filtering.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from surreal_memory.core.brain import Brain, BrainConfig
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.core.synapse import Synapse, SynapseType
+from surreal_memory.engine.diagnostics import DiagnosticsEngine
+from surreal_memory.storage.memory_store import InMemoryStorage
+
+
+async def _brain_with_code_index() -> tuple[InMemoryStorage, str]:
+    """A brain that mirrors the real encoder's pathology.
+
+    4 indexed symbol neurons + 3 code-index edges between them (CONTAINS,
+    CO_OCCURS, IS_A — all indexed-indexed), plus 4 organic neurons with 2
+    organic semantic edges (RELATED_TO). The organic graph is thin (0.5/neuron)
+    but the 3 code-index edges would inflate a type-unaware numerator.
+    """
+    store = InMemoryStorage()
+    brain = Brain.create(name="k3-numerator", config=BrainConfig(), owner_id="test")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    for i in range(4):
+        await store.add_neuron(
+            Neuron.create(
+                type=NeuronType.CONCEPT,
+                content=f"idx-{i}",
+                neuron_id=f"idx-{i}",
+                metadata={"indexed": True},
+            )
+        )
+    for i in range(4):
+        await store.add_neuron(
+            Neuron.create(type=NeuronType.ENTITY, content=f"org-{i}", neuron_id=f"org-{i}")
+        )
+
+    sids: set[str] = set()
+    code_edges = [
+        ("idx-0", "idx-1", SynapseType.CONTAINS),
+        ("idx-1", "idx-2", SynapseType.CO_OCCURS),
+        ("idx-2", "idx-3", SynapseType.IS_A),
+    ]
+    organic_edges = [
+        ("org-0", "org-1", SynapseType.RELATED_TO),
+        ("org-2", "org-3", SynapseType.RELATED_TO),
+    ]
+    for idx, (s, t, st) in enumerate(code_edges + organic_edges):
+        sid = f"e-{idx}"
+        await store.add_synapse(
+            Synapse.create(source_id=s, target_id=t, type=st, weight=0.6, synapse_id=sid)
+        )
+        sids.add(sid)
+
+    await store.add_fiber(
+        Fiber.create(
+            neuron_ids={f"idx-{i}" for i in range(4)} | {f"org-{i}" for i in range(4)},
+            synapse_ids=sids,
+            anchor_neuron_id="org-0",
+            fiber_id="f-0",
+        )
+    )
+    return store, brain.id
+
+
+@pytest_asyncio.fixture
+async def code_index_brain() -> tuple[InMemoryStorage, str]:
+    return await _brain_with_code_index()
+
+
+class TestOrganicSynapseCount:
+    @pytest.mark.asyncio
+    async def test_enhanced_stats_reports_organic_synapse_count(
+        self, code_index_brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        store, brain_id = code_index_brain
+        enhanced = await store.get_enhanced_stats(brain_id)
+
+        assert enhanced["synapse_count"] == 5
+        # Only the 2 organic↔organic RELATED_TO edges; the 3 code-index edges
+        # (indexed-indexed) are excluded by endpoint filter.
+        assert enhanced["synapse_stats"]["organic_synapse_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_is_structural_neuron_helper(self) -> None:
+        assert DiagnosticsEngine._is_structural_neuron({"indexed": True}) is True
+        assert DiagnosticsEngine._is_structural_neuron({"indexed": False}) is False
+        assert DiagnosticsEngine._is_structural_neuron({}) is False
+        assert DiagnosticsEngine._is_structural_neuron(None) is False
+
+    @pytest.mark.asyncio
+    async def test_connectivity_score_ignores_code_index_edges(
+        self, code_index_brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        """The 3 code-index edges must not inflate connectivity.
+
+        With organic denominator 4 and organic numerator 2, ratio = 0.5/neuron.
+        A type-unaware numerator (counting all 5) would give 1.25/neuron (or 5/4
+        if alias etc. excluded) — measurably higher.
+        """
+        store, brain_id = code_index_brain
+        report = await DiagnosticsEngine(store).analyze(brain_id)
+
+        # organic denominator excludes the 4 indexed neurons (4 organic remain).
+        # organic numerator = 2 (only the organic↔organic RELATED_TO edges);
+        # the 3 code-index edges are excluded by endpoint filter even though
+        # their types are NOT in _STRUCTURAL_SYNAPSE_TYPES.
+        assert report.connectivity_neuron_count == 4
+        # connectivity score: sigmoid(-1.5*(0.5-3.0)) over 0.5 ratio.
+        # report.connectivity is rounded to 4 dp, so match at that precision.
+        import math
+
+        expected = round(1.0 / (1.0 + math.exp(-1.5 * (0.5 - 3.0))), 4)
+        assert report.connectivity == pytest.approx(expected, abs=1e-4)
+
+
+class TestPerMetricOrganicFiltering:
+    @pytest.mark.asyncio
+    async def test_freshness_excludes_code_index_fibers(
+        self, code_index_brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        """Freshness computed over organic fibers only.
+
+        The single fiber here is organic (no code_index tag), so freshness is
+        1.0 (created today). A code_index fiber added today must not change it.
+        """
+        store, brain_id = code_index_brain
+
+        # Add a code_index fiber (would inflate freshness if not excluded)
+        await store.add_fiber(
+            Fiber.create(
+                neuron_ids={"idx-0"},
+                synapse_ids=set(),
+                anchor_neuron_id="idx-0",
+                fiber_id="f-code",
+                tags={"code_index"},
+            )
+        )
+        report = await DiagnosticsEngine(store).analyze(brain_id)
+        # Only the organic fiber counts in the denominator → freshness stays 1.0
+        assert report.freshness == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_activation_efficiency_organic_denominator(
+        self, code_index_brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        """Activation efficiency denominator = organic neuron count (4), not 8."""
+        store, brain_id = code_index_brain
+        report = await DiagnosticsEngine(store).analyze(brain_id)
+        # No neuron has been activated → 0.0 regardless, but the point is no
+        # divide-by-included-indexed. Verify it runs and reports against organic.
+        assert report.activation_efficiency == 0.0

--- a/tests/unit/test_connectivity_organic_subgraph.py
+++ b/tests/unit/test_connectivity_organic_subgraph.py
@@ -1,0 +1,149 @@
+"""K2 (run 013) — connectivity scored on the organic subgraph.
+
+Code-index neurons (``metadata.indexed = true``) are structural leaves emitted by
+``CodebaseIndexer`` — one tree per file, never the endpoint of a memory the user
+recalls. Counting them in the connectivity denominator deflated the score on
+code-heavy brains: a brain with 20k indexed neurons + 20k organic neurons at a
+healthy 6 synapses/neuron reported ~3, because half the denominator was inert.
+
+This pins two things:
+1. ``get_stats`` returns ``structural_neuron_count`` (live, backend-computed).
+2. ``connectivity`` is scored against the ORGANIC count
+   (``connectivity_neuron_count = neuron_count - structural_neuron_count``), so
+   adding code-index neurons does not move the score.
+
+See DECISIONS.md (run 013, K1) — variant (c): both endpoints organic.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from surreal_memory.core.brain import Brain, BrainConfig
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.core.synapse import Synapse, SynapseType
+from surreal_memory.engine.diagnostics import DiagnosticsEngine
+from surreal_memory.storage.memory_store import InMemoryStorage
+
+
+async def _seed_brain(
+    *, indexed: int, organic: int, edges_per_organic: int
+) -> tuple[InMemoryStorage, str]:
+    """Build a brain with `indexed` code-index neurons + `organic` organic ones.
+
+    Only organic neurons carry semantic synapses (mirrors the real encoder: all
+    code-index edges are indexed-indexed within one file, see codebase_encoder.py).
+    """
+    store = InMemoryStorage()
+    brain = Brain.create(name="k2-structural", config=BrainConfig(), owner_id="test")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    for i in range(indexed):
+        await store.add_neuron(
+            Neuron.create(
+                type=NeuronType.CONCEPT,
+                content=f"file:{i}",
+                neuron_id=f"idx-{i}",
+                metadata={"indexed": True},
+            )
+        )
+
+    for i in range(organic):
+        await store.add_neuron(
+            Neuron.create(type=NeuronType.ENTITY, content=f"mem-{i}", neuron_id=f"org-{i}")
+        )
+
+    sids: set[str] = set()
+    if organic > 0:
+        for i in range(edges_per_organic * organic):
+            src = f"org-{i % organic}"
+            tgt = f"org-{(i + 1) % organic}"
+            sid = f"e-{i}"
+            await store.add_synapse(
+                Synapse.create(
+                    source_id=src,
+                    target_id=tgt,
+                    type=SynapseType.RELATED_TO,
+                    weight=0.6,
+                    synapse_id=sid,
+                )
+            )
+            sids.add(sid)
+
+    await store.add_fiber(
+        Fiber.create(
+            neuron_ids={f"org-{i}" for i in range(organic)} | {f"idx-{i}" for i in range(indexed)},
+            synapse_ids=sids,
+            anchor_neuron_id="org-0" if organic else "idx-0",
+            fiber_id="f-0",
+        )
+    )
+    return store, brain.id
+
+
+@pytest_asyncio.fixture
+async def mixed_brain() -> tuple[InMemoryStorage, str]:
+    # 20 indexed + 20 organic, organic graph at 3 edges/neuron.
+    return await _seed_brain(indexed=20, organic=20, edges_per_organic=3)
+
+
+class TestStructuralNeuronCountReported:
+    @pytest.mark.asyncio
+    async def test_stats_exposes_structural_count(
+        self, mixed_brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        store, brain_id = mixed_brain
+        stats = await store.get_stats(brain_id)
+
+        assert stats["neuron_count"] == 40
+        assert stats["structural_neuron_count"] == 20
+
+    @pytest.mark.asyncio
+    async def test_enhanced_stats_inherits_structural_count(
+        self, mixed_brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        store, brain_id = mixed_brain
+        enhanced = await store.get_enhanced_stats(brain_id)
+
+        assert enhanced["neuron_count"] == 40
+        assert enhanced["structural_neuron_count"] == 20
+
+    @pytest.mark.asyncio
+    async def test_report_carries_connectivity_neuron_count(
+        self, mixed_brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        store, brain_id = mixed_brain
+        report = await DiagnosticsEngine(store).analyze(brain_id)
+
+        assert report.neuron_count == 40
+        assert report.structural_neuron_count == 20
+        assert report.connectivity_neuron_count == 20
+
+
+class TestConnectivityOnOrganicSubgraph:
+    @pytest.mark.asyncio
+    async def test_indexed_neurons_do_not_deflate_connectivity(
+        self, mixed_brain: tuple[InMemoryStorage, str]
+    ) -> None:
+        """Adding 20 structural leaves must not move the score vs an all-organic brain."""
+        store, mixed_id = mixed_brain
+        organic_store, organic_id = await _seed_brain(indexed=0, organic=20, edges_per_organic=3)
+
+        mixed_report = await DiagnosticsEngine(store).analyze(mixed_id)
+        organic_report = await DiagnosticsEngine(organic_store).analyze(organic_id)
+
+        assert mixed_report.connectivity == pytest.approx(organic_report.connectivity, rel=1e-6)
+
+    @pytest.mark.asyncio
+    async def test_pure_indexed_brain_is_not_divide_by_zero(
+        self,
+    ) -> None:
+        """connectivity_neuron_count == 0 must not raise; connectivity is 0."""
+        store, brain_id = await _seed_brain(indexed=10, organic=0, edges_per_organic=0)
+        report = await DiagnosticsEngine(store).analyze(brain_id)
+
+        assert report.connectivity_neuron_count == 0
+        assert report.connectivity == 0.0

--- a/tests/unit/test_connectivity_thresholds_k4.py
+++ b/tests/unit/test_connectivity_thresholds_k4.py
@@ -1,0 +1,160 @@
+"""K4 (run 013) — organic connectivity in maintenance pulse + stats hints.
+
+Proves the two dup call-sites (`maintenance_handler._health_pulse`,
+`stats_handler._generate_stats_hints`) and the `_evaluate_thresholds` static
+helper now score connectivity on the ORGANIC subgraph, and that the 1.5 / 2.0
+thresholds (left UNCHANGED) still fire correctly:
+
+- a genuinely thin ORGANIC brain fires both the enrich hint and the auto-dream
+  trigger (the rescue path is intact);
+- a code-heavy brain whose organic graph is HEALTHY fires NEITHER — this used
+  to be a false positive (code-index noise deflated the ratio) and going silent
+  is the FIX, not a regression.
+
+See DECISIONS_K4.md for why the thresholds were NOT recalibrated.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from surreal_memory.core.brain import Brain, BrainConfig
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.core.synapse import Synapse, SynapseType
+from surreal_memory.mcp.maintenance_handler import (
+    HealthPulse,
+    MaintenanceHandler,
+    _evaluate_thresholds,
+)
+from surreal_memory.mcp.stats_handler import StatsHandler
+from surreal_memory.storage.memory_store import InMemoryStorage
+from surreal_memory.unified_config import MaintenanceConfig, UnifiedConfig
+
+
+async def _seed(
+    *, indexed: int, organic: int, edges_per_organic: int
+) -> tuple[InMemoryStorage, str]:
+    store = InMemoryStorage()
+    brain = Brain.create(name="k4", config=BrainConfig(), owner_id="test")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+    for i in range(indexed):
+        await store.add_neuron(
+            Neuron.create(
+                type=NeuronType.CONCEPT,
+                content=f"idx-{i}",
+                neuron_id=f"idx-{i}",
+                metadata={"indexed": True},
+            )
+        )
+    for i in range(organic):
+        await store.add_neuron(
+            Neuron.create(type=NeuronType.ENTITY, content=f"org-{i}", neuron_id=f"org-{i}")
+        )
+    sids: set[str] = set()
+    if organic > 0:
+        for i in range(edges_per_organic * organic):
+            sid = f"e-{i}"
+            await store.add_synapse(
+                Synapse.create(
+                    source_id=f"org-{i % organic}",
+                    target_id=f"org-{(i + 1) % organic}",
+                    type=SynapseType.RELATED_TO,
+                    weight=0.6,
+                    synapse_id=sid,
+                )
+            )
+            sids.add(sid)
+    await store.add_fiber(
+        Fiber.create(
+            neuron_ids={f"idx-{i}" for i in range(indexed)} | {f"org-{i}" for i in range(organic)},
+            synapse_ids=sids,
+            anchor_neuron_id="org-0" if organic else "idx-0",
+            fiber_id="f-0",
+        )
+    )
+    return store, brain.id
+
+
+class _FakeServer(MaintenanceHandler):
+    def __init__(self, storage: InMemoryStorage) -> None:
+        self._storage = storage
+        self.config = UnifiedConfig(maintenance=MaintenanceConfig())
+
+    async def get_storage(self) -> InMemoryStorage:
+        return self._storage
+
+    async def _maybe_run_expiry_cleanup(self) -> int:
+        return 0
+
+
+async def _pulse(store: InMemoryStorage) -> HealthPulse:
+    p = await _FakeServer(store)._health_pulse()
+    assert p is not None
+    return p
+
+
+async def _stats_hint(store: InMemoryStorage, brain_id: str) -> str | None:
+    handler = StatsHandler.__new__(StatsHandler)
+    stats = await store.get_enhanced_stats(brain_id)
+    hints = await handler._generate_stats_hints(store, brain_id, stats)
+    return next((h for h in hints if "connectivity" in h.lower()), None)
+
+
+class TestThinOrganicBrainFiresRescue:
+    @pytest.mark.asyncio
+    async def test_thin_organic_brain_fires_stats_hint_and_dream(self) -> None:
+        # 60 organic neurons, 0.5 edges/neuron → organic connectivity 0.5 < 2.0.
+        store, brain_id = await _seed(indexed=0, organic=60, edges_per_organic=0)
+        # add 30 organic edges manually → 0.5/neuron
+        for i in range(30):
+            await store.add_synapse(
+                Synapse.create(
+                    source_id=f"org-{i % 60}",
+                    target_id=f"org-{(i + 1) % 60}",
+                    type=SynapseType.RELATED_TO,
+                    weight=0.6,
+                    synapse_id=f"s-{i}",
+                )
+            )
+
+        hint = await _stats_hint(store, brain_id)
+        assert hint is not None
+        assert "Low connectivity" in hint
+
+        pulse = await _pulse(store)
+        assert pulse.connectivity < 1.5
+        assert any("connectivity" in h.message.lower() for h in pulse.hints)
+
+
+class TestCodeHeavyHealthyOrganicDoesNotFire:
+    @pytest.mark.asyncio
+    async def test_code_heavy_healthy_organic_brain_silent(self) -> None:
+        # 200 indexed neurons (code-index) + 60 organic at 5/neuron (healthy).
+        # Organic connectivity 5.0 > 2.0 → no hint, no dream. Pre-fix the indexed
+        # neurons deflated the ratio and fired a false alarm.
+        store, brain_id = await _seed(indexed=200, organic=60, edges_per_organic=5)
+
+        hint = await _stats_hint(store, brain_id)
+        assert hint is None, f"unexpected low-connectivity hint: {hint}"
+
+        pulse = await _pulse(store)
+        # organic connectivity ~5.0 → above the 1.5 dream threshold
+        assert pulse.connectivity >= 1.5
+        assert not any("connectivity" in h.message.lower() for h in pulse.hints)
+
+
+class TestThresholdsUnchangedSemantics:
+    def test_evaluate_thresholds_uses_organic_connectivity(self) -> None:
+        # connectivity passed in is already the organic ratio (as the pulse now
+        # provides). 1.0 organic → low-connectivity hint fires.
+        hints = _evaluate_thresholds(
+            fiber_count=100,
+            neuron_count=60,
+            synapse_count=60,
+            connectivity=1.0,
+            orphan_ratio=0.0,
+            cfg=MaintenanceConfig(),
+        )
+        assert any("connectivity" in h.message.lower() for h in hints)

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.4.0"
+        assert surreal_memory.__version__ == "3.5.0"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

3.5.0 makes the connectivity health metric honest. A code-heavy brain no longer
reads as under-connected purely because ~half its neurons are code-index leaves.

Connectivity is now scored on the **organic subgraph**: both the denominator
(`connectivity_neuron_count = neuron_count − structural_neuron_count`) and the
numerator (`organic_synapse_count` — both endpoints organic) exclude code-index
volume. The duplicate call-sites in the maintenance pulse, stats hints and
threshold evaluator are switched to the organic ratio.

The codebase indexer also gains two fixes: co-occurrence edges are now capped by
an **edge budget** (20, line-proximity sorted) rather than a symbol-count gate
that gave large files zero edges; and the import relationship target now points
at the imported **symbol name** (was the dotted module path, which never matched
the encoder's symbol-id key, so import synapses were silently dropped).

> **Purity-direction warning:** unlike the 2.15.0 alias fix (which *lowered*
> purity — brain had less than advertised), 3.5.0 drops code-index edges and
> *raises* purity on code-heavy brains: the organic memory graph was healthier
> than the inflated denominator suggested. The pre-change purity score is **not
> comparable** to the post-change one. See CHANGELOG.

### Changes by unit (run 013)

- **K1** measurement: code-index synapse edges 100% indexed-indexed, 0% mixed.
  Variant (c): an edge counts only when both endpoints are organic.
- **K2** `structural_neuron_count` as a live indexed COUNT (not a fragile
  counter); `connectivity_neuron_count` is the new denominator. Surfaced on the
  health report + dashboard payload.
- **K3** `organic_synapse_count` (both endpoints organic AND type not
  structural) is the new numerator. Endpoint-based, not type-based — the 4
  code-index types are shared with the organic encoder. `_is_structural_neuron`
  helper. `activation_efficiency`, `consolidation_ratio`, `freshness` also
  exclude structural/code-index volume.
- **K4** dup call-sites switched to organic connectivity. Thresholds 1.5/2.0
  **not** recalibrated — triggers fire on LOW connectivity; the code-heavy brain
  going silent was a false positive, not a regression.
- **K5** indexer: co-occurrence edge cap; import-key fix. Cross-file neuron
  reuse deferred (enhancement; naive content-key reuse would falsely merge).

## Test plan

- [x] ruff lint + format-check + security pass
- [x] mypy clean (353 source files)
- [x] 152/152 K2–K5 tests pass (test_connectivity_organic_subgraph,
      test_connectivity_numerator, test_connectivity_thresholds_k4,
      test_connectivity_indexer_k5, plus consistency/semantic_only regression)
- [x] codebase indexer regression 52/52 pass
- [x] version bump 3.4.0 → 3.5.0 confirmed in all 9 places
- [x] grep-ban placeholder/TODO in changed files: 0 real hits
- [ ] `uv run make verify` full suite with cov gate 67% — runs on host (sandbox
      is network-isolated; 3 failures + 32 errors there were infrastructural:
      no embedding API / live SurrealDB)
- [ ] post-change purity on live `default` — requires pipx install 3.5.0 +
      smem-mcp restart (host); expected to RISE vs pre-change 34.5
