### PR TITLE
fix(mcp): smem_edit refreshes content_hash and the embedding on a content change

### DIFF
--- a/src/surreal_memory/mcp/lifecycle_handler.py
+++ b/src/surreal_memory/mcp/lifecycle_handler.py
@@ -15,10 +15,71 @@ from surreal_memory.mcp.tool_handler_utils import _get_brain_or_error, _require_
 from surreal_memory.utils.timeutils import utcnow
 
 if TYPE_CHECKING:
+    from surreal_memory.core.neuron import Neuron
     from surreal_memory.storage.base import NeuralStorage
     from surreal_memory.unified_config import UnifiedConfig
 
 logger = logging.getLogger(__name__)
+
+
+async def _content_refreshed(storage: NeuralStorage, neuron: Neuron, new_content: str) -> Neuron:
+    """Return *neuron* with its content replaced and the derived fields refreshed.
+
+    ``content_hash`` is a pure function of the content, so it is recomputed
+    unconditionally — keeping the old fingerprint would feed near-duplicate
+    detection the SimHash of text that no longer exists.
+
+    The embedding is recomputed only when the neuron already carries one
+    (``metadata["_embedding"]``, surfaced by the storage read). ``update_neuron``
+    writes whatever vector that key holds, so without a refresh a content edit
+    actively re-saves the OLD vector against the NEW text: the memory stays
+    retrievable by what it used to say, and ``reindex --missing-only`` cannot
+    repair it because the field is never empty. Re-embedding goes through the
+    same provider path and bounded wait the write path uses; if the provider is
+    unavailable the edit still succeeds, but the stale vector is reported with a
+    warning instead of being rewritten silently.
+    """
+    from dataclasses import replace as dc_replace
+
+    from surreal_memory.utils.simhash import simhash
+
+    meta = dict(neuron.metadata)
+    updated = dc_replace(
+        neuron, content=new_content, content_hash=simhash(new_content), metadata=meta
+    )
+    if "_embedding" not in meta:
+        return updated
+    try:
+        import asyncio
+
+        from surreal_memory.core.brain import BrainConfig
+        from surreal_memory.engine.encoder import _inline_embed_timeout
+        from surreal_memory.engine.semantic_discovery import _create_provider
+
+        brain = await storage.get_brain(storage.brain_id or "")
+        provider = _create_provider(
+            brain.config if brain else BrainConfig(), task_type="RETRIEVAL_DOCUMENT"
+        )
+        embed = provider.embed_batch([updated.embedding_text()])
+        budget = _inline_embed_timeout()
+        vectors = await (asyncio.wait_for(embed, timeout=budget) if budget else embed)
+        meta["_embedding"] = list(vectors[0])
+    except TimeoutError:
+        logger.warning(
+            "smem_edit changed the content of neuron %s but re-embedding exceeded "
+            "its time budget — the stored vector still describes the old content; "
+            "run `smem reindex --all` to repair it.",
+            neuron.id,
+        )
+    except Exception:
+        logger.warning(
+            "smem_edit changed the content of neuron %s but could not recompute its "
+            "embedding — the stored vector still describes the old content; "
+            "run `smem reindex --all` to repair it.",
+            neuron.id,
+            exc_info=True,
+        )
+    return updated
 
 
 class LifecycleHandler:
@@ -108,13 +169,11 @@ class LifecycleHandler:
                         changes.append(f"tier: {old_tier} → {updated_tm.tier}")
                 await storage.update_typed_memory(updated_tm)
 
-            # Update anchor neuron content
+            # Update anchor neuron content (and the fields derived from it)
             if new_content is not None:
                 anchor = await storage.get_neuron(fiber.anchor_neuron_id)
                 if anchor:
-                    from dataclasses import replace as dc_replace
-
-                    updated_neuron = dc_replace(anchor, content=new_content)
+                    updated_neuron = await _content_refreshed(storage, anchor, new_content)
                     await storage.update_neuron(updated_neuron)
                     changes.append(f"content updated ({len(new_content)} chars)")
 
@@ -131,7 +190,7 @@ class LifecycleHandler:
 
             changes = []
             if new_content is not None:
-                neuron = dc_replace(neuron, content=new_content)
+                neuron = await _content_refreshed(storage, neuron, new_content)
                 changes.append(f"content updated ({len(new_content)} chars)")
             if new_type is not None:
                 from surreal_memory.core.neuron import NeuronType

--- a/tests/unit/test_edit_forget.py
+++ b/tests/unit/test_edit_forget.py
@@ -240,3 +240,132 @@ class TestNmemForget:
         result = await server.call_tool("smem_forget", {"memory_id": neuron.id, "hard": True})
         assert result["status"] == "hard_deleted"
         storage.delete_neuron.assert_awaited_once()
+
+
+class TestEditRefreshesDerivedFields:
+    """A content edit must refresh the fields derived from the content.
+
+    Without this, ``smem_edit`` re-saved the OLD SimHash and the OLD embedding
+    vector alongside the NEW text — the memory stayed retrievable by what it
+    used to say, and ``reindex --missing-only`` could not repair it because the
+    vector field was never empty.
+    """
+
+    @pytest.mark.asyncio
+    async def test_edit_recomputes_content_hash(self) -> None:
+        from surreal_memory.core.neuron import Neuron, NeuronType
+        from surreal_memory.utils.simhash import simhash
+
+        server = _make_server()
+        storage = AsyncMock()
+        storage.current_brain_id = "brain-1"
+        old = "the office is closed on fridays"
+        neuron = Neuron.create(type=NeuronType.CONCEPT, content=old)
+        from dataclasses import replace as dc_replace
+
+        neuron = dc_replace(neuron, content_hash=simhash(old))
+
+        storage.get_typed_memory = AsyncMock(return_value=None)
+        storage.get_fiber = AsyncMock(return_value=None)
+        storage.get_neuron = AsyncMock(return_value=neuron)
+        storage.update_neuron = AsyncMock()
+        server.get_storage = AsyncMock(return_value=storage)
+
+        new = "the office is open on fridays again"
+        result = await server.call_tool("smem_edit", {"memory_id": neuron.id, "content": new})
+        assert result["status"] == "edited"
+
+        saved = storage.update_neuron.await_args.args[0]
+        assert saved.content == new
+        assert saved.content_hash == simhash(new), (
+            "content_hash must be the fingerprint of the NEW content — keeping the old "
+            "one feeds near-duplicate detection the SimHash of text that no longer exists"
+        )
+
+    @pytest.mark.asyncio
+    async def test_edit_reembeds_when_vector_present(self) -> None:
+        from unittest.mock import patch
+
+        from surreal_memory.core.neuron import Neuron, NeuronType
+
+        server = _make_server()
+        storage = AsyncMock()
+        storage.current_brain_id = "brain-1"
+        stale_vec = [0.1, 0.2, 0.3]
+        anchor = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="old content",
+            metadata={"_embedding": list(stale_vec)},
+        )
+        fiber = MagicMock()
+        fiber.anchor_neuron_id = anchor.id
+
+        from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
+
+        typed_mem = TypedMemory.create(
+            fiber_id="fiber-1",
+            memory_type=MemoryType.FACT,
+            priority=Priority.NORMAL,
+            source="test",
+        )
+        storage.get_typed_memory = AsyncMock(return_value=typed_mem)
+        storage.get_fiber = AsyncMock(return_value=fiber)
+        storage.get_neuron = AsyncMock(return_value=anchor)
+        storage.update_neuron = AsyncMock()
+        server.get_storage = AsyncMock(return_value=storage)
+
+        fresh_vec = [9.0, 8.0, 7.0]
+        provider = MagicMock()
+        provider.embed_batch = AsyncMock(return_value=[list(fresh_vec)])
+        with patch(
+            "surreal_memory.engine.semantic_discovery._create_provider", return_value=provider
+        ):
+            result = await server.call_tool(
+                "smem_edit", {"memory_id": "fiber-1", "content": "corrected content"}
+            )
+
+        assert result["status"] == "edited"
+        saved = storage.update_neuron.await_args.args[0]
+        assert saved.metadata["_embedding"] == fresh_vec, (
+            "the vector saved with the new content must describe the new content — "
+            "re-saving the old one keeps the memory retrievable by what it used to say"
+        )
+        provider.embed_batch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_edit_survives_provider_unavailable_but_warns(self, caplog) -> None:
+        import logging
+        from unittest.mock import patch
+
+        from surreal_memory.core.neuron import Neuron, NeuronType
+
+        server = _make_server()
+        storage = AsyncMock()
+        storage.current_brain_id = "brain-1"
+        neuron = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="old content",
+            metadata={"_embedding": [0.1, 0.2]},
+        )
+        storage.get_typed_memory = AsyncMock(return_value=None)
+        storage.get_fiber = AsyncMock(return_value=None)
+        storage.get_neuron = AsyncMock(return_value=neuron)
+        storage.update_neuron = AsyncMock()
+        server.get_storage = AsyncMock(return_value=storage)
+
+        with (
+            patch(
+                "surreal_memory.engine.semantic_discovery._create_provider",
+                side_effect=RuntimeError("no provider"),
+            ),
+            caplog.at_level(logging.WARNING, logger="surreal_memory.mcp.lifecycle_handler"),
+        ):
+            result = await server.call_tool(
+                "smem_edit", {"memory_id": neuron.id, "content": "new content"}
+            )
+
+        assert result["status"] == "edited", "edit must not depend on embedder availability"
+        assert any("reindex" in r.message for r in caplog.records), (
+            "a stale vector left behind must be reported loudly, with the remediation "
+            "command — silence here is indistinguishable from a successful refresh"
+        )


### PR DESCRIPTION
## Summary

- A content edit through `smem_edit` now recomputes `content_hash` and, when the neuron already carries an embedding, re-embeds the new text through the same provider path the write path uses.
- If the provider is unavailable, the edit still succeeds but logs a warning naming `smem reindex --all` — the stale vector becomes loud and repairable instead of silent and invisible.
- Adds three regression tests: hash refresh, vector refresh, and the provider-unavailable fallback.

## Why

Both edit paths did `dc_replace(neuron, content=new_content)` and handed the result to `update_neuron`. That writes `content_hash` from the object and the vector from `metadata["_embedding"]` — and since `_row_to_neuron` surfaces the *stored* vector into that key on read, the old embedding was not merely left behind. It was actively re-saved against the new text, on every content edit.

Three things drift at once, and each is quiet in its own way:

- **Semantic recall returns the memory for what it *used* to say.** The worst case we measured is also the most natural use of an edit: an entry corrected specifically to say it is outdated was still retrieved as if current, because its vector still described the pre-edit text.
- **`reindex --missing-only` (the default) cannot see the damage.** The vector field is never empty, so the only repair is a blind `--all` re-embed of the whole brain.
- **Near-duplicate detection compares fingerprints of text that no longer exists**, since `content_hash` is a stored field, not a computed one.

Measured on a production brain of ~15k neurons (full re-embed and cosine compare of every neuron): 7 edited memories had drifted, worst cosine 0.75 against a flat 1.0000 for every untouched neuron — and all 7 carried an explicit correction marker in their text, i.e. they were exactly the memories someone had cared enough to fix.

Design choices, called out so they are decisions rather than surprises:

- The embedding is refreshed **only when one already exists**. Installs without an embedding provider have no vector to go stale, and the edit path gains no new dependency on one.
- On provider failure the edit **keeps the old vector and warns**, mirroring the write path's fail-soft philosophy (a slow or absent provider must not turn a successful edit into an error). If you would rather clear the vector so `--missing-only` picks it up, that is a one-line change in the helper — I chose the warning because clearing silently degrades recall for that memory, and the log line names the repair either way.
- The same stale-derived-data pattern exists in `mcp/instruction_handler.py` and in `engine/compression.py`'s compress/restore paths; this PR deliberately fixes only the user-facing edit tool. Happy to follow up on the others if you want them handled the same way — and a `reindex --stale` mode (re-embed-and-compare, which is how we found this) might be worth having regardless.
- `metadata["_structure"]` has the same problem on content edits. I have left it out of this PR and will raise it separately, because it needs a product decision (recompute vs drop) rather than a mechanical refresh.

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` passes locally — 7020 passed, 142 skipped, 1 xfailed (baseline on `main` is 7017; the delta is this PR's three tests).
- [x] `ruff check src/ tests/` clean; `ruff format --check` clean.
- [x] `mypy src/ --ignore-missing-imports` clean — no issues in 353 source files.
- [x] All three new tests were proven to fail on `main`'s `lifecycle_handler.py`: the saved neuron kept the old `content_hash`, kept the old vector, and no warning was emitted — the exact silent behaviour this PR removes.
- [x] Diff touches `mcp/` and `tests/` only; no server routes or dashboard assets.

## Verified by

@RobertSigmundsson
