### PR TITLE
fix: remove the SELECT VALUE unwrap heuristic — SDK 2.x already unwraps (#154.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed — the `SELECT VALUE` unwrap heuristic is gone (#154, finding 3)
+
+- **`_query` no longer shape-sniffs its result.** The `result[0] if isinstance(result[0],
+  list) else result` unwrap was a fossil from SDK 1.x, which returned the RPC envelope;
+  the pinned `surrealdb>=2.0.0,<3.0.0` unwraps it itself (verified live over ws and http
+  against SurrealDB 3.5.0). Its only remaining effect was the #143 bug class: a
+  `SELECT VALUE` on an array-typed field returns a list of per-row arrays, and the
+  heuristic collapsed that to the **first row's array**. The retry/reconnect core moved to
+  `_query_response`, with `_query` (rows) and `_query_values` (per-row values) as honest
+  thin wrappers. New live integration tests pin all three shapes — scalar `VALUE`,
+  array-typed `VALUE`, and rows — plus `get_connected_neuron_ids` end to end
+  (`tests/integration/test_surrealdb_query_shapes.py`); unit mocks that encoded the
+  envelope shape were corrected to what the SDK actually returns.
+
 ## [3.5.0] — 2026-08-13 — connectivity honesty: code-index excluded from the metric
 
 ### Changed — connectivity is now scored on the organic subgraph

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Forward-looking vision. What's next, what's possible, where we're going.
 > ZERO LLM dependency — pure algorithmic, regex, graph-based.
 
-**Current state**: v3.4.0 — 57 MCP tools, 7100+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
+**Current state**: v3.4.0 — 57 MCP tools, 7200+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
 
 **Storage**: SurrealDB is the only persistent backend — schema v9 — and `storage_backend`
 defaults to it. `#141` removed the SQLite backend entirely; selecting `storage_backend = "sqlite"`

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -675,8 +675,9 @@ class SurrealDBStorage(
     # Query helper
     # ================================================================
 
-    async def _query(self, sql: str, **params: Any) -> list[dict[str, Any]]:
-        """Execute a SurrealQL query and return result rows.
+    async def _query_response(self, sql: str, **params: Any) -> Any:
+        """Execute a SurrealQL query and return the SDK's result for the first
+        statement, as-is.
 
         Retries once after re-authenticating if the cached connection's token
         has expired. SurrealDB issues root tokens with a ~1h TTL and the SDK's
@@ -721,25 +722,38 @@ class SurrealDBStorage(
                     )
             else:
                 raise last_exc
-        if result and isinstance(result, list) and len(result) > 0:
-            return result[0] if isinstance(result[0], list) else result
-        return []
+        return result
+
+    async def _query(self, sql: str, **params: Any) -> list[dict[str, Any]]:
+        """Execute a row query and return its rows.
+
+        The pinned SDK (``surrealdb>=2.0.0,<3.0.0``) already unwraps the RPC
+        envelope: ``query()`` returns the first statement's result directly —
+        rows for a ``SELECT``. The historical ``result[0] if
+        isinstance(result[0], list)`` unwrap predates that and only "worked"
+        because rows are dicts, never lists; on ``SELECT VALUE`` it corrupted
+        the result whenever the projected field was array-typed (a list of
+        per-row arrays collapsed to the first row — the #143 bug, left behind
+        by #154's finding 3). A statement that returns a non-list (a bare
+        scalar) reads as no rows, as before.
+        """
+        result = await self._query_response(sql, **params)
+        return result if isinstance(result, list) else []
 
     async def _query_values(self, sql: str, **params: Any) -> list[Any]:
         """Execute a ``SELECT VALUE ...`` query and return the flat per-row value list.
 
-        ``_query`` is typed ``list[dict[str, Any]]``, which understates what it
-        actually returns for ``SELECT VALUE``: each element is the selected
-        field's raw value (a record id, a scalar, or -- if the field is
-        array-typed -- itself a list), never a row dict. mypy stays quiet about
-        every ``SELECT VALUE`` call site that (mis)treats the result as rows
-        precisely because that mismatched annotation makes it look like one;
-        that silence is the mechanism behind #143's bug (a `SELECT VALUE
-        <array-field>` result iterated character-by-character). Give
-        ``SELECT VALUE`` call sites an honestly-typed entry point instead of
-        re-litigating the row-vs-value distinction at each one.
+        Each element is the selected field's raw value for one row (a record
+        id, a scalar, or -- if the field is array-typed -- itself a list), so an
+        array-typed field yields a list of lists, one per row, and that shape
+        must survive: callers that flatten it decide how, not this helper.
+        ``_query``'s ``list[dict[str, Any]]`` annotation understates exactly
+        this, which is why mypy stayed quiet about the ``SELECT VALUE`` call
+        site that #143 fixed; give value queries an honestly-typed entry point
+        instead of re-litigating the row-vs-value distinction at each one.
         """
-        return await self._query(sql, **params)
+        result = await self._query_response(sql, **params)
+        return result if isinstance(result, list) else []
 
     async def _reconnect(self) -> None:
         """Re-establish the SurrealDB connection after a token expiry / 401.
@@ -2748,6 +2762,11 @@ class SurrealDBStorage(
             logger.warning("Device lookup failed for %s", device_id, exc_info=True)
             return None
         if result:
+            # SDK 2.x `select()` on a single record returns [record]; the bare-
+            # dict branch is defensive for shapes it has been seen to return in
+            # other versions. Unlike the removed `_query` unwrap, this tests
+            # `result` itself, not its first element, so a record whose field
+            # is a list cannot be mistaken for the wrapper.
             r = result[0] if isinstance(result, list) else result
             return _device_record(r, brain_id, fallback_device_id=device_id)
         return None

--- a/tests/integration/test_surrealdb_query_shapes.py
+++ b/tests/integration/test_surrealdb_query_shapes.py
@@ -1,0 +1,115 @@
+"""Live integration tests for SurrealDB query-result shapes.
+
+These run against a REAL SurrealDB >= 3.2.0 (skipped unless SURREALDB_URL is set).
+
+``_query`` carried a shape heuristic -- ``result[0] if isinstance(result[0],
+list) else result`` -- left over from the SDK 1.x era when ``query()`` returned
+the RPC envelope. The pinned SDK (>=2.0.0) unwraps that envelope itself, so the
+heuristic's only remaining effect was corrupting ``SELECT VALUE`` results on
+array-typed fields: a list of per-row arrays collapsed to the first row's array,
+which the caller then iterated as if it were the rows (#143; the residual was
+#154's finding 3). A unit mock can pin our unwrapping code, but only a live
+server proves which shapes the SDK actually hands us -- which is the half the
+heuristic got wrong.
+
+Run (real-db-test-runner drives this):
+    SURREALDB_URL=http://localhost:<port> SURREALDB_USER=root SURREALDB_PASS=... \
+        uv run --extra dev --extra server --extra surrealdb \
+        pytest tests/integration/test_surrealdb_query_shapes.py -m integration -q
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from surreal_memory.core.brain import Brain
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.core.synapse import Synapse, SynapseType
+from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+SURREALDB_URL = os.getenv("SURREALDB_URL")
+SURREALDB_USER = os.getenv("SURREALDB_USER", "root")
+SURREALDB_PASS = os.getenv("SURREALDB_PASS", "root")
+SURREALDB_NS = os.getenv("SURREALDB_NS", "smem_it")
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not SURREALDB_URL, reason="requires SURREALDB_URL (live SurrealDB >= 3.2.0)"
+    ),
+]
+
+
+@pytest_asyncio.fixture
+async def store():
+    """A fresh, initialised store scoped to its own throwaway database."""
+    storage = SurrealDBStorage(
+        url=SURREALDB_URL,
+        user=SURREALDB_USER,
+        password=SURREALDB_PASS,
+        namespace=SURREALDB_NS,
+        database="it_" + uuid.uuid4().hex[:12],
+    )
+    await storage.initialize()
+    brain = Brain.create(name="query-shapes-it")
+    await storage.save_brain(brain)
+    storage.set_brain(brain.id)
+    try:
+        yield storage
+    finally:
+        await storage.close()
+
+
+async def _seed_probe_table(store: SurrealDBStorage) -> None:
+    """Three rows: two with tag arrays, one without (NULL projects as None).
+
+    The fixture's database is throwaway, so no WHERE scoping is needed — every
+    row in ``query_shape_probe`` is ours. (String-vs-RecordID ``IN`` filters
+    silently match nothing; see test_surrealdb_pinning's header.)
+    """
+    await store._query("REMOVE TABLE IF EXISTS query_shape_probe")
+    await store._query("CREATE query_shape_probe:a, query_shape_probe:b, query_shape_probe:c")
+    await store._query(
+        "UPDATE query_shape_probe SET tags = ['t1', 't2'] WHERE id = query_shape_probe:a"
+    )
+    await store._query("UPDATE query_shape_probe SET tags = ['t3'] WHERE id = query_shape_probe:b")
+
+
+async def test_row_queries_return_row_dicts(store: SurrealDBStorage):
+    await _seed_probe_table(store)
+    rows = await store._query("SELECT * FROM query_shape_probe ORDER BY id")
+    # Schemaless rows omit absent fields (row c has no tags key at all).
+    assert [r.get("tags") for r in rows] == [["t1", "t2"], ["t3"], None]
+
+
+async def test_value_query_on_scalar_field_is_flat(store: SurrealDBStorage):
+    await _seed_probe_table(store)
+    values = await store._query_values("SELECT VALUE id FROM query_shape_probe ORDER BY id")
+    assert [str(v) for v in values] == [
+        "query_shape_probe:a",
+        "query_shape_probe:b",
+        "query_shape_probe:c",
+    ]
+
+
+async def test_value_query_on_array_field_keeps_every_row(store: SurrealDBStorage):
+    """The #143/#154.3 regression pin: the old heuristic returned only the
+    first row's array here. All rows must survive, nesting intact."""
+    await _seed_probe_table(store)
+    values = await store._query_values("SELECT VALUE tags FROM query_shape_probe ORDER BY id")
+    assert values == [["t1", "t2"], ["t3"], None]
+
+
+async def test_connected_neuron_ids_through_real_synapses(store: SurrealDBStorage):
+    """The one production caller of ``_query_values`` must keep working: two
+    neurons joined by one synapse surface both endpoints."""
+    a = await store.add_neuron(Neuron.create(type=NeuronType.CONCEPT, content="a"))
+    b = await store.add_neuron(Neuron.create(type=NeuronType.CONCEPT, content="b"))
+    await store.add_synapse(Synapse.create(source_id=a, target_id=b, type=SynapseType.RELATED_TO))
+
+    connected = await store.get_connected_neuron_ids()
+    assert connected == {a, b}

--- a/tests/unit/test_consolidation_timeouts_and_reconnect.py
+++ b/tests/unit/test_consolidation_timeouts_and_reconnect.py
@@ -100,7 +100,9 @@ class _FlakyConn:
         if self.remaining > 0:
             self.remaining -= 1
             raise ConnectionResetError(104, "Connection reset by peer")
-        return [[{"ok": True}]]
+        # SDK >=2.0.0 shape: query() returns the first statement's rows
+        # directly, with no envelope to unwrap (see _query's docstring).
+        return [{"ok": True}]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_dashboard_perf_queries.py
+++ b/tests/unit/test_dashboard_perf_queries.py
@@ -79,14 +79,12 @@ class TestFindNeuronsProjection:
         st, conn = _store_with_mock_conn()
         conn.query = AsyncMock(
             return_value=[
-                [
-                    {
-                        "id": _FakeRID("neuron", "n_1"),
-                        "type": "concept",
-                        "content": "x",
-                        "metadata": {},
-                    }
-                ]
+                {
+                    "id": _FakeRID("neuron", "n_1"),
+                    "type": "concept",
+                    "content": "x",
+                    "metadata": {},
+                }
             ]
         )
         neurons = await st.find_neurons(limit=1, include_embedding=False)
@@ -136,8 +134,8 @@ class TestSynapseDegrees:
         st, conn = _store_with_mock_conn()
         conn.query = AsyncMock(
             side_effect=[
-                [[{"nid": _FakeRID("neuron", "a_1"), "deg": 3}]],  # GROUP BY in
-                [[{"nid": _FakeRID("neuron", "a_1"), "deg": 2}]],  # GROUP BY out
+                [{"nid": _FakeRID("neuron", "a_1"), "deg": 3}],  # GROUP BY in
+                [{"nid": _FakeRID("neuron", "a_1"), "deg": 2}],  # GROUP BY out
             ]
         )
         degree = await st.get_synapse_degrees()
@@ -154,20 +152,18 @@ class TestEdgesForNeurons:
         st, conn = _store_with_mock_conn()
         conn.query = AsyncMock(
             return_value=[
-                [
-                    {
-                        "id": _FakeRID("neuron", "src_1"),
-                        "edges": [
-                            {
-                                "id": _FakeRID("synapse", "e_1"),
-                                "out": _FakeRID("neuron", "dst_2"),
-                                "type": "related_to",
-                                "weight": 0.8,
-                                "direction": "uni",
-                            }
-                        ],
-                    }
-                ]
+                {
+                    "id": _FakeRID("neuron", "src_1"),
+                    "edges": [
+                        {
+                            "id": _FakeRID("synapse", "e_1"),
+                            "out": _FakeRID("neuron", "dst_2"),
+                            "type": "related_to",
+                            "weight": 0.8,
+                            "direction": "uni",
+                        }
+                    ],
+                }
             ]
         )
         edges = await st.get_edges_for_neurons(["src-1"])
@@ -190,7 +186,7 @@ class TestEdgesForNeurons:
 class TestDiagnosticsAggregates:
     async def test_count_activated_uses_group_all(self):
         st, conn = _store_with_mock_conn()
-        conn.query = AsyncMock(return_value=[[{"c": 42}]])
+        conn.query = AsyncMock(return_value=[{"c": 42}])
         n = await st.count_activated_neuron_states()
         (sql,) = _queries(conn)
         assert "count()" in sql and "access_frequency > 0" in sql and "GROUP ALL" in sql
@@ -200,8 +196,8 @@ class TestDiagnosticsAggregates:
         st, conn = _store_with_mock_conn()
         conn.query = AsyncMock(
             side_effect=[
-                [[str(_FakeRID("neuron", "a_1"))]],  # SELECT VALUE in ... GROUP BY in
-                [[str(_FakeRID("neuron", "b_2"))]],  # SELECT VALUE out ... GROUP BY out
+                [str(_FakeRID("neuron", "a_1"))],  # SELECT VALUE in ... GROUP BY in
+                [str(_FakeRID("neuron", "b_2"))],  # SELECT VALUE out ... GROUP BY out
             ]
         )
         connected = await st.get_connected_neuron_ids()
@@ -215,16 +211,20 @@ class TestDiagnosticsAggregates:
 # _query_values -- honest SELECT VALUE typing (#154 finding 3)
 # --------------------------------------------------------------------------- #
 class TestQueryValues:
+    """The SDK (>=2.0.0) unwraps the RPC envelope itself: query() returns the
+    first statement's result directly, so these mocks use the shapes a live
+    server produces (verified against SurrealDB 3.5.0 over ws and http)."""
+
     async def test_flat_scalar_list(self):
         """`in`/`out` are scalar record links -- one value per row."""
         st, conn = _store_with_mock_conn()
-        conn.query = AsyncMock(return_value=[["neuron:a", "neuron:b"]])
+        conn.query = AsyncMock(return_value=["neuron:a", "neuron:b"])
         values = await st._query_values("SELECT VALUE in FROM synapse")
         assert values == ["neuron:a", "neuron:b"]
 
     async def test_empty_result_is_empty_list(self):
         st, conn = _store_with_mock_conn()
-        conn.query = AsyncMock(return_value=[[]])
+        conn.query = AsyncMock(return_value=[])
         assert await st._query_values("SELECT VALUE in FROM synapse") == []
 
     async def test_a_row_whose_value_is_itself_an_array_is_not_collapsed(self):
@@ -232,9 +232,23 @@ class TestQueryValues:
         row whose value is an array must come back as that one array, not be
         confused for "these array elements are separate rows"."""
         st, conn = _store_with_mock_conn()
-        conn.query = AsyncMock(return_value=[[["tag-a", "tag-b"]]])
+        conn.query = AsyncMock(return_value=[["tag-a", "tag-b"]])
         values = await st._query_values("SELECT VALUE tags FROM neuron")
         assert values == [["tag-a", "tag-b"]]
+
+    async def test_every_rows_array_comes_back_not_just_the_first(self):
+        """The #154-finding-3 residual, pinned: the old ``result[0] if
+        isinstance(result[0], list)`` unwrap collapsed a list of per-row
+        arrays to the FIRST row's array. All rows must survive."""
+        st, conn = _store_with_mock_conn()
+        conn.query = AsyncMock(return_value=[["t1", "t2"], ["t3"], None])
+        values = await st._query_values("SELECT VALUE tags FROM neuron")
+        assert values == [["t1", "t2"], ["t3"], None]
+
+    async def test_scalar_statement_result_reads_as_no_values(self):
+        st, conn = _store_with_mock_conn()
+        conn.query = AsyncMock(return_value=5)
+        assert await st._query_values("RETURN 5") == []
 
 
 class TestGetAllSynapsesProjection:


### PR DESCRIPTION
## Summary

- `_query` no longer shape-sniffs its result: the `result[0] if isinstance(result[0], list) else result` unwrap is deleted, and the retry/reconnect core moved to a new `_query_response` with `_query` (rows) and `_query_values` (per-row values) as honest thin wrappers.
- Unit mocks that encoded the SDK 1.x envelope shape are corrected to what `surrealdb>=2.0.0,<3.0.0` actually returns; a new live integration module pins the row / scalar-VALUE / array-VALUE result shapes plus `get_connected_neuron_ids` end to end.

## Why

The heuristic was a fossil from the SDK 1.x era, when `query()` returned the RPC envelope. The pinned SDK unwraps that envelope itself — verified live over both ws and http transports against SurrealDB 3.5.0 — so the heuristic's only remaining effect was the #143 bug class it was built around: a `SELECT VALUE` on an array-typed field returns a list of per-row arrays, and the heuristic collapsed that to the **first row's array** (`SELECT VALUE tags` on three rows returned `[['t1','t2']]`). #157 added the honestly-typed `_query_values` entry point (#154 finding 3) but delegated to `_query`, leaving the trap underneath; removing the heuristic outright closes it, and the live tests keep it closed in the `integration` CI job.

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` passes locally (pre-existing parallel-run connection resets on live-server tests reproduce identically on the base commit; all of them pass sequentially with this change).
- [x] `ruff check src/ tests/` clean.
- [x] `mypy src/ --ignore-missing-imports` — the one error (`google.genai`) reproduces identically on the base commit; none introduced.
- [x] `pytest tests/integration -m integration` — 25 passed against a live SurrealDB 3.5.0, including the 4 new tests in `tests/integration/test_surrealdb_query_shapes.py`.

## Verified by

@acidkill.