### PR TITLE
fix(consolidation): merge must not absorb a pinned fiber

### DIFF
--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -938,6 +938,17 @@ class ConsolidationEngine:
             ):
                 continue
 
+            # Never merge a pinned fiber away, for the same reason as the marker
+            # guard above: the merged fiber carries only `merged_from`, dropping
+            # both the pin itself and the source metadata. That guard covers
+            # pattern fibers; it does not cover the other reasons a fiber is
+            # pinned — a trained knowledge base, or an explicit user pin.
+            # Pinning exists precisely to make a fiber survive lifecycle, and
+            # merge is part of lifecycle, so without this a pinned fiber is
+            # silently absorbed on the next consolidation pass.
+            if fiber_list[i].pinned or fiber_list[j].pinned:
+                continue
+
             set_a = fiber_list[i].neuron_ids
             set_b = fiber_list[j].neuron_ids
             intersection = len(set_a & set_b)

--- a/tests/unit/test_consolidation.py
+++ b/tests/unit/test_consolidation.py
@@ -784,3 +784,63 @@ async def test_merge_never_removes_reasoning_pattern_fiber() -> None:
         if f.id in {"pattern-1", "pattern-2"}:
             assert f.metadata.get("_source_model") == "claude-fable-5"
             assert f.metadata.get("_reasoning_category") == "debugging"
+
+
+@pytest.mark.asyncio
+async def test_merge_never_removes_pinned_fiber_without_pattern_markers() -> None:
+    """A fiber pinned for any reason must survive _merge at 100% neuron overlap.
+
+    _merge already skips fibers carrying `_habit_pattern` / `_reasoning_pattern`
+    markers, so the pinned fiber here deliberately carries NEITHER: with such a
+    marker the existing guard rescues it and the test passes with or without the
+    `pinned` check, proving nothing. Unprotected today is every other reason a
+    fiber is pinned — a trained knowledge base, or an explicit user pin. Merge
+    deletes the member fibers and the merged fiber keeps only `merged_from`, so
+    the pin goes with them.
+    """
+    store = InMemoryStorage()
+    brain = Brain.create(name="merge_pinned_test", brain_id="mp-brain")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    for nid in ("n-a", "n-b", "n-c"):
+        await store.add_neuron(Neuron.create(type=NeuronType.ENTITY, content=nid, neuron_id=nid))
+
+    shared = {"n-a", "n-b", "n-c"}  # 100% overlap → Jaccard 1.0, well above 0.5
+    plain1 = Fiber(
+        id="plain-1",
+        neuron_ids=shared,
+        synapse_ids=set(),
+        anchor_neuron_id="n-a",
+        pathway=["n-a"],
+        frequency=5,
+    )
+    plain2 = Fiber(
+        id="plain-2",
+        neuron_ids=shared,
+        synapse_ids=set(),
+        anchor_neuron_id="n-b",
+        pathway=["n-b"],
+        frequency=5,
+    )
+    pinned_fiber = Fiber(
+        id="pinned-1",
+        neuron_ids=shared,
+        synapse_ids=set(),
+        anchor_neuron_id="n-a",
+        pathway=["n-a"],
+        frequency=5,
+        pinned=True,
+    )
+    assert not any(
+        marker in pinned_fiber.metadata for marker in ("_habit_pattern", "_reasoning_pattern")
+    ), "the fixture must not qualify for the pre-existing marker guard"
+
+    for f in (plain1, plain2, pinned_fiber):
+        await store.add_fiber(f)
+
+    engine = ConsolidationEngine(store, ConsolidationConfig())
+    await engine._merge(ConsolidationReport(), dry_run=False)
+
+    remaining = {f.id for f in await store.get_fibers(limit=100)}
+    assert "pinned-1" in remaining, "merge must never delete a pinned fiber"


### PR DESCRIPTION
## Summary

- `_merge` now skips any pair where either fiber is pinned, so a pinned fiber is no longer absorbed into a merged one.
- Adds a regression test using a pinned fiber that carries neither pattern marker, so it exercises the new guard rather than the existing one.

## Why

`_merge` already refuses to merge fibers carrying `_habit_pattern` or `_reasoning_pattern`, on the grounds that the merged fiber keeps only `merged_from` and would drop the source metadata. The same argument applies to the pin itself, but the marker guard does not reach it: a fiber pinned for any other reason — a trained knowledge base, or an explicit user pin — is still absorbed on the next consolidation pass, and the pin goes with it.

That leaves pinning inconsistent across lifecycle. Decay honours it, dead-neuron pruning honours it, orphan pruning honours it since the guard was hoisted above both branches — and then merge, which is also lifecycle, does not. A fiber surviving every other pass only to be merged away looks like a gap rather than a deliberate policy, and it is silent: the merged fiber is a legitimate object, nothing errors, and the only symptom is that something pinned is no longer there.

The guard is placed alongside the existing marker check and shares its rationale, so the two read as one policy rather than two special cases.

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` passes locally — 7018 passed, 142 skipped, 1 xfailed (baseline on `main` is 7017; the delta is this PR's test).
- [x] `ruff check src/ tests/` clean.
- [x] `ruff format --check src/ tests/` clean.
- [x] `mypy src/ --ignore-missing-imports` clean — no issues in 353 source files.
- [x] The new test was proven to fail without the fix: with `engine/consolidation.py` reverted to `main`, it fails on `assert "pinned-1" in remaining` — the pinned fiber is gone and only the merged fiber's new id remains.
- [x] The fixture deliberately carries neither `_habit_pattern` nor `_reasoning_pattern`, with an assertion pinning that. An earlier version of this test carried `_reasoning_pattern` and passed with *and* without the change, because the pre-existing marker guard rescued it — worth stating explicitly, since it is an easy trap to fall back into when extending this test later.

## Verified by

@RobertSigmundsson
