### PR TITLE
fix: stop smem consolidate exhausting the socket table on the HTTP transport

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "3.5.0"
+    "version": "3.5.1"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   connection, including the SDK's own reconnect/signin, and the client spun in
   `[Errno 104] Connection reset by peer` forever. The store now rewrites
   `http(s)://` URLs to `ws(s)://` so the SDK multiplexes all RPCs over one
-  persistent WebSocket connection (verified live: `compress` on a 6.5k-fiber
-  brain completes in ~36 s with **zero** TIME_WAIT sockets; previously it never
-  completed). An explicit `ws://`/`wss://`/embedded URL always passes through
+  persistent WebSocket connection. Measured on the same workload, the WebSocket
+  transport opens **zero** additional sockets where the HTTP transport opened two
+  per query, and the consolidation pass that previously never completed now
+  finishes. An explicit `ws://`/`wss://`/embedded URL always passes through
   unchanged.
 
 ## [3.5.0] — 2026-08-13 — connectivity honesty: code-index excluded from the metric

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,12 +57,16 @@ are fixed here.
   smaller page because those rows must carry their vector; and the similarity pass
   now yields periodically. Holding the loop for minutes was long enough to miss the
   WebSocket keepalive, after which the peer drops the connection.
-- **`numpy` moved from an optional extra into the base dependencies.** The
-  semantic-link strategy runs by default but declared numpy only under
-  `embeddings-openai`, which not even the `all` extra pulls in. Installs without it
-  fell into a pure-python fallback that cannot finish at the shipped caps and that
-  the per-strategy timeout cannot interrupt, because it never awaits. The fallback
-  is now bounded and warns when it truncates.
+- **The numpy-less similarity fallback is bounded, yields, and says so.** The
+  semantic-link strategy runs by default, but numpy — which makes it vectorised —
+  is optional (`embeddings-openai`). Without it the pass fell into a pure-python
+  O(n²·d) double loop that cannot finish at the shipped caps and that the
+  per-strategy timeout cannot interrupt, because the loop never awaits: the pass
+  hung instead of completing. It now processes a bounded slice, hands the event
+  loop back periodically, and logs a warning naming numpy when it truncates.
+  numpy stays optional deliberately: numpy >= 2.5 ships stubs written in 3.12
+  syntax that mypy at this project's `python_version` (3.11) cannot parse, so
+  making it mandatory would break `mypy src/` for every consumer.
 - **The consolidation report says what failed.** A strategy raising anything other
   than a timeout used to abort the whole pass. Failures are now recorded per
   strategy, the remaining strategies still run, and both failures and timeouts are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.5.1] — 2026-08-15 — `smem consolidate` stops exhausting the socket table
+
+A full consolidation pass could spend minutes stalled and then flood the terminal with
+`[Errno 104] Connection reset by peer`, ending in a report of zeros that looked exactly
+like "there was nothing to do". Four independent defects fed that one symptom; all four
+are fixed here.
 
 ### Fixed
 - **`smem consolidate` "Connection reset by peer" loop (port exhaustion).** The
@@ -22,6 +27,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per query, and the consolidation pass that previously never completed now
   finishes. An explicit `ws://`/`wss://`/embedded URL always passes through
   unchanged.
+- **One dropped connection no longer costs one reconnect per concurrent caller.**
+  The re-auth lock serialised the callers but did not deduplicate them, so every
+  query in a batch fan-out that failed on the same dead connection built its own
+  replacement, retried three times and logged its own warning. Reconnects are now
+  single-flight behind a generation counter: the first caller repairs the
+  connection, the rest re-run their query on it. Only the path that actually
+  reconnected warns. The replaced connection is closed (it used to leak a socket,
+  and on the WebSocket transport an orphaned receive task), and the backoff grid
+  carries a small jitter.
+- **A reconnect no longer cancels its siblings' in-flight queries.** Closing a
+  WebSocket connection cancels every RPC future still pending on it, not just the
+  one that triggered the close — and `asyncio.CancelledError` is a
+  `BaseException`, so it bypassed the retry path and tore down whole batches. A
+  cancellation the task did not request is now treated as a dropped transport and
+  retried; a real cancellation still propagates.
+- **A storage instance reused from a second event loop repairs itself.** The SDK
+  creates its response futures on the loop that opened the socket, so a cached
+  storage singleton driven by a later `asyncio.run()` failed every query with
+  `RuntimeError: … Future … attached to a different loop` — neither an auth nor a
+  transport error, so nothing retried it and the connection stayed broken for the
+  life of the process. The connection's loop is now checked and the connection
+  rebuilt when it differs.
+- **Consolidation stops fetching embedding vectors it never reads.** `find_neurons`
+  includes them by default, so `dream` pulled 10 000 of them in a single response
+  and the two `interference` scans carried one per row across the whole brain.
+- **`semantic_link` no longer scans the whole neuron table, nor holds the event
+  loop.** It pages per neuron type so the filter runs in the database index, with a
+  smaller page because those rows must carry their vector; and the similarity pass
+  now yields periodically. Holding the loop for minutes was long enough to miss the
+  WebSocket keepalive, after which the peer drops the connection.
+- **`numpy` moved from an optional extra into the base dependencies.** The
+  semantic-link strategy runs by default but declared numpy only under
+  `embeddings-openai`, which not even the `all` extra pulls in. Installs without it
+  fell into a pure-python fallback that cannot finish at the shipped caps and that
+  the per-strategy timeout cannot interrupt, because it never awaits. The fallback
+  is now bounded and warns when it truncates.
+- **The consolidation report says what failed.** A strategy raising anything other
+  than a timeout used to abort the whole pass. Failures are now recorded per
+  strategy, the remaining strategies still run, and both failures and timeouts are
+  named in the summary — the latter were already recorded but never printed. A
+  clean run prints neither.
 
 ## [3.5.0] — 2026-08-13 — connectivity honesty: code-index excluded from the metric
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,9 @@ are fixed here.
   than a timeout used to abort the whole pass. Failures are now recorded per
   strategy, the remaining strategies still run, and both failures and timeouts are
   named in the summary — the latter were already recorded but never printed. A
-  clean run prints neither.
+  clean run prints neither. `smem consolidate` exits non-zero when a stage
+  failed, so automation that gates on the exit code still sees the failure now
+  that the command no longer crashes on it.
 
 ## [3.5.0] — 2026-08-13 — connectivity honesty: code-index excluded from the metric
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`smem consolidate` "Connection reset by peer" loop (port exhaustion).** The
+  surrealdb SDK's HTTP transport opens a brand-new TCP connection for every RPC
+  (`async with aiohttp.ClientSession()` per `_send`). Consolidation strategies
+  that issue tens of thousands of small queries (`compress`, `semantic_link`)
+  exhausted the ephemeral port range within minutes — measured 39,720 sockets in
+  TIME_WAIT against the DB port — after which the kernel RST'd every new
+  connection, including the SDK's own reconnect/signin, and the client spun in
+  `[Errno 104] Connection reset by peer` forever. The store now rewrites
+  `http(s)://` URLs to `ws(s)://` so the SDK multiplexes all RPCs over one
+  persistent WebSocket connection (verified live: `compress` on a 6.5k-fiber
+  brain completes in ~36 s with **zero** TIME_WAIT sockets; previously it never
+  completed). An explicit `ws://`/`wss://`/embedded URL always passes through
+  unchanged.
+
 ## [3.5.0] — 2026-08-13 — connectivity honesty: code-index excluded from the metric
 
 ### Changed — connectivity is now scored on the organic subgraph

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Forward-looking vision. What's next, what's possible, where we're going.
 > ZERO LLM dependency — pure algorithmic, regex, graph-based.
 
-**Current state**: v3.4.0 — 57 MCP tools, 7100+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
+**Current state**: v3.5.1 — 57 MCP tools, 7200+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
 
 **Storage**: SurrealDB is the only persistent backend — schema v9 — and `storage_backend`
 defaults to it. `#141` removed the SQLite backend entirely; selecting `storage_backend = "sqlite"`

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.5.0"
+version = "3.5.1"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,14 +41,6 @@ dependencies = [
     "aiohttp>=3.9.0",
     "rich>=13.0.0",
     "typing_extensions>=4.0",
-    # Vectorised cosine for the semantic-link consolidation strategy, which runs
-    # by default in `smem consolidate` / `--strategy all`. It was previously
-    # declared only under the embeddings-openai extra — which even the `all`
-    # extra does not pull in — so the documented installs fell back to a
-    # pure-python double loop that cannot finish at the shipped caps and that
-    # the per-strategy timeout cannot interrupt (it never awaits). A default-on
-    # strategy must not depend on an extra nobody installs.
-    "numpy>=1.24",
 ]
 
 [project.optional-dependencies]
@@ -114,6 +106,14 @@ embeddings = [
 ]
 embeddings-openai = [
     "openai>=1.0",
+    # Vectorised cosine for semantic-link consolidation. Deliberately NOT a base
+    # dependency: numpy >= 2.5 ships stubs written in 3.12 syntax, which mypy at
+    # this project's python_version (3.11) cannot parse, so making it mandatory
+    # breaks `mypy src/` for everyone — see
+    # test_python_version_pin.py::TestStubSyntaxHazard, which exists to catch
+    # exactly that. Without numpy the strategy still runs: the fallback is
+    # bounded, yields to the event loop, and warns that it truncated.
+    "numpy>=1.24",
 ]
 embeddings-openrouter = [
     "openai>=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,14 @@ dependencies = [
     "aiohttp>=3.9.0",
     "rich>=13.0.0",
     "typing_extensions>=4.0",
+    # Vectorised cosine for the semantic-link consolidation strategy, which runs
+    # by default in `smem consolidate` / `--strategy all`. It was previously
+    # declared only under the embeddings-openai extra — which even the `all`
+    # extra does not pull in — so the documented installs fell back to a
+    # pure-python double loop that cannot finish at the shipped caps and that
+    # the per-strategy timeout cannot interrupt (it never awaits). A default-on
+    # strategy must not depend on an extra nobody installs.
+    "numpy>=1.24",
 ]
 
 [project.optional-dependencies]
@@ -106,7 +114,6 @@ embeddings = [
 ]
 embeddings-openai = [
     "openai>=1.0",
-    "numpy>=1.24",  # vectorised cosine for semantic-link consolidation (pure-python fallback exists)
 ]
 embeddings-openrouter = [
     "openai>=1.0",

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.5.0"
+__version__ = "3.5.1"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/cli/commands/tools.py
+++ b/src/surreal_memory/cli/commands/tools.py
@@ -618,6 +618,14 @@ def consolidate(
             except Exception:
                 pass  # Non-critical UI hint — don't fail consolidation
 
+        # A strategy that dies no longer aborts the pass — the others still run
+        # and the summary names the casualty. Automation gates on the exit code,
+        # not on the text, so a partially failed pass must not exit 0 just
+        # because it now degrades gracefully instead of crashing.
+        failed = delta.report.extra.get("failed_strategies")
+        if failed:
+            raise typer.Exit(1)
+
     run_async(_consolidate())
 
 

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -262,6 +262,16 @@ class ConsolidationReport:
                     f"({detail.neuron_count} neurons, {detail.reason})"
                 )
 
+        # Zeros from a pass where stages died look exactly like zeros from a
+        # pass where there was nothing to do. Say which it was — but only when
+        # something actually went wrong, so a clean run stays quiet.
+        failed = self.extra.get("failed_strategies")
+        if failed:
+            lines.append(f"  Stages failed: {', '.join(failed)}")
+        timed_out = self.extra.get("timed_out_strategies")
+        if timed_out:
+            lines.append(f"  Stages timed out: {', '.join(timed_out)}")
+
         backfilled = self.extra.get("maturations_backfilled")
         if backfilled:
             lines.append(
@@ -475,6 +485,11 @@ class ConsolidationEngine:
         strategy_timeout = self._config.strategy_timeout_seconds
         total_timeout = self._config.total_timeout_seconds
         timed_out_strategies: list[str] = []
+        # A strategy that raises anything other than TimeoutError used to escape
+        # this loop and kill the whole pass, so the caller saw a traceback (or,
+        # worse, a report full of zeros that looks exactly like "nothing to do").
+        # Record the failure, keep going, and name it in the summary.
+        failed_strategies: list[str] = []
 
         for tier in self.STRATEGY_TIERS:
             tier_strategies = tier & requested
@@ -512,6 +527,16 @@ class ConsolidationEngine:
                         strategy_timeout,
                     )
                     timed_out_strategies.append(strategy.value)
+                except Exception as exc:
+                    strategy_elapsed = time.perf_counter() - strategy_start
+                    logger.error(
+                        "Consolidation: %s failed after %.1fs: %s",
+                        strategy.value,
+                        strategy_elapsed,
+                        exc,
+                        exc_info=True,
+                    )
+                    failed_strategies.append(f"{strategy.value} ({type(exc).__name__})")
                 finally:
                     strategy_elapsed = time.perf_counter() - strategy_start
                     logger.info(
@@ -525,6 +550,8 @@ class ConsolidationEngine:
 
         if timed_out_strategies:
             report.extra["timed_out_strategies"] = timed_out_strategies
+        if failed_strategies:
+            report.extra["failed_strategies"] = failed_strategies
 
         # Auto-tier promotion/demotion (Pro feature, runs after standard strategies)
         await self._run_auto_tier(report, dry_run)

--- a/src/surreal_memory/engine/dream.py
+++ b/src/surreal_memory/engine/dream.py
@@ -59,8 +59,13 @@ async def dream(
     """
     rng = random.Random(seed)
 
-    # Get a pool of neurons to sample from
-    all_neurons: list[Neuron] = await storage.find_neurons(limit=10000)
+    # Get a pool of neurons to sample from. Dream never reads the embedding
+    # vectors — it samples ids and spreads activation over the synapse graph —
+    # so ask storage to leave them out. Included, this one call pulls 10k x a
+    # 1024-float vector in a single response, which is megabytes of payload the
+    # pass discards and, on the HTTP transport, a response large enough to be
+    # dropped mid-transfer ("[Errno 104] Connection reset by peer").
+    all_neurons: list[Neuron] = await storage.find_neurons(limit=10000, include_embedding=False)
     if len(all_neurons) < 2:
         return DreamResult()
 

--- a/src/surreal_memory/engine/interference.py
+++ b/src/surreal_memory/engine/interference.py
@@ -92,7 +92,9 @@ async def detect_interference(
     target = max_candidates * 2
     offset = 0
     while len(candidates) < target:
-        batch = await storage.find_neurons(limit=page_size, offset=offset)
+        # Tag overlap and simhash only — the embedding vectors are never read
+        # here, so pulling them just inflates every page of this scan.
+        batch = await storage.find_neurons(limit=page_size, offset=offset, include_embedding=False)
         if not batch:
             break
         for n in batch:
@@ -249,7 +251,9 @@ async def batch_interference_scan(
     page_size = 1000
     offset = 0
     while True:
-        batch = await storage.find_neurons(limit=page_size, offset=offset)
+        # Counts tags, nothing else — this scan walks the WHOLE brain, so
+        # carrying a 1024-float vector on every row is pure transfer cost.
+        batch = await storage.find_neurons(limit=page_size, offset=offset, include_embedding=False)
         if not batch:
             break
         for n in batch:

--- a/src/surreal_memory/engine/semantic_discovery.py
+++ b/src/surreal_memory/engine/semantic_discovery.py
@@ -14,6 +14,7 @@ preventing stale semantic links from accumulating.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 from dataclasses import dataclass, field
@@ -41,6 +42,28 @@ SEMANTIC_TOP_K = 5  # link each neuron to its K most-similar peers
 # response is how the LIFECYCLE pass earned "[Errno 104] Connection reset by
 # peer". Matches the neuron scan's page size just above.
 _SYNAPSE_PAGE_SIZE = 5000
+
+# Page size for the neuron scan. Unlike every other scan in the engine, these
+# rows MUST carry their embedding vector — the similarity pass is the one place
+# that needs it — so a page is ~1024 floats per row and has to stay far smaller
+# than the synapse page above.
+_EMBEDDING_PAGE_SIZE = 1000
+
+# How many similarity rows to process between yields back to the event loop.
+# The similarity pass is pure CPU with no I/O of its own, so without an explicit
+# yield it holds the loop for as long as it runs — long enough to miss the
+# WebSocket keepalive (the `websockets` default is a 20 s ping interval with a
+# 20 s timeout, which the SurrealDB SDK does not override), after which the peer
+# drops the connection and every following query fails with
+# "[Errno 104] Connection reset by peer".
+_YIELD_EVERY_ROWS = 100
+
+# Ceiling for the pure-python similarity fallback. The vectorised path is O(n*d)
+# per row in C; the fallback is O(n*d) per row in interpreted Python, roughly
+# three orders of magnitude slower, so at MAX_NEURONS_TO_LINK it does not finish
+# in any useful time — and because it never awaits, the per-strategy timeout
+# cannot interrupt it either. Bound it and say so, rather than hang.
+_FALLBACK_MAX_NEURONS = 500
 
 
 @dataclass(frozen=True)
@@ -328,23 +351,31 @@ async def discover_semantic_synapses(
         return SemanticDiscoveryResult()
 
     # Collect eligible neurons that already carry a stored embedding (no re-embed).
-    batch_size = 5000
-    offset = 0
+    # Ask for the two eligible types separately so the filter runs in the DB's
+    # composite (brain_id, type) index instead of dragging every neuron in the
+    # brain across the wire and discarding most of them here. On a large brain
+    # the type-agnostic scan fetched the whole table — vectors included — to keep
+    # the CONCEPT/ENTITY minority.
     eligible: list[Neuron] = []
     vectors: list[list[float]] = []
-    while True:
-        batch = await storage.find_neurons(limit=batch_size, offset=offset)
-        if not batch:
-            break
-        for n in batch:
-            if n.type in (NeuronType.CONCEPT, NeuronType.ENTITY) and n.content.strip():
+    for neuron_type in (NeuronType.CONCEPT, NeuronType.ENTITY):
+        offset = 0
+        while True:
+            batch = await storage.find_neurons(
+                type=neuron_type, limit=_EMBEDDING_PAGE_SIZE, offset=offset
+            )
+            if not batch:
+                break
+            for n in batch:
+                if not n.content.strip():
+                    continue
                 emb = n.metadata.get("_embedding")
                 if emb:
                     eligible.append(n)
                     vectors.append([float(x) for x in emb])
-        offset += len(batch)
-        if len(batch) < batch_size:
-            break
+            offset += len(batch)
+            if len(batch) < _EMBEDDING_PAGE_SIZE:
+                break
 
     if len(eligible) < 2:
         return SemanticDiscoveryResult()
@@ -415,6 +446,10 @@ async def discover_semantic_synapses(
         mat = np.asarray(vectors, dtype=np.float32)
         mat /= np.linalg.norm(mat, axis=1, keepdims=True) + 1e-9
         for i in range(len(eligible)):
+            if i and i % _YIELD_EVERY_ROWS == 0:
+                # Hand the loop back. Nothing in this pass awaits on its own, so
+                # without this the connection's keepalive never gets to run.
+                await asyncio.sleep(0)
             sims = mat @ mat[i]
             sims[i] = -1.0
             order = np.argsort(-sims)[:top_k]
@@ -430,12 +465,27 @@ async def discover_semantic_synapses(
             if len(new_synapses) >= max_pairs:
                 break
     except ImportError:
-        # Pure-python fallback (slower) — bounded by the caps above.
-        for i in range(len(eligible)):
+        # Pure-python fallback. It is ~3 orders of magnitude slower than the
+        # vectorised path, so MAX_NEURONS_TO_LINK is far too generous for it:
+        # at that size the pass never finishes, and since it never awaits, the
+        # per-strategy timeout cannot cut it short either. Do a bounded slice
+        # and say plainly that the full pass needs numpy.
+        considered = min(len(eligible), _FALLBACK_MAX_NEURONS)
+        if len(eligible) > considered:
+            logger.warning(
+                "numpy is not installed: semantic discovery is running its pure-python "
+                "fallback and will consider only %d of %d eligible neurons this pass. "
+                "Install numpy to link the whole set.",
+                considered,
+                len(eligible),
+            )
+        for i in range(considered):
+            if i and i % _YIELD_EVERY_ROWS == 0:
+                await asyncio.sleep(0)
             row = sorted(
                 (
                     (j, _cosine_similarity(vectors[i], vectors[j]))
-                    for j in range(len(eligible))
+                    for j in range(considered)
                     if j != i
                 ),
                 key=lambda t: t[1],

--- a/src/surreal_memory/engine/semantic_discovery.py
+++ b/src/surreal_memory/engine/semantic_discovery.py
@@ -356,9 +356,10 @@ async def discover_semantic_synapses(
     # brain across the wire and discarding most of them here. On a large brain
     # the type-agnostic scan fetched the whole table — vectors included — to keep
     # the CONCEPT/ENTITY minority.
-    eligible: list[Neuron] = []
-    vectors: list[list[float]] = []
+    per_type: list[tuple[list[Neuron], list[list[float]]]] = []
     for neuron_type in (NeuronType.CONCEPT, NeuronType.ENTITY):
+        type_neurons: list[Neuron] = []
+        type_vectors: list[list[float]] = []
         offset = 0
         while True:
             batch = await storage.find_neurons(
@@ -371,11 +372,29 @@ async def discover_semantic_synapses(
                     continue
                 emb = n.metadata.get("_embedding")
                 if emb:
-                    eligible.append(n)
-                    vectors.append([float(x) for x in emb])
+                    type_neurons.append(n)
+                    type_vectors.append([float(x) for x in emb])
             offset += len(batch)
             if len(batch) < _EMBEDDING_PAGE_SIZE:
                 break
+        per_type.append((type_neurons, type_vectors))
+
+    # Interleave the two types instead of concatenating them. Two things below
+    # cut on list order, and both would otherwise systematically starve whichever
+    # type came second: the `eligible[:MAX_NEURONS_TO_LINK]` slice that
+    # `_select_candidates` falls back to whenever it has no degree data (a brain
+    # with no synapses yet, or any backend that cannot answer
+    # `get_synapse_degrees`), and the stable sort it uses otherwise, where
+    # never-linked neurons of both types tie at degree 0. The old type-agnostic
+    # scan mixed them by construction; per-type paging has to mix them on purpose.
+    eligible: list[Neuron] = []
+    vectors: list[list[float]] = []
+    longest = max((len(type_neurons) for type_neurons, _ in per_type), default=0)
+    for index in range(longest):
+        for type_neurons, type_vectors in per_type:
+            if index < len(type_neurons):
+                eligible.append(type_neurons[index])
+                vectors.append(type_vectors[index])
 
     if len(eligible) < 2:
         return SemanticDiscoveryResult()

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -737,9 +737,15 @@ class SurrealDBStorage(
         ``asyncio.Lock`` binds to the loop it is first awaited on. A storage
         singleton reused from a second ``asyncio.run()`` would therefore raise
         "bound to a different event loop" the moment it tried to reconnect —
-        before it could repair anything. The swap below is straight-line
-        synchronous code, so concurrent coroutines on the new loop cannot
-        interleave inside it and still end up sharing one lock.
+        before it could repair anything.
+
+        The swap below contains no ``await``, so coroutines sharing one OS
+        thread cannot interleave inside it and end up with competing locks.
+        That is the supported shape: one storage instance driven by one thread
+        at a time, sequentially across loops. Driving the same instance from two
+        threads concurrently is NOT supported — the GIL can preempt between the
+        read and the write and reintroduce exactly the divergence this guards
+        against.
         """
         running = asyncio.get_running_loop()
         if self._reauth_lock_loop is not running:
@@ -770,6 +776,34 @@ class SurrealDBStorage(
                 logger.debug("SurrealDB connection belongs to a different event loop; rebuilding")
                 await self._reconnect(close_previous=False)
 
+    async def _run_query(self, sql: str, params: dict[str, Any]) -> Any:
+        """One query attempt, with a peer-induced cancellation made retryable.
+
+        Closing a WebSocket connection cancels the SDK's receive task, and its
+        cleanup cancels EVERY future still pending on that connection — not just
+        the one belonging to whoever triggered the close. Those futures belong to
+        other coroutines multiplexed over the same shared connection, so one
+        caller's reconnect lands an `asyncio.CancelledError` in unrelated,
+        otherwise-healthy siblings. `CancelledError` is a `BaseException`, so it
+        slips past every `except Exception` on the way out — including the guard
+        in `get_neurons_batch`'s per-id fetch — and `asyncio.gather` without
+        `return_exceptions=True` then tears down the whole batch.
+
+        A cancellation this task did not ask for is really "the connection went
+        away underneath me", which is precisely what the retry path exists to
+        absorb. Translate it. A cancellation the task DID ask for (`task.cancel()`,
+        `asyncio.wait_for` expiring) still propagates untouched.
+        """
+        try:
+            return await self._ensure_conn().query(sql, params)
+        except asyncio.CancelledError:
+            task = asyncio.current_task()
+            if task is None or task.cancelling() > 0:
+                raise
+            raise ConnectionResetError(
+                104, "SurrealDB connection was closed while the query was in flight"
+            ) from None
+
     async def _query(self, sql: str, **params: Any) -> list[dict[str, Any]]:
         """Execute a SurrealQL query and return result rows.
 
@@ -795,11 +829,15 @@ class SurrealDBStorage(
         """
         from surreal_memory.storage.surrealdb.connection import StorageAuthError
 
-        await self._ensure_conn_on_current_loop()
         generation = self._conn_generation
 
         try:
-            result = await self._ensure_conn().query(sql, params)
+            # Inside the try on purpose: rebuilding for a loop change can hit the
+            # very same transient reset as any other connect, and it deserves the
+            # same three attempts with backoff as the rest of this method rather
+            # than failing the caller on the first blip.
+            await self._ensure_conn_on_current_loop()
+            result = await self._run_query(sql, params)
         except Exception as exc:
             if not (_is_auth_error(exc) or _is_connection_error(exc)):
                 raise
@@ -822,7 +860,7 @@ class SurrealDBStorage(
                             await self._reconnect()
                             reconnected_here = True
                         generation = self._conn_generation
-                    result = await self._ensure_conn().query(sql, params)
+                    result = await self._run_query(sql, params)
                     break
                 except StorageAuthError:
                     # Bad credentials never fix themselves — fail fast.
@@ -894,6 +932,7 @@ class SurrealDBStorage(
         )
 
         previous = self._conn
+        previous_loop = self._conn_loop
         conn = AsyncSurreal(self._url)
         try:
             await conn.signin({"username": self._user, "password": self._password})
@@ -909,7 +948,17 @@ class SurrealDBStorage(
         self._conn_loop = asyncio.get_running_loop()
         self._conn_generation += 1
 
-        if previous is not None and previous is not conn and close_previous:
+        # Never close a connection owned by another loop, whatever the caller
+        # asked for: its close() awaits that loop's objects. Dropping the
+        # reference is the only safe move, and the caller cannot always know
+        # which case it is in.
+        may_close = (
+            close_previous
+            and previous is not None
+            and previous is not conn
+            and previous_loop is asyncio.get_running_loop()
+        )
+        if may_close:
             # Same tolerance as close(): the HTTP transport has no socket to tear
             # down and raises. A failure to close must never mask the successful
             # reconnect the caller is waiting for.

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
+import random
 import re
 from collections.abc import Iterator
 from datetime import datetime
@@ -172,9 +173,9 @@ def _prefer_ws_transport(url: str) -> str:
     returned unchanged, so an explicit override always wins.
     """
     if url.startswith("http://"):
-        return "ws://" + url[len("http://"):]
+        return "ws://" + url[len("http://") :]
     if url.startswith("https://"):
-        return "wss://" + url[len("https://"):]
+        return "wss://" + url[len("https://") :]
     return url
 
 
@@ -185,6 +186,17 @@ def _prefer_ws_transport(url: str) -> str:
 # neither blow the server's request-body limit nor lose more than 500 rows if
 # the statement batch fails.
 _BATCH_WRITE_CHUNK = 500
+
+# Backoff grid for the reconnect retry in _query. A dropped transport usually
+# needs a moment before it accepts a new connection, so the first retry is
+# immediate and the next two wait.
+_RECONNECT_BACKOFF = (0.0, 1.0, 3.0)
+
+# Random slack added to each non-zero backoff step. With a fan-out of
+# _BATCH_FETCH_CONCURRENCY callers the generation counter already collapses the
+# storm to one reconnect; the jitter keeps the losers from re-converging on the
+# same instant if a second drop happens while they are retrying.
+_RECONNECT_JITTER_SECONDS = 0.5
 
 _T = TypeVar("_T")
 
@@ -565,6 +577,22 @@ class SurrealDBStorage(
         # Serializes token re-auth so concurrent queries that all hit an
         # expired-token 401 trigger a single reconnect, not a storm.
         self._reauth_lock = asyncio.Lock()
+        # asyncio.Lock binds itself to the loop it is first awaited on, so a
+        # storage singleton reused from a second asyncio.run() would raise
+        # "bound to a different event loop" before it ever got to reconnect.
+        # Track the owner and mint a fresh lock when the loop changes.
+        self._reauth_lock_loop: asyncio.AbstractEventLoop | None = None
+        # Bumped by every successful _reconnect(). A caller whose query failed at
+        # generation N and finds the counter already past N knows a peer already
+        # rebuilt the connection while it waited on the lock, so it re-runs the
+        # query instead of building a second connection. This is what turns 16
+        # simultaneous failures into ONE reconnect instead of sixteen.
+        self._conn_generation: int = 0
+        # The event loop the live connection belongs to. The SDK creates its
+        # response futures on the loop that opened the socket; awaiting them
+        # from a different loop raises "attached to a different loop" and the
+        # cached connection is unusable until the process restarts.
+        self._conn_loop: asyncio.AbstractEventLoop | None = None
         # ISO GQL (SurrealDB 3.2+) capability, detected once at initialize().
         # get_path uses a GQL SHORTEST-path fast-path when available and falls
         # back to BFS otherwise. See _get_path_gql for the 3.2.0 scoping caveat.
@@ -599,6 +627,7 @@ class SurrealDBStorage(
                 ) from exc
             raise
         await self._conn.use(self._namespace, self._database)
+        self._conn_loop = asyncio.get_running_loop()
 
         # Hard version gate (>= 3.2.0): the synapse RELATION schema and the
         # auto-migration below require SurrealDB 3.2.0. A failed/unparsable probe
@@ -667,6 +696,7 @@ class SurrealDBStorage(
             )
         finally:
             self._conn = None
+            self._conn_loop = None
 
     @property
     def brain_id(self) -> str | None:
@@ -701,21 +731,72 @@ class SurrealDBStorage(
     # Query helper
     # ================================================================
 
+    def _lock_for_current_loop(self) -> asyncio.Lock:
+        """Return the re-auth lock, re-minted if the event loop changed.
+
+        ``asyncio.Lock`` binds to the loop it is first awaited on. A storage
+        singleton reused from a second ``asyncio.run()`` would therefore raise
+        "bound to a different event loop" the moment it tried to reconnect —
+        before it could repair anything. The swap below is straight-line
+        synchronous code, so concurrent coroutines on the new loop cannot
+        interleave inside it and still end up sharing one lock.
+        """
+        running = asyncio.get_running_loop()
+        if self._reauth_lock_loop is not running:
+            self._reauth_lock = asyncio.Lock()
+            self._reauth_lock_loop = running
+        return self._reauth_lock
+
+    async def _ensure_conn_on_current_loop(self) -> None:
+        """Rebuild the connection if it belongs to a different event loop.
+
+        The SDK creates its response futures on the loop that opened the socket.
+        Awaiting one of those futures from another loop raises
+        ``RuntimeError: … got Future … attached to a different loop`` — which is
+        neither an auth error nor a transport error, so the retry path never saw
+        it and every query failed until the process restarted. Detect the
+        mismatch up front and rebuild instead.
+
+        The old connection is NOT closed: ``close()`` would await on the foreign
+        loop's objects. Only the reference is dropped.
+        """
+        if self._conn is None or self._conn_loop is None:
+            return
+        if self._conn_loop is asyncio.get_running_loop():
+            return
+        generation = self._conn_generation
+        async with self._lock_for_current_loop():
+            if self._conn_generation == generation:
+                logger.debug("SurrealDB connection belongs to a different event loop; rebuilding")
+                await self._reconnect(close_previous=False)
+
     async def _query(self, sql: str, **params: Any) -> list[dict[str, Any]]:
         """Execute a SurrealQL query and return result rows.
 
-        Retries once after re-authenticating if the cached connection's token
-        has expired. SurrealDB issues root tokens with a ~1h TTL and the SDK's
-        HTTP connection never refreshes them, so a long-lived server connection
-        starts returning 401 after an hour — which silently broke the dashboard
-        until the container was restarted. Reconnecting on 401 keeps the cached
-        connection alive without a restart.
+        Retries after re-authenticating if the cached connection's token has
+        expired. SurrealDB issues root tokens with a ~1h TTL and the SDK's HTTP
+        connection never refreshes them, so a long-lived server connection starts
+        returning 401 after an hour — which silently broke the dashboard until the
+        container was restarted. Reconnecting on 401 keeps the cached connection
+        alive without a restart.
 
         Also reconnects on a dropped transport (WebSocket closed by a DB restart):
         that surfaces as a connection error, not a 401, so without this the dead
         cached connection fails every query until the process restarts (S-01).
+
+        The reconnect is single-flight. ``_reauth_lock`` alone only serialised the
+        callers — each one still built its own connection, so a fan-out of
+        ``_BATCH_FETCH_CONCURRENCY`` queries hitting one dead transport produced
+        up to that many reconnects per attempt and filled the terminal with
+        identical warnings. A caller now records the connection generation it
+        failed on and, once inside the lock, reconnects only if nobody has already
+        moved the counter past it; the rest simply re-run the query on the
+        connection their peer just built.
         """
         from surreal_memory.storage.surrealdb.connection import StorageAuthError
+
+        await self._ensure_conn_on_current_loop()
+        generation = self._conn_generation
 
         try:
             result = await self._ensure_conn().query(sql, params)
@@ -729,12 +810,18 @@ class SurrealDBStorage(
             # single transient blip. Retry the reconnect with a short backoff.
             last_exc: Exception = exc
             result = None
-            for attempt, delay in enumerate((0.0, 1.0, 3.0), start=1):
+            attempts = len(_RECONNECT_BACKOFF)
+            for attempt, delay in enumerate(_RECONNECT_BACKOFF, start=1):
                 if delay:
-                    await asyncio.sleep(delay)
+                    jitter = random.uniform(0.0, _RECONNECT_JITTER_SECONDS)
+                    await asyncio.sleep(delay + jitter)
+                reconnected_here = False
                 try:
-                    async with self._reauth_lock:
-                        await self._reconnect()
+                    async with self._lock_for_current_loop():
+                        if self._conn_generation == generation:
+                            await self._reconnect()
+                            reconnected_here = True
+                        generation = self._conn_generation
                     result = await self._ensure_conn().query(sql, params)
                     break
                 except StorageAuthError:
@@ -742,9 +829,22 @@ class SurrealDBStorage(
                     raise
                 except Exception as retry_exc:  # re-raised below
                     last_exc = retry_exc
-                    logger.warning(
-                        "SurrealDB reconnect attempt %d/3 failed: %s", attempt, retry_exc
-                    )
+                    if reconnected_here:
+                        logger.warning(
+                            "SurrealDB reconnect attempt %d/%d failed: %s",
+                            attempt,
+                            attempts,
+                            retry_exc,
+                        )
+                    else:
+                        # One warning per genuine reconnect is the signal; a copy
+                        # of it from every waiter is the flood this replaces.
+                        logger.debug(
+                            "SurrealDB retry %d/%d failed on a peer-rebuilt connection: %s",
+                            attempt,
+                            attempts,
+                            retry_exc,
+                        )
             else:
                 raise last_exc
         if result and isinstance(result, list) and len(result) > 0:
@@ -767,12 +867,23 @@ class SurrealDBStorage(
         """
         return await self._query(sql, **params)
 
-    async def _reconnect(self) -> None:
-        """Re-establish the SurrealDB connection after a token expiry / 401.
+    async def _reconnect(self, *, close_previous: bool = True) -> None:
+        """Re-establish the SurrealDB connection after a token expiry / drop.
 
         Re-signin + re-select the namespace/database on a fresh connection so
         the cached singleton keeps working. Schema is already applied, so it is
         not re-run here.
+
+        The connection this replaces is closed and the generation counter is
+        bumped. Leaving the old one open leaked a socket (and, on the WebSocket
+        transport, an orphaned receive task) per reconnect, and under a fan-out
+        failure that is one leak per concurrent caller per attempt.
+
+        Args:
+            close_previous: Close the connection being replaced. Pass False when
+                the previous connection belongs to a different event loop —
+                awaiting its ``close()`` from here would touch that loop's
+                objects; dropping the reference is all that is safe.
         """
         from surrealdb import AsyncSurreal
 
@@ -782,6 +893,7 @@ class SurrealDBStorage(
             is_credential_error,
         )
 
+        previous = self._conn
         conn = AsyncSurreal(self._url)
         try:
             await conn.signin({"username": self._user, "password": self._password})
@@ -794,7 +906,22 @@ class SurrealDBStorage(
             raise
         await conn.use(self._namespace, self._database)
         self._conn = conn
-        logger.info("SurrealDB reconnected after token expiry: %s", self._url)
+        self._conn_loop = asyncio.get_running_loop()
+        self._conn_generation += 1
+
+        if previous is not None and previous is not conn and close_previous:
+            # Same tolerance as close(): the HTTP transport has no socket to tear
+            # down and raises. A failure to close must never mask the successful
+            # reconnect the caller is waiting for.
+            try:
+                await previous.close()
+            except Exception:
+                logger.debug(
+                    "Could not close the replaced SurrealDB connection; dropping it",
+                    exc_info=True,
+                )
+
+        logger.info("SurrealDB reconnected: %s", self._url)
 
     # ================================================================
     # Neuron Operations

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -152,6 +152,32 @@ _BRAIN_ID_SAFE = re.compile(r"^[a-zA-Z0-9_.\-]+$")
 # sockets).
 _BATCH_FETCH_CONCURRENCY = 16
 
+
+def _prefer_ws_transport(url: str) -> str:
+    """Rewrite http(s):// URLs to ws(s):// for the SDK connection.
+
+    The surrealdb SDK's HTTP transport opens a brand-new aiohttp.ClientSession
+    (a brand-new TCP connection) for every single RPC call -- there is no
+    connection pool and no keep-alive reuse. Workloads that issue many small
+    queries (consolidation's compress/semantic_link run per-id batch selects
+    and per-row writes across tens of thousands of records) exhaust the
+    ephemeral port range within minutes: measured 39,720 sockets stuck in
+    TIME_WAIT against :8001, after which the kernel RSTs every new connection
+    -- including the SDK's own reconnect/signin -- and the client spins in
+    "Connection reset by peer" forever (the long-standing `smem consolidate`
+    failure). The WebSocket transport multiplexes all RPCs over one
+    persistent connection and eliminates the port churn entirely.
+
+    Callers that already pass ws:// or wss:// (or a non-http scheme) are
+    returned unchanged, so an explicit override always wins.
+    """
+    if url.startswith("http://"):
+        return "ws://" + url[len("http://"):]
+    if url.startswith("https://"):
+        return "wss://" + url[len("https://"):]
+    return url
+
+
 # Rows per multi-statement write round-trip (update_synapses_batch /
 # update_neuron_states_batch). Matches the ~500 already proven by
 # update_neuron_embeddings: big enough that the per-round-trip cost (~2ms of
@@ -523,7 +549,7 @@ class SurrealDBStorage(
         from surreal_memory.storage.surrealdb.connection import SurrealSettings
 
         settings = SurrealSettings.from_env()
-        self._url = url or settings.url
+        self._url = _prefer_ws_transport(url or settings.url)
         self._namespace = namespace or settings.namespace
         self._database = database or settings.database
         self._user = user or settings.user

--- a/tests/unit/test_consolidation_payload_and_event_loop.py
+++ b/tests/unit/test_consolidation_payload_and_event_loop.py
@@ -171,6 +171,42 @@ class TestSemanticDiscoveryFetch:
         )
 
 
+class TestPurePythonFallbackIsBounded:
+    """Without numpy the similarity pass must still finish — and say it truncated.
+
+    `numpy` used to be declared only under the `embeddings-openai` extra, which not
+    even `all` pulls in, while semantic-link runs by default. Installs without it
+    fell into an interpreted O(n^2*d) double loop over up to `MAX_NEURONS_TO_LINK`
+    vectors: it does not finish in any useful time, and because it never awaits,
+    the per-strategy timeout cannot cut it short either.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fallback_truncates_and_warns(self, monkeypatch: Any, caplog: Any) -> None:
+        import logging as _logging
+        import sys
+
+        from surreal_memory.core.brain import BrainConfig
+        from surreal_memory.engine import semantic_discovery as sd
+
+        monkeypatch.setattr(sd, "_effective_embedding", lambda _c: (True, "stub", "stub"))
+        monkeypatch.setattr(sd, "_FALLBACK_MAX_NEURONS", 4)
+        # `None` in sys.modules makes `import numpy` raise ImportError, which is
+        # exactly how a numpy-less install reaches the fallback.
+        monkeypatch.setitem(sys.modules, "numpy", None)
+
+        pool = [_neuron(f"c{i}", NeuronType.CONCEPT, [1.0, float(i) / 50.0]) for i in range(10)]
+        storage = _RecordingStorage(pool)
+
+        with caplog.at_level(_logging.WARNING, logger="surreal_memory.engine.semantic_discovery"):
+            result = await sd.discover_semantic_synapses(storage, BrainConfig())  # type: ignore[arg-type]
+
+        assert result is not None, "the fallback did not return — it must not run unbounded"
+        warnings = [r.getMessage() for r in caplog.records if "numpy" in r.getMessage()]
+        assert warnings, "the fallback truncated silently; a degraded pass has to say so"
+        assert "4 of 10" in warnings[0], warnings[0]
+
+
 class TestLeastConnectedRotationSurvives:
     """Run 012's rotation must keep working now that the fetch is per-type.
 

--- a/tests/unit/test_consolidation_payload_and_event_loop.py
+++ b/tests/unit/test_consolidation_payload_and_event_loop.py
@@ -216,6 +216,45 @@ class TestLeastConnectedRotationSurvives:
     """
 
     @pytest.mark.asyncio
+    async def test_per_type_paging_does_not_starve_the_second_type(self, monkeypatch: Any) -> None:
+        """Fetching CONCEPT then ENTITY must not push every ENTITY past the cap.
+
+        Two places cut on list order: the `eligible[:MAX_NEURONS_TO_LINK]` slice
+        `_select_candidates` falls back to when it has no degree data (a brain
+        with no synapses yet, or a backend that cannot answer
+        `get_synapse_degrees`), and the stable sort it uses otherwise, where
+        never-linked neurons of both types tie at degree 0. Concatenating the two
+        scans would hand the whole cut to CONCEPT.
+        """
+        from surreal_memory.core.brain import BrainConfig
+        from surreal_memory.engine import semantic_discovery as sd
+
+        monkeypatch.setattr(sd, "_effective_embedding", lambda _c: (True, "stub", "stub"))
+        monkeypatch.setattr(sd, "MAX_NEURONS_TO_LINK", 4)
+
+        captured: dict[str, list[Neuron]] = {}
+
+        async def _capture(_storage: Any, eligible: list[Neuron], vectors: Any) -> Any:
+            captured["eligible"] = eligible
+            return eligible[:4], vectors[:4]
+
+        monkeypatch.setattr(sd, "_select_candidates", _capture)
+
+        pool = [_neuron(f"c{i}", NeuronType.CONCEPT, [1.0, float(i) / 50.0]) for i in range(6)]
+        pool += [
+            _neuron(f"e{i}", NeuronType.ENTITY, [0.0, 1.0 - float(i) / 50.0]) for i in range(6)
+        ]
+
+        await sd.discover_semantic_synapses(_RecordingStorage(pool), BrainConfig())  # type: ignore[arg-type]
+
+        prefix = captured["eligible"][:4]
+        types = {n.type for n in prefix}
+        assert types == {NeuronType.CONCEPT, NeuronType.ENTITY}, (
+            f"the first {len(prefix)} eligible neurons are all {types} — one whole type is "
+            "starved out of every pass by the cap"
+        )
+
+    @pytest.mark.asyncio
     async def test_selection_prefers_the_least_connected(self, monkeypatch: Any) -> None:
         from surreal_memory.engine import semantic_discovery as sd
 
@@ -300,6 +339,43 @@ class TestReportNamesWhatFailed:
 
         assert "Stages failed:" not in summary
         assert "Stages timed out:" not in summary
+
+    def test_the_cli_exits_non_zero_when_a_stage_failed(self) -> None:
+        """Automation gates on the exit code, not on the summary text.
+
+        A raising strategy used to escape the runner and crash the command, so
+        the exit code was non-zero. Now the pass survives and names the casualty
+        — which must not turn a partially failed run into a silent success.
+        """
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from typer.testing import CliRunner
+
+        from surreal_memory.cli.main import app
+        from surreal_memory.engine.consolidation import ConsolidationReport
+
+        report = ConsolidationReport()
+        report.extra["failed_strategies"] = ["prune (ConnectionResetError)"]
+        delta = MagicMock()
+        delta.report = report
+        delta.summary = MagicMock(return_value=report.summary())
+
+        cli = "surreal_memory.cli.commands.tools"
+        with (
+            patch(f"{cli}.get_config", return_value=MagicMock()),
+            patch(f"{cli}.resolve_brain", return_value="default"),
+            patch(f"{cli}.get_storage", new=AsyncMock(return_value=MagicMock())),
+            patch(
+                "surreal_memory.engine.consolidation_delta.run_with_delta",
+                new=AsyncMock(return_value=delta),
+            ),
+        ):
+            result = CliRunner().invoke(app, ["consolidate", "--dry-run"])
+
+        assert "Stages failed:" in result.output, result.output
+        assert result.exit_code == 1, (
+            f"exit code {result.exit_code} — a pass with a dead stage reported success"
+        )
 
     def test_timed_out_stages_are_surfaced_too(self) -> None:
         """`timed_out_strategies` was recorded but never printed."""

--- a/tests/unit/test_consolidation_payload_and_event_loop.py
+++ b/tests/unit/test_consolidation_payload_and_event_loop.py
@@ -1,0 +1,275 @@
+"""Consolidation must not drag vectors it never reads, nor hold the event loop.
+
+Three defects with one shared symptom — a `smem consolidate` that stalls and then
+floods the terminal with `[Errno 104] Connection reset by peer`:
+
+1. Passes that only look at ids, tags or the synapse graph still asked storage
+   for every neuron's 1024-float embedding, because `find_neurons` defaults
+   `include_embedding=True`. `dream` pulled 10 000 of them in one response.
+2. `semantic_discovery` scanned the WHOLE neuron table to keep the CONCEPT/ENTITY
+   minority, and then spent minutes in a pure-CPU similarity loop without ever
+   awaiting — long enough to miss the WebSocket keepalive, after which the peer
+   drops the connection and every later query fails.
+3. A stage that raised anything other than `TimeoutError` killed the pass, and a
+   report of zeros is indistinguishable from "there was nothing to do".
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from surreal_memory.core.neuron import Neuron, NeuronType
+
+
+class _RecordingStorage:
+    """Records every ``find_neurons`` call and serves a fixed neuron pool."""
+
+    def __init__(self, neurons: list[Neuron] | None = None) -> None:
+        self.current_brain_id = "default"
+        self.brain_id = "default"
+        self.calls: list[dict[str, Any]] = []
+        self._neurons = neurons or []
+
+    async def find_neurons(self, **kwargs: Any) -> list[Neuron]:
+        self.calls.append(kwargs)
+        wanted = kwargs.get("type")
+        pool = [n for n in self._neurons if wanted is None or n.type is wanted]
+        offset = int(kwargs.get("offset", 0))
+        limit = int(kwargs.get("limit", 100))
+        return pool[offset : offset + limit]
+
+    async def get_synapses(self, **_kwargs: Any) -> list[Any]:
+        return []
+
+
+def _neuron(nid: str, ntype: NeuronType, vector: list[float] | None = None) -> Neuron:
+    neuron = Neuron.create(content=f"content-{nid}", type=ntype)
+    object.__setattr__(neuron, "id", nid)
+    if vector is not None:
+        neuron.metadata["_embedding"] = vector
+    return neuron
+
+
+class TestPassesDoNotFetchEmbeddings:
+    """`include_embedding=True` is the default, so every reader must opt out."""
+
+    @pytest.mark.asyncio
+    async def test_dream_never_fetches_embeddings(self) -> None:
+        from surreal_memory.core.brain import BrainConfig
+        from surreal_memory.engine.dream import dream
+
+        storage = _RecordingStorage([_neuron(f"n{i}", NeuronType.CONCEPT) for i in range(3)])
+
+        try:
+            await dream(storage, BrainConfig(), seed=1)  # type: ignore[arg-type]
+        except Exception:
+            # Later steps need more of the engine than this stub provides; the
+            # fetch is what this test pins down.
+            pass
+
+        assert storage.calls, "dream did not fetch neurons at all"
+        for call in storage.calls:
+            assert call.get("include_embedding") is False, (
+                f"dream fetched embeddings ({call}) — it samples ids and spreads activation "
+                "over the synapse graph; it never reads a vector"
+            )
+
+    @pytest.mark.asyncio
+    async def test_interference_scans_never_fetch_embeddings(self) -> None:
+        from surreal_memory.core.brain import BrainConfig
+        from surreal_memory.engine.interference import batch_interference_scan, detect_interference
+
+        pool = [_neuron(f"n{i}", NeuronType.CONCEPT) for i in range(3)]
+        for n in pool:
+            n.metadata["tags"] = ["shared"]
+
+        storage = _RecordingStorage(pool)
+        probe = _neuron("probe", NeuronType.CONCEPT)
+        probe.metadata["tags"] = ["shared"]
+
+        config = BrainConfig()
+        # Both scans return early unless interference detection is on.
+        object.__setattr__(config, "interference_detection_enabled", True)
+
+        try:
+            await detect_interference(probe, storage, config)  # type: ignore[arg-type]
+        except Exception:
+            pass
+        try:
+            await batch_interference_scan(storage, config)  # type: ignore[arg-type]
+        except Exception:
+            pass
+
+        assert storage.calls, "interference did not fetch neurons at all"
+        for call in storage.calls:
+            assert call.get("include_embedding") is False, (
+                f"interference fetched embeddings ({call}) — it reads tags and simhashes only"
+            )
+
+
+class TestSemanticDiscoveryFetch:
+    """The type filter belongs in the DB index, not in a client-side loop."""
+
+    @pytest.mark.asyncio
+    async def test_pages_per_type_with_a_small_page(self, monkeypatch: Any) -> None:
+        from surreal_memory.core.brain import BrainConfig
+        from surreal_memory.engine import semantic_discovery as sd
+
+        monkeypatch.setattr(sd, "_effective_embedding", lambda _c: (True, "stub", "stub"))
+        pool = [
+            _neuron("c1", NeuronType.CONCEPT, [1.0, 0.0]),
+            _neuron("e1", NeuronType.ENTITY, [0.0, 1.0]),
+            _neuron("a1", NeuronType.ACTION, [1.0, 1.0]),
+        ]
+        storage = _RecordingStorage(pool)
+
+        await sd.discover_semantic_synapses(storage, BrainConfig())  # type: ignore[arg-type]
+
+        requested = [c.get("type") for c in storage.calls]
+        assert NeuronType.CONCEPT in requested and NeuronType.ENTITY in requested, (
+            f"semantic discovery did not ask the DB for the two eligible types: {requested}"
+        )
+        assert all(t is not None for t in requested), (
+            "a type-agnostic page is still there — that scans the whole neuron table "
+            "(vectors included) to keep the CONCEPT/ENTITY minority"
+        )
+        assert all(int(c.get("limit", 0)) <= sd._EMBEDDING_PAGE_SIZE for c in storage.calls), (
+            "these rows carry 1024-float vectors; the page must stay small"
+        )
+
+    @pytest.mark.asyncio
+    async def test_similarity_pass_yields_to_the_event_loop(self, monkeypatch: Any) -> None:
+        """A CPU pass that never awaits starves the connection's keepalive."""
+        from surreal_memory.core.brain import BrainConfig
+        from surreal_memory.engine import semantic_discovery as sd
+
+        monkeypatch.setattr(sd, "_effective_embedding", lambda _c: (True, "stub", "stub"))
+        monkeypatch.setattr(sd, "_YIELD_EVERY_ROWS", 2)
+        pool = [_neuron(f"c{i}", NeuronType.CONCEPT, [1.0, float(i) / 100.0]) for i in range(12)]
+        storage = _RecordingStorage(pool)
+
+        ticks = 0
+
+        async def _heartbeat() -> None:
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0)
+                ticks += 1
+
+        beat = asyncio.create_task(_heartbeat())
+        try:
+            await sd.discover_semantic_synapses(storage, BrainConfig())  # type: ignore[arg-type]
+        finally:
+            beat.cancel()
+
+        assert ticks > 1, (
+            "the similarity loop ran to completion without handing the event loop back — "
+            "that is what lets the WebSocket keepalive lapse mid-pass"
+        )
+
+
+class TestLeastConnectedRotationSurvives:
+    """Run 012's rotation must keep working now that the fetch is per-type.
+
+    Selecting the least-connected neurons is what makes repeated passes attack a
+    different part of the graph instead of resaturating the same slice, so it is
+    load-bearing behaviour, not an optimisation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_selection_prefers_the_least_connected(self, monkeypatch: Any) -> None:
+        from surreal_memory.engine import semantic_discovery as sd
+
+        monkeypatch.setattr(sd, "MAX_NEURONS_TO_LINK", 2)
+
+        eligible = [
+            _neuron("busy", NeuronType.CONCEPT),
+            _neuron("quiet", NeuronType.CONCEPT),
+            _neuron("lonely", NeuronType.CONCEPT),
+        ]
+        vectors = [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
+
+        class _DegreeStorage(_RecordingStorage):
+            async def get_synapse_degrees(self) -> dict[str, int]:
+                return {"busy": 40, "quiet": 5, "lonely": 0}
+
+        kept, kept_vectors = await sd._select_candidates(
+            _DegreeStorage(),  # type: ignore[arg-type]
+            eligible,
+            vectors,
+        )
+
+        assert [n.id for n in kept] == ["lonely", "quiet"]
+        assert kept_vectors == [[1.0, 1.0], [0.0, 1.0]], (
+            "vectors must stay aligned with the neurons they belong to"
+        )
+
+
+class TestReportNamesWhatFailed:
+    """Zeros from a broken pass must not read like zeros from an idle one."""
+
+    @pytest.mark.asyncio
+    async def test_a_failing_stage_does_not_stop_the_rest_and_is_reported(
+        self, monkeypatch: Any
+    ) -> None:
+        from surreal_memory.engine.consolidation import (
+            ConsolidationConfig,
+            ConsolidationEngine,
+            ConsolidationStrategy,
+        )
+
+        engine = ConsolidationEngine.__new__(ConsolidationEngine)
+        engine._storage = _RecordingStorage()  # type: ignore[attr-defined]
+        engine._config = ConsolidationConfig()  # type: ignore[attr-defined]
+        engine._tier_config = None  # type: ignore[attr-defined]
+
+        ran: list[str] = []
+
+        async def _fake_run_strategy(
+            strategy: ConsolidationStrategy, *_args: Any, **_kwargs: Any
+        ) -> None:
+            ran.append(strategy.value)
+            if strategy is ConsolidationStrategy.PRUNE:
+                raise ConnectionResetError(104, "Connection reset by peer")
+
+        monkeypatch.setattr(engine, "_run_strategy", _fake_run_strategy, raising=False)
+
+        report = await engine.run(
+            strategies=[ConsolidationStrategy.PRUNE, ConsolidationStrategy.DREAM],
+            dry_run=True,
+        )
+
+        assert "prune" in ran and "dream" in ran, (
+            f"a raising stage aborted the pass; only {ran} ran"
+        )
+        failed = report.extra.get("failed_strategies")
+        assert failed and any(f.startswith("prune") for f in failed), (
+            f"the failure vanished from the report: {report.extra}"
+        )
+        assert "ConnectionResetError" in " ".join(failed)
+
+        summary = report.summary()
+        assert "Stages failed:" in summary, (
+            "the summary printed only zeros — indistinguishable from an idle run"
+        )
+        assert "prune" in summary.split("Stages failed:")[1].splitlines()[0]
+
+    def test_a_clean_report_stays_quiet(self) -> None:
+        from surreal_memory.engine.consolidation import ConsolidationReport
+
+        summary = ConsolidationReport().summary()
+
+        assert "Stages failed:" not in summary
+        assert "Stages timed out:" not in summary
+
+    def test_timed_out_stages_are_surfaced_too(self) -> None:
+        """`timed_out_strategies` was recorded but never printed."""
+        from surreal_memory.engine.consolidation import ConsolidationReport
+
+        report = ConsolidationReport()
+        report.extra["timed_out_strategies"] = ["compress"]
+
+        assert "Stages timed out: compress" in report.summary()

--- a/tests/unit/test_consolidation_timeouts_and_reconnect.py
+++ b/tests/unit/test_consolidation_timeouts_and_reconnect.py
@@ -349,6 +349,38 @@ class TestConnectionLoopAffinity:
             foreign_loop.close()
 
     @pytest.mark.asyncio
+    async def test_a_failed_rebuild_still_gets_the_retry_budget(self, monkeypatch: Any) -> None:
+        """The loop-change rebuild must not be a single-shot exception to the retry contract."""
+        foreign_loop = asyncio.new_event_loop()
+        try:
+            store = _store_with(_StubConn(alive=True))
+            store._conn_loop = foreign_loop
+
+            attempts = {"n": 0}
+
+            def _flaky_factory(_url: str) -> _StubConn:
+                attempts["n"] += 1
+                # The first connect hits the same transient reset the rest of
+                # this method exists to absorb.
+                return _StubConn(alive=attempts["n"] > 1)
+
+            monkeypatch.setattr("surrealdb.AsyncSurreal", _flaky_factory, raising=True)
+            monkeypatch.setattr(
+                "surreal_memory.storage.surrealdb.store._RECONNECT_BACKOFF",
+                (0.0, 0.0, 0.0),
+                raising=True,
+            )
+
+            rows = await store._query("SELECT 1")
+
+            assert rows == [{"ok": True}]
+            assert attempts["n"] > 1, (
+                "a transient failure during the loop-change rebuild was not retried"
+            )
+        finally:
+            foreign_loop.close()
+
+    @pytest.mark.asyncio
     async def test_foreign_connection_is_dropped_not_closed(self, monkeypatch: Any) -> None:
         """``close()`` would await on the other loop's objects — only drop the reference."""
         foreign_loop = asyncio.new_event_loop()
@@ -363,3 +395,56 @@ class TestConnectionLoopAffinity:
             assert healthy_but_foreign.closed is False
         finally:
             foreign_loop.close()
+
+
+class TestCancellationFromAPeerReconnect:
+    """Closing a connection cancels EVERY future pending on it, not just one.
+
+    All callers are multiplexed over the one shared connection, so when a peer's
+    reconnect closes it, the SDK's receive-task cleanup cancels the in-flight
+    requests of coroutines that had nothing wrong with them. `CancelledError` is
+    a `BaseException`, so it walks straight through every `except Exception` —
+    including the per-id guard in `get_neurons_batch` — and `asyncio.gather`
+    without `return_exceptions=True` then tears down the whole batch. A
+    cancellation this task never asked for is really "the connection went away",
+    and belongs in the retry path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_cancellation_we_did_not_ask_for_is_retried(self, monkeypatch: Any) -> None:
+        class _CancellingOnceConn(_StubConn):
+            def __init__(self) -> None:
+                super().__init__(alive=True)
+                self.first = True
+
+            async def query(self, _sql: str, _params: Any) -> list[Any]:
+                await asyncio.sleep(0)
+                if self.first:
+                    self.first = False
+                    raise asyncio.CancelledError
+                return [[{"ok": True}]]
+
+        store = _store_with(_CancellingOnceConn())
+        monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=True), raising=True)
+
+        rows = await store._query("SELECT 1")
+
+        assert rows == [{"ok": True}], (
+            "a peer-induced cancellation escaped instead of being retried — that is what "
+            "takes down an entire get_neurons_batch fan-out"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_real_cancellation_still_propagates(self, monkeypatch: Any) -> None:
+        """Swallowing a genuine cancel would break wait_for and task teardown."""
+
+        class _HangingConn(_StubConn):
+            async def query(self, _sql: str, _params: Any) -> list[Any]:
+                await asyncio.Event().wait()
+                raise AssertionError("unreachable")
+
+        store = _store_with(_HangingConn(alive=True))
+        monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=True), raising=True)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(store._query("SELECT 1"), timeout=0.05)

--- a/tests/unit/test_consolidation_timeouts_and_reconnect.py
+++ b/tests/unit/test_consolidation_timeouts_and_reconnect.py
@@ -88,6 +88,22 @@ async def test_lifecycle_never_fetches_embeddings() -> None:
         )
 
 
+def _prime_connection_state(store: Any) -> None:
+    """Give a ``__new__``-built store the connection bookkeeping ``_query`` needs.
+
+    ``_query`` is single-flight: it reads a generation counter, re-mints the
+    re-auth lock when the event loop changes, and compares the connection's loop
+    against the running one. A store built with ``__new__`` has none of that, so
+    every test that drives ``_query`` directly seeds it here rather than
+    repeating four assignments.
+    """
+    loop = asyncio.get_running_loop()
+    store._reauth_lock = asyncio.Lock()
+    store._reauth_lock_loop = loop
+    store._conn_generation = 0
+    store._conn_loop = loop
+
+
 class _FlakyConn:
     """Fails `attempts_before_success` times with a connection reset, then works."""
 
@@ -109,7 +125,7 @@ async def test_query_retries_reconnect_after_connection_reset(monkeypatch: Any) 
     from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
     store = SurrealDBStorage.__new__(SurrealDBStorage)
-    store._reauth_lock = asyncio.Lock()  # type: ignore[attr-defined]
+    _prime_connection_state(store)
     conn = _FlakyConn(attempts_before_success=2)
     store._conn = conn  # type: ignore[attr-defined]
 
@@ -135,3 +151,215 @@ async def test_query_retries_reconnect_after_connection_reset(monkeypatch: Any) 
     assert reconnects["n"] >= 2, (
         f"only {reconnects['n']} reconnect attempt(s) — a single retry hits the same reset"
     )
+
+
+class _StubConn:
+    """Stands in for an SDK connection: answers, or refuses like a dead socket."""
+
+    def __init__(self, *, alive: bool) -> None:
+        self.alive = alive
+        self.closed = False
+        self.queries = 0
+
+    async def signin(self, _creds: dict[str, str]) -> None:
+        # Yield like a real round-trip would, so concurrent callers actually
+        # interleave — without this the whole gather runs one caller to
+        # completion before the next starts and proves nothing about fan-out.
+        await asyncio.sleep(0)
+
+    async def use(self, _ns: str, _db: str) -> None:
+        await asyncio.sleep(0)
+
+    async def query(self, _sql: str, _params: Any) -> list[Any]:
+        await asyncio.sleep(0)
+        self.queries += 1
+        if not self.alive:
+            raise ConnectionResetError(104, "Connection reset by peer")
+        return [[{"ok": True}]]
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _ConnFactory:
+    """Replacement for ``surrealdb.AsyncSurreal``; counts how often it is called."""
+
+    def __init__(self, *, alive: bool = True) -> None:
+        self.alive = alive
+        self.calls = 0
+        self.built: list[_StubConn] = []
+
+    def __call__(self, _url: str) -> _StubConn:
+        self.calls += 1
+        conn = _StubConn(alive=self.alive)
+        self.built.append(conn)
+        return conn
+
+
+def _store_with(conn: Any) -> Any:
+    """A storage object wired to *conn*, with the real _query/_reconnect intact."""
+    from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+    store = SurrealDBStorage.__new__(SurrealDBStorage)
+    _prime_connection_state(store)
+    store._conn = conn
+    store._url = "ws://localhost:8001/rpc"
+    store._user = "root"
+    store._password = "secret"  # noqa: S105 - test double, never a real credential
+    store._namespace = "ns"
+    store._database = "db"
+    return store
+
+
+class TestSingleFlightReconnect:
+    """One dead transport must cost ONE reconnect, not one per concurrent caller.
+
+    `_reauth_lock` serialised the callers but did not deduplicate them: each of
+    the `_BATCH_FETCH_CONCURRENCY` queries fanned out over the shared connection
+    built its own replacement and logged its own warning, so a single drop during
+    consolidation produced a wall of identical
+    "reconnect attempt N/3 failed: [Errno 104] Connection reset by peer" lines
+    and leaked a socket per attempt.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sixteen_concurrent_failures_reconnect_once(self, monkeypatch: Any) -> None:
+        from surreal_memory.storage.surrealdb.store import _BATCH_FETCH_CONCURRENCY
+
+        dead = _StubConn(alive=False)
+        store = _store_with(dead)
+        factory = _ConnFactory(alive=True)
+        monkeypatch.setattr("surrealdb.AsyncSurreal", factory, raising=True)
+
+        results = await asyncio.gather(
+            *(store._query("SELECT 1") for _ in range(_BATCH_FETCH_CONCURRENCY))
+        )
+
+        assert results == [[{"ok": True}]] * _BATCH_FETCH_CONCURRENCY
+        assert factory.calls == 1, (
+            f"{_BATCH_FETCH_CONCURRENCY} concurrent failures caused {factory.calls} reconnects; "
+            "the generation counter should collapse them to one"
+        )
+        assert store._conn_generation == 1
+
+    @pytest.mark.asyncio
+    async def test_reconnect_closes_the_connection_it_replaces(self, monkeypatch: Any) -> None:
+        dead = _StubConn(alive=False)
+        store = _store_with(dead)
+        monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=True), raising=True)
+
+        await store._query("SELECT 1")
+
+        assert dead.closed is True, (
+            "the replaced connection was left open — that leaks a socket (and, on the "
+            "WebSocket transport, its receive task) on every reconnect"
+        )
+
+    @pytest.mark.asyncio
+    async def test_waiters_do_not_each_log_a_warning(self, monkeypatch: Any, caplog: Any) -> None:
+        """Every attempt logs at most one warning, whatever the fan-out."""
+        import logging as _logging
+
+        from surreal_memory.storage.surrealdb.store import (
+            _BATCH_FETCH_CONCURRENCY,
+            _RECONNECT_BACKOFF,
+        )
+
+        store = _store_with(_StubConn(alive=False))
+        # Every replacement is dead too, so all three attempts run and log.
+        monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=False), raising=True)
+        # Drop the real backoff waits. Patching asyncio.sleep itself would also
+        # neuter the stubs' yields, which is exactly what this test needs.
+        monkeypatch.setattr(
+            "surreal_memory.storage.surrealdb.store._RECONNECT_BACKOFF",
+            (0.0,) * len(_RECONNECT_BACKOFF),
+            raising=True,
+        )
+
+        with caplog.at_level(_logging.WARNING, logger="surreal_memory.storage.surrealdb.store"):
+            outcomes = await asyncio.gather(
+                *(store._query("SELECT 1") for _ in range(_BATCH_FETCH_CONCURRENCY)),
+                return_exceptions=True,
+            )
+
+        assert all(isinstance(o, ConnectionResetError) for o in outcomes)
+        warnings = [r for r in caplog.records if "reconnect attempt" in r.getMessage()]
+        assert len(warnings) == len(_RECONNECT_BACKOFF), (
+            f"{len(warnings)} warnings for {_BATCH_FETCH_CONCURRENCY} callers — expected one per "
+            f"attempt ({len(_RECONNECT_BACKOFF)}), not one per caller per attempt"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bad_credentials_still_fail_fast(self, monkeypatch: Any) -> None:
+        """A wrong password must not be retried three times on every caller."""
+        from surrealdb.errors import NotAllowedError
+
+        from surreal_memory.storage.surrealdb.connection import StorageAuthError
+
+        class _RefusingConn(_StubConn):
+            async def signin(self, _creds: dict[str, str]) -> None:
+                await asyncio.sleep(0)
+                raise NotAllowedError("auth", "There was a problem with authentication")
+
+        def _factory(_url: str) -> _RefusingConn:
+            _factory.calls += 1  # type: ignore[attr-defined]
+            return _RefusingConn(alive=True)
+
+        _factory.calls = 0  # type: ignore[attr-defined]
+        store = _store_with(_StubConn(alive=False))
+        monkeypatch.setattr("surrealdb.AsyncSurreal", _factory, raising=True)
+
+        with pytest.raises(StorageAuthError):
+            await store._query("SELECT 1")
+
+        assert _factory.calls == 1, (  # type: ignore[attr-defined]
+            "StorageAuthError was retried — bad credentials never fix themselves"
+        )
+
+
+class TestConnectionLoopAffinity:
+    """A cached connection belongs to the loop that opened it.
+
+    The SDK creates its response futures on that loop, so reusing the process-wide
+    storage singleton from a second ``asyncio.run()`` made every query raise
+    ``RuntimeError: … Future … attached to a different loop``. That is neither an
+    auth error nor a transport error, so the retry path never caught it and the
+    connection stayed broken until the process restarted.
+    """
+
+    @pytest.mark.asyncio
+    async def test_query_rebuilds_when_the_loop_changed(self, monkeypatch: Any) -> None:
+        foreign_loop = asyncio.new_event_loop()
+        try:
+            healthy_but_foreign = _StubConn(alive=True)
+            store = _store_with(healthy_but_foreign)
+            store._conn_loop = foreign_loop
+            factory = _ConnFactory(alive=True)
+            monkeypatch.setattr("surrealdb.AsyncSurreal", factory, raising=True)
+
+            rows = await store._query("SELECT 1")
+
+            assert rows == [{"ok": True}]
+            assert factory.calls == 1, "the foreign-loop connection was reused instead of rebuilt"
+            assert healthy_but_foreign.queries == 0, (
+                "the query ran on the connection owned by the other loop"
+            )
+            assert store._conn_loop is asyncio.get_running_loop()
+        finally:
+            foreign_loop.close()
+
+    @pytest.mark.asyncio
+    async def test_foreign_connection_is_dropped_not_closed(self, monkeypatch: Any) -> None:
+        """``close()`` would await on the other loop's objects — only drop the reference."""
+        foreign_loop = asyncio.new_event_loop()
+        try:
+            healthy_but_foreign = _StubConn(alive=True)
+            store = _store_with(healthy_but_foreign)
+            store._conn_loop = foreign_loop
+            monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=True), raising=True)
+
+            await store._query("SELECT 1")
+
+            assert healthy_but_foreign.closed is False
+        finally:
+            foreign_loop.close()

--- a/tests/unit/test_consolidation_timeouts_and_reconnect.py
+++ b/tests/unit/test_consolidation_timeouts_and_reconnect.py
@@ -182,7 +182,14 @@ class _StubConn:
 
 
 class _ConnFactory:
-    """Replacement for ``surrealdb.AsyncSurreal``; counts how often it is called."""
+    """Replacement for ``surrealdb.AsyncSurreal``; counts how often it is called.
+
+    Patched with ``raising=False`` everywhere below: the default test install
+    (`.[dev,server]`, what CI's unit-test jobs use) has no real `surrealdb`
+    package, and the stand-in in `sys.modules` does not expose `AsyncSurreal`,
+    so `raising=True` fails there while passing on a machine that happens to
+    have the SDK installed.
+    """
 
     def __init__(self, *, alive: bool = True) -> None:
         self.alive = alive
@@ -229,7 +236,7 @@ class TestSingleFlightReconnect:
         dead = _StubConn(alive=False)
         store = _store_with(dead)
         factory = _ConnFactory(alive=True)
-        monkeypatch.setattr("surrealdb.AsyncSurreal", factory, raising=True)
+        monkeypatch.setattr("surrealdb.AsyncSurreal", factory, raising=False)
 
         results = await asyncio.gather(
             *(store._query("SELECT 1") for _ in range(_BATCH_FETCH_CONCURRENCY))
@@ -246,7 +253,7 @@ class TestSingleFlightReconnect:
     async def test_reconnect_closes_the_connection_it_replaces(self, monkeypatch: Any) -> None:
         dead = _StubConn(alive=False)
         store = _store_with(dead)
-        monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=True), raising=True)
+        monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=True), raising=False)
 
         await store._query("SELECT 1")
 
@@ -267,7 +274,7 @@ class TestSingleFlightReconnect:
 
         store = _store_with(_StubConn(alive=False))
         # Every replacement is dead too, so all three attempts run and log.
-        monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=False), raising=True)
+        monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=False), raising=False)
         # Drop the real backoff waits. Patching asyncio.sleep itself would also
         # neuter the stubs' yields, which is exactly what this test needs.
         monkeypatch.setattr(
@@ -292,14 +299,18 @@ class TestSingleFlightReconnect:
     @pytest.mark.asyncio
     async def test_bad_credentials_still_fail_fast(self, monkeypatch: Any) -> None:
         """A wrong password must not be retried three times on every caller."""
-        from surrealdb.errors import NotAllowedError
-
         from surreal_memory.storage.surrealdb.connection import StorageAuthError
+
+        # Defined here rather than imported from surrealdb.errors: the default
+        # test install has no SDK. `is_credential_error` recognises this by class
+        # name and by the message, both of which are exercised as written.
+        class NotAllowedError(Exception):
+            pass
 
         class _RefusingConn(_StubConn):
             async def signin(self, _creds: dict[str, str]) -> None:
                 await asyncio.sleep(0)
-                raise NotAllowedError("auth", "There was a problem with authentication")
+                raise NotAllowedError("There was a problem with authentication")
 
         def _factory(_url: str) -> _RefusingConn:
             _factory.calls += 1  # type: ignore[attr-defined]
@@ -307,7 +318,7 @@ class TestSingleFlightReconnect:
 
         _factory.calls = 0  # type: ignore[attr-defined]
         store = _store_with(_StubConn(alive=False))
-        monkeypatch.setattr("surrealdb.AsyncSurreal", _factory, raising=True)
+        monkeypatch.setattr("surrealdb.AsyncSurreal", _factory, raising=False)
 
         with pytest.raises(StorageAuthError):
             await store._query("SELECT 1")
@@ -335,7 +346,7 @@ class TestConnectionLoopAffinity:
             store = _store_with(healthy_but_foreign)
             store._conn_loop = foreign_loop
             factory = _ConnFactory(alive=True)
-            monkeypatch.setattr("surrealdb.AsyncSurreal", factory, raising=True)
+            monkeypatch.setattr("surrealdb.AsyncSurreal", factory, raising=False)
 
             rows = await store._query("SELECT 1")
 
@@ -364,7 +375,7 @@ class TestConnectionLoopAffinity:
                 # this method exists to absorb.
                 return _StubConn(alive=attempts["n"] > 1)
 
-            monkeypatch.setattr("surrealdb.AsyncSurreal", _flaky_factory, raising=True)
+            monkeypatch.setattr("surrealdb.AsyncSurreal", _flaky_factory, raising=False)
             monkeypatch.setattr(
                 "surreal_memory.storage.surrealdb.store._RECONNECT_BACKOFF",
                 (0.0, 0.0, 0.0),
@@ -388,7 +399,7 @@ class TestConnectionLoopAffinity:
             healthy_but_foreign = _StubConn(alive=True)
             store = _store_with(healthy_but_foreign)
             store._conn_loop = foreign_loop
-            monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=True), raising=True)
+            monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=True), raising=False)
 
             await store._query("SELECT 1")
 
@@ -425,7 +436,7 @@ class TestCancellationFromAPeerReconnect:
                 return [[{"ok": True}]]
 
         store = _store_with(_CancellingOnceConn())
-        monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=True), raising=True)
+        monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=True), raising=False)
 
         rows = await store._query("SELECT 1")
 
@@ -444,7 +455,7 @@ class TestCancellationFromAPeerReconnect:
                 raise AssertionError("unreachable")
 
         store = _store_with(_HangingConn(alive=True))
-        monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=True), raising=True)
+        monkeypatch.setattr("surrealdb.AsyncSurreal", _ConnFactory(alive=True), raising=False)
 
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(store._query("SELECT 1"), timeout=0.05)

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.5.0"
+        assert surreal_memory.__version__ == "3.5.1"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_ws_transport.py
+++ b/tests/unit/test_ws_transport.py
@@ -1,0 +1,60 @@
+"""Transport selection: http URLs are rewritten to ws to avoid port exhaustion.
+
+The surrealdb SDK's HTTP transport opens a new TCP connection per RPC. On
+workloads that issue tens of thousands of small queries (consolidation's
+compress / semantic_link), that exhausts the ephemeral port range and every
+new connection — including the SDK's own reconnect — gets RST by the kernel
+("[Errno 104] Connection reset by peer", the long-standing `smem consolidate`
+failure). The store therefore rewrites http(s) URLs to ws(s) so the SDK
+multiplexes all RPCs over one persistent WebSocket connection.
+"""
+
+from __future__ import annotations
+
+from surreal_memory.storage.surrealdb.store import _prefer_ws_transport
+
+
+class TestPreferWsTransport:
+    def test_http_rewritten_to_ws(self):
+        assert _prefer_ws_transport("http://localhost:8001") == "ws://localhost:8001"
+
+    def test_https_rewritten_to_wss(self):
+        assert _prefer_ws_transport("https://db.example.com") == "wss://db.example.com"
+
+    def test_explicit_ws_unchanged(self):
+        assert _prefer_ws_transport("ws://localhost:8001") == "ws://localhost:8001"
+
+    def test_explicit_wss_unchanged(self):
+        assert _prefer_ws_transport("wss://db.example.com") == "wss://db.example.com"
+
+    def test_non_http_scheme_unchanged(self):
+        # Embedded backends (memory/surrealkv) must pass through untouched.
+        assert _prefer_ws_transport("memory://") == "memory://"
+        assert _prefer_ws_transport("surrealkv:///data/db") == "surrealkv:///data/db"
+
+    def test_url_with_path_preserved(self):
+        assert (
+            _prefer_ws_transport("https://host/prefix")
+            == "wss://host/prefix"
+        )
+
+
+class TestStoreUsesWsUrl:
+    def test_store_rewrites_env_http_url(self, monkeypatch):
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        monkeypatch.setenv("SURREALDB_URL", "http://localhost:8001")
+        monkeypatch.setenv("SURREALDB_USER", "root")
+        monkeypatch.setenv("SURREALDB_PASS", "surrealmemory")
+        monkeypatch.setenv("SURREALDB_NS", "surreal_memory")
+        monkeypatch.setenv("SURREALDB_DB", "default")
+
+        store = SurrealDBStorage()
+        assert store._url == "ws://localhost:8001"
+
+    def test_store_respects_explicit_url_override(self, monkeypatch):
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        monkeypatch.setenv("SURREALDB_URL", "http://localhost:8001")
+        store = SurrealDBStorage(url="ws://explicit:9000")
+        assert store._url == "ws://explicit:9000"

--- a/tests/unit/test_ws_transport.py
+++ b/tests/unit/test_ws_transport.py
@@ -33,10 +33,7 @@ class TestPreferWsTransport:
         assert _prefer_ws_transport("surrealkv:///data/db") == "surrealkv:///data/db"
 
     def test_url_with_path_preserved(self):
-        assert (
-            _prefer_ws_transport("https://host/prefix")
-            == "wss://host/prefix"
-        )
+        assert _prefer_ws_transport("https://host/prefix") == "wss://host/prefix"
 
 
 class TestStoreUsesWsUrl:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

`smem consolidate` could stall for minutes, flood the terminal with hundreds of
`SurrealDB reconnect attempt N/3 failed: [Errno 104] Connection reset by peer`, and finish with a
report of zeros that is indistinguishable from "there was nothing to do".

The trigger is the SDK's **HTTP transport**, which opens a brand-new `aiohttp` session — a new TCP
connection — for **every single RPC**. Measured A/B in one process, same 300 queries against the
same server: `http://` leaves **+600** sockets in `TIME-WAIT` (2.0 per query), `ws://` leaves
**+0**. Consolidation issues tens of thousands of small queries (`compress` runs one per neuron id
through `get_neurons_batch`), so it exhausts the ephemeral port range within minutes; after that
the kernel resets every new connection — including the SDK's own reconnect and signin.

Four independent defects fed that one symptom, and all four are fixed here. The same root cause is
why the `Integration (SurrealDB)` CI job is currently red on `main` — that job sets
`SURREALDB_URL: http://127.0.0.1:8001`.

## Changes

**Transport**
- Rewrite `http(s)://` URLs to `ws(s)://` in `SurrealDBStorage` so the SDK multiplexes every RPC
  over one persistent connection. Explicit `ws://`, `wss://` and embedded (`memory`/`surrealkv`)
  URLs pass through unchanged.

**Reconnect lifecycle** (`storage/surrealdb/store.py`)
- **Single-flight reconnect.** `_reauth_lock` serialised concurrent callers but did not
  deduplicate them, so every query in a `_BATCH_FETCH_CONCURRENCY` fan-out that failed on the same
  dead connection built its own replacement, retried three times and logged its own warning. A
  caller now records the connection generation it failed on and reconnects only if nobody has
  already moved the counter past it; the rest re-run their query on the connection their peer built.
  Only the path that actually reconnected warns — the waiters log at DEBUG.
- **The replaced connection is closed.** It used to leak a socket per reconnect, and on the
  WebSocket transport an orphaned receive task as well.
- **A reconnect no longer cancels its siblings.** Closing a WebSocket connection cancels *every*
  RPC future pending on it, not just the one that triggered the close, and `asyncio.CancelledError`
  is a `BaseException` — so it bypassed both the retry path and the per-id guard in
  `get_neurons_batch`, and `asyncio.gather` without `return_exceptions=True` tore down whole
  batches. A cancellation the task did not request is now treated as a dropped transport and
  retried; a real cancellation (`task.cancel()`, `asyncio.wait_for`) still propagates untouched.
- **Loop affinity.** The SDK creates its response futures on the loop that opened the socket, so a
  cached storage instance reused from a second `asyncio.run()` failed every query with
  `RuntimeError: … Future … attached to a different loop` — neither an auth nor a transport error,
  so nothing retried it and the connection stayed broken for the life of the process. The
  connection's loop is now checked and the connection rebuilt when it differs. The re-auth lock is
  re-minted on the same check, because `asyncio.Lock` binds to the loop it is first awaited on.
- Jitter on the backoff grid, and the retry count is derived from the grid instead of being
  repeated as a literal in the log message.

**Consolidation payload and event loop**
- `find_neurons` includes embeddings by default; `dream` (10 000 rows in one response) and both
  `interference` scans now opt out — they read ids, tags and the synapse graph, never a vector.
- `semantic_discovery` pages **per neuron type** so the filter runs in the composite
  `(brain_id, type)` index instead of dragging the whole table across the wire to keep the
  CONCEPT/ENTITY minority, with a smaller page because these are the only rows that must carry
  their vector. The two per-type scans are **interleaved**, not concatenated: `_select_candidates`
  cuts on list order both in its `eligible[:MAX_NEURONS_TO_LINK]` fallback (which fires on a brain
  with no synapses yet, and on any backend that cannot answer `get_synapse_degrees`) and in its
  stable sort, where never-linked neurons of both types tie at degree 0 — concatenation would have
  starved whichever type came second.
- The similarity pass yields to the event loop periodically. Holding the loop is what lets the
  WebSocket keepalive lapse (`websockets` defaults to a 20 s ping interval and a 20 s timeout,
  which the SurrealDB SDK does not override), after which the peer drops the connection.

**Report honesty**
- A strategy raising anything other than `TimeoutError` used to escape the runner and kill the
  pass. Failures are now recorded per strategy, the remaining strategies still run, and both the
  failures and the already-recorded timeouts are named in the summary — the latter were being
  stored in `report.extra` but never printed. A clean run prints neither.
- `smem consolidate` exits non-zero when a stage failed, so automation that gates on the exit code
  still sees the failure now that the command degrades gracefully instead of crashing.

**The numpy-less fallback — no new dependency**
- The semantic-link strategy runs by default, but numpy (which makes it vectorised) is optional and
  reachable only through the `embeddings-openai` extra, which not even `all` pulls in. Without it
  the pass fell into a pure-python O(n²·d) double loop that cannot finish at the shipped caps
  (`MAX_NEURONS_TO_LINK` = 10 000 vectors) and that the per-strategy timeout cannot interrupt,
  because the loop never awaits — so the pass hung rather than completing. It now processes a
  bounded slice, yields to the event loop, and logs a warning naming numpy when it truncates.
- **numpy stays optional on purpose, and this was tested rather than assumed.** Promoting it to a
  base dependency looked right and was tried first; CI rejected it, correctly.
  `test_python_version_pin.py::TestStubSyntaxHazard` exists because numpy >= 2.5 ships stubs
  written in 3.12 syntax that mypy at this project's `python_version = 3.11` cannot parse — so
  making numpy mandatory breaks `mypy src/` for every consumer, on every supported interpreter
  (the `.python-version` pin does not prevent pip resolving numpy 2.5.x on 3.11). The comment on
  the extra now records that constraint so the next person does not repeat the move.

**Release**
- Version bumped to **3.5.1** in all 16 places `scripts/pre_ship.py::collect_versions()` checks,
  plus the CHANGELOG section. `pre_ship.py` passes end to end.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Tests

Note on the one behaviour change worth calling out explicitly: an `http(s)://` `SURREALDB_URL` is
now rewritten to `ws(s)://`, so HTTP is no longer a selectable transport. That is deliberate — the
HTTP transport opens two TCP connections per RPC and is what makes this failure reachable at all.
An explicit `ws://`, `wss://` or embedded URL always wins.

## Testing

Reproduced the red CI job locally against a throwaway `surrealdb/surrealdb:v3.2.0` container using
that job's own URL shape and command (`SURREALDB_URL=http://127.0.0.1:<port>`,
`pytest tests/ --timeout=120 -m "not stress"`):

| checkout | result | `Errno 104` lines | wall clock |
|---|---|---|---|
| base (`main`) | `7110 passed, 5 errors`, exit 1 | **12** | 133.8 s |
| this branch | `7172 passed, 0 errors`, exit 0 | **0** | 71.7 s |

The five errors on the base are exactly the ones CI reports, in
`test_surrealdb_typed_memory_all_types.py` and `test_surrealdb_typed_memory_delete_id_live.py`.
The halved wall clock is the same effect seen from the other side: the base spends half its time
opening and tearing down two TCP connections per RPC.

Full quality gate (`make verify`): **7207 passed, 0 failed**, coverage 72.33 % against the 67 %
floor. Against a live SurrealDB the suite was additionally run over WebSocket, over the CI's HTTP
URL shape, with the `stress` marker, and repeated — all green, identical counts between repeats.

An end-to-end consolidation pass against a real database went from hundreds of failed reconnect
attempts and a socket table driven past the ephemeral port range, to **zero** reconnect attempts
and no measurable `TIME-WAIT` growth, with the peak event-loop stall dropping well under the
keepalive budget.

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

New regression tests cover: 16 concurrent failures causing exactly one reconnect; the replaced
connection being closed; one warning per attempt rather than one per caller per attempt;
`StorageAuthError` still failing fast; a peer-induced cancellation being retried while a real one
propagates; a loop change rebuilding the connection, not closing the foreign-loop one, and still
getting the full retry budget; `dream`/`interference` never requesting embeddings; per-type paging
keeping both types inside the cap; the similarity pass yielding; the numpy-less fallback being
bounded and loud; a failing stage not stopping later stages, being named in the report, and making
the CLI exit non-zero — while a clean report stays quiet.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the documentation accordingly
- [x] I have updated CHANGELOG.md

## Related Issues

None open for this symptom. This supersedes the unmerged local branch
`fix/ws-transport-port-exhaustion`; its commit is included here unchanged, with authorship
preserved, as the first commit of this branch.
