### PR TITLE
docs: AGENTS.md PR template no longer asks for the attribution Hard Rule #2 forbids (#154.7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,8 +123,11 @@ One paragraph: the problem this PR solves and why it solves it this way.
 
 ## Verified by
 
-@your-github-handle — built with <agent name + version>.
+@your-github-handle.
 ```
+
+The handle is the accountability record — Hard Rule #2 forbids naming the tool
+next to it, so this section stays attribution-free.
 
 ---
 


### PR DESCRIPTION
## Summary

- The PR template's `## Verified by` section keeps the GitHub handle but drops the `— built with <agent name + version>` footer, with one sentence tying it to Hard Rule #2.

## Why

One file asked for two opposite things: Hard Rule #2 forbids AI attribution in PR descriptions, while the template a hundred lines below demanded exactly that footer — and the `no-ai-attribution` commit-msg hook rejects the trailers the template tells agents to write. This is the one-line edit #154 (finding 7) asked for, resolving it the way the reporter already adopted locally: the handle is the accountability record, nothing else rides along.

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` passes locally (no code touched).
- [x] `ruff check src/ tests/` clean.
- [x] `mypy src/ --ignore-missing-imports` clean (no code touched).
- [x] `grep -rn "built with" AGENTS.md CONTRIBUTING.md .github/` — no remaining occurrence.

## Verified by

@acidkill.