### PR TITLE
fix: initialize() retries a transient connection reset during signin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed — `initialize()` survives a transient reset during signin
+
+- **Signin/`use` now retry with backoff on connection-class errors** (3 attempts,
+  0/1/3 s), mirroring the retry `_query` already had for dropped transports (S-01).
+  The Integration CI job showed a single SurrealDB hiccup mid-run aborting whichever
+  live-gated test happened to be signing in at that moment — `Errno 104` at signin,
+  a different test set each run, and the job red on `main` for it. Credential errors
+  still fail fast on the first attempt; non-connection errors still propagate
+  unchanged.
+
 ## [3.5.0] — 2026-08-13 — connectivity honesty: code-index excluded from the metric
 
 ### Changed — connectivity is now scored on the organic subgraph

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Forward-looking vision. What's next, what's possible, where we're going.
 > ZERO LLM dependency — pure algorithmic, regex, graph-based.
 
-**Current state**: v3.4.0 — 57 MCP tools, 7100+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
+**Current state**: v3.4.0 — 57 MCP tools, 7200+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
 
 **Storage**: SurrealDB is the only persistent backend — schema v9 — and `storage_backend`
 defaults to it. `#141` removed the SQLite backend entirely; selecting `storage_backend = "sqlite"`

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -562,17 +562,35 @@ class SurrealDBStorage(
         )
         from surreal_memory.storage.surrealdb.migrations import apply_migrations
 
-        self._conn = AsyncSurreal(self._url)
-        try:
-            await self._conn.signin({"username": self._user, "password": self._password})
-        except Exception as exc:
-            if is_credential_error(exc):
-                raise StorageAuthError(
-                    f"SurrealDB authentication failed for user '{self._user}' at {self._url}.",
-                    hint=AUTH_HINT,
-                ) from exc
-            raise
-        await self._conn.use(self._namespace, self._database)
+        # A reset during signin/use is the same transient class _query already
+        # retries (S-01). Every live-gated test opens its own connection, and
+        # the Integration CI job showed a single server hiccup mid-run
+        # aborting whichever test happened to be signing in at that moment
+        # (Errno 104 at signin — a different test set each run). Credential
+        # errors still fail fast: they never fix themselves.
+        delays = (0.0, 1.0, 3.0)
+        for attempt, delay in enumerate(delays, start=1):
+            if delay:
+                await asyncio.sleep(delay)
+            try:
+                self._conn = AsyncSurreal(self._url)
+                await self._conn.signin({"username": self._user, "password": self._password})
+                await self._conn.use(self._namespace, self._database)
+                break
+            except Exception as exc:
+                if is_credential_error(exc):
+                    raise StorageAuthError(
+                        f"SurrealDB authentication failed for user '{self._user}' at {self._url}.",
+                        hint=AUTH_HINT,
+                    ) from exc
+                if not _is_connection_error(exc) or attempt == len(delays):
+                    raise
+                logger.warning(
+                    "SurrealDB signin attempt %d/%d failed: %s",
+                    attempt,
+                    len(delays),
+                    exc,
+                )
 
         # Hard version gate (>= 3.2.0): the synapse RELATION schema and the
         # auto-migration below require SurrealDB 3.2.0. A failed/unparsable probe

--- a/tests/unit/test_surrealdb_store.py
+++ b/tests/unit/test_surrealdb_store.py
@@ -69,17 +69,21 @@ class TestInitializeAuthFailFast:
         assert "myhost" in msg
 
     @pytest.mark.asyncio
-    async def test_non_credential_exception_propagates_unchanged(self):
+    async def test_non_credential_non_connection_exception_propagates_unchanged(self):
         from surreal_memory.storage.surrealdb.store import SurrealDBStorage
 
         mock_conn = AsyncMock()
-        mock_conn.signin.side_effect = ConnectionRefusedError("connection refused")
+        # NOT a connection-class error: those now retry with backoff (see
+        # TestInitializeTransientReset below); everything else must still
+        # surface on the first attempt.
+        mock_conn.signin.side_effect = RuntimeError("unexpected")
 
         storage = SurrealDBStorage()
 
         with patch("surrealdb.AsyncSurreal", return_value=mock_conn, create=True):
-            with pytest.raises(ConnectionRefusedError):
+            with pytest.raises(RuntimeError):
                 await storage.initialize()
+        assert mock_conn.signin.await_count == 1
 
     @pytest.mark.asyncio
     async def test_initialize_success_does_not_raise(self):
@@ -96,6 +100,125 @@ class TestInitializeAuthFailFast:
             patch("surreal_memory.storage.surrealdb.store.ensure_schema", new_callable=AsyncMock),
         ):
             await storage.initialize()  # must not raise
+
+
+class TestInitializeTransientReset:
+    """A transient transport reset during signin/use retries with backoff.
+
+    The Integration CI job runs the live-gated tests against one container;
+    each opens its own connection, and a single server hiccup mid-run aborted
+    whichever test was signing in at that moment (Errno 104 — a different
+    test set each run). _query already retries this class (S-01); signin
+    now does too. Credential errors never retry."""
+
+    @pytest.mark.asyncio
+    async def test_transient_reset_during_signin_is_retried(self, monkeypatch):
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        async def _no_sleep(_d: float) -> None:
+            return None
+
+        monkeypatch.setattr("surreal_memory.storage.surrealdb.store.asyncio.sleep", _no_sleep)
+
+        def _conn() -> AsyncMock:
+            c = AsyncMock()
+            c.version.return_value = "surrealdb-3.5.0"
+            return c
+
+        conn1, conn2, conn3 = _conn(), _conn(), _conn()
+        conn1.signin.side_effect = ConnectionResetError(104, "Connection reset by peer")
+        conn2.signin.side_effect = ConnectionResetError(104, "Connection reset by peer")
+
+        storage = SurrealDBStorage()
+
+        with (
+            patch("surrealdb.AsyncSurreal", side_effect=[conn1, conn2, conn3], create=True),
+            patch("surreal_memory.storage.surrealdb.store.ensure_schema", new_callable=AsyncMock),
+            patch(
+                "surreal_memory.storage.surrealdb.migrations.apply_migrations",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await storage.initialize()  # third attempt lands
+
+        assert storage._conn is conn3
+        assert conn3.signin.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_transient_reset_during_use_is_retried(self, monkeypatch):
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        async def _no_sleep(_d: float) -> None:
+            return None
+
+        monkeypatch.setattr("surreal_memory.storage.surrealdb.store.asyncio.sleep", _no_sleep)
+
+        def _conn() -> AsyncMock:
+            c = AsyncMock()
+            c.version.return_value = "surrealdb-3.5.0"
+            return c
+
+        conn1, conn2 = _conn(), _conn()
+        conn1.use.side_effect = ConnectionResetError(104, "Connection reset by peer")
+
+        storage = SurrealDBStorage()
+
+        with (
+            patch("surrealdb.AsyncSurreal", side_effect=[conn1, conn2], create=True),
+            patch("surreal_memory.storage.surrealdb.store.ensure_schema", new_callable=AsyncMock),
+            patch(
+                "surreal_memory.storage.surrealdb.migrations.apply_migrations",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await storage.initialize()
+
+        assert storage._conn is conn2
+
+    @pytest.mark.asyncio
+    async def test_persistent_reset_exhausts_retries_and_raises(self, monkeypatch):
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        sleeps: list[float] = []
+
+        async def _fake_sleep(d: float) -> None:
+            sleeps.append(d)
+
+        monkeypatch.setattr("surreal_memory.storage.surrealdb.store.asyncio.sleep", _fake_sleep)
+
+        conns = []
+        for _ in range(3):
+            c = AsyncMock()
+            c.signin.side_effect = ConnectionResetError(104, "Connection reset by peer")
+            conns.append(c)
+
+        storage = SurrealDBStorage()
+
+        with patch("surrealdb.AsyncSurreal", side_effect=conns, create=True):
+            with pytest.raises(ConnectionResetError):
+                await storage.initialize()
+
+        # Backoff happened between the three attempts.
+        assert sleeps == [1.0, 3.0]
+
+    @pytest.mark.asyncio
+    async def test_credential_error_is_not_retried(self):
+        from surreal_memory.storage.surrealdb.connection import StorageAuthError
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        class NotAllowedError(Exception):  # name triggers class-name fallback
+            pass
+
+        mock_conn = AsyncMock()
+        mock_conn.signin.side_effect = NotAllowedError("not allowed")
+
+        storage = SurrealDBStorage()
+
+        with patch("surrealdb.AsyncSurreal", return_value=mock_conn, create=True):
+            with pytest.raises(StorageAuthError):
+                await storage.initialize()
+
+        assert mock_conn.signin.await_count == 1  # fail fast, no retry
 
 
 class TestReconnectAuthFailFast:


### PR DESCRIPTION
## Summary

- `initialize()` retries signin/use with backoff (3 attempts, 0/1/3 s) when the failure is connection-class, mirroring the retry `_query` already had for dropped transports (S-01).
- Credential errors still fail fast on the first attempt; non-connection errors still propagate unchanged. Pinned by four new unit tests, including backoff timing and fail-fast.

## Why

The Integration (SurrealDB) job has been red intermittently on `main` (today's 64548880, also 0e894b9d / 1107ad5e on Aug 6): every live-gated test opens its own connection, and a single server hiccup mid-run aborted whichever test happened to be signing in at that moment — `Errno 104` at signin, a different test set each run. A reset at startup is not actionable by the caller and the same retry already exists one layer up for queries; this closes the gap for the connection handshake. It also helps production: a process starting while the DB container restarts currently dies at signin instead of waiting out the blip.

## Test plan

- [x] `pytest tests/unit/test_surrealdb_store.py` — 26 passed (4 new).
- [x] `pytest tests/unit/test_surrealdb_typed_memory_all_types.py tests/unit/test_surrealdb_typed_memory_delete_id_live.py` (the CI-failing files, sequential as the job runs them) — 35 passed.
- [x] `ruff check src/ tests/` clean.
- [x] `mypy src/ --ignore-missing-imports` — the one error (`google.genai`) reproduces identically on the base commit; none introduced.
- [x] `pytest tests/ -m "not stress" -n auto` — same pre-existing local parallel-load connection resets as on the base commit (live-server tests under `-n auto` against a single container); all pass sequentially.
- [x] Live smoke: `initialize()` against a running SurrealDB 3.5.0 over ws, first attempt.

## Verified by

@acidkill.