### PR TITLE
fix: initialize() retries the whole connect-and-prepare window, not just signin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a different test set each run, and the job red on `main` for it. Credential errors
   still fail fast on the first attempt; non-connection errors still propagate
   unchanged.
+- **The retry now covers the whole connect-and-prepare window, not just signin.** The
+  flake simply moved: with signin protected, the next Integration failure landed at
+  `INFO FOR DB` inside `apply_migrations` — a handshake query on the raw connection,
+  where no `_query` retry reaches. Version gate, schema apply and migrations are
+  extracted into `_prepare_database()` and re-run as one idempotent unit on a fresh
+  connection after a dropped transport. Version-gate rejections still fail fast — an
+  old server does not get newer by reconnecting.
 
 ## [3.5.0] — 2026-08-13 — connectivity honesty: code-index excluded from the metric
 

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -554,20 +554,21 @@ class SurrealDBStorage(
 
         from surreal_memory.storage.surrealdb.connection import (
             AUTH_HINT,
-            MIN_SERVER_VERSION,
             StorageAuthError,
-            StorageVersionError,
             is_credential_error,
-            parse_server_version,
         )
-        from surreal_memory.storage.surrealdb.migrations import apply_migrations
 
-        # A reset during signin/use is the same transient class _query already
-        # retries (S-01). Every live-gated test opens its own connection, and
-        # the Integration CI job showed a single server hiccup mid-run
-        # aborting whichever test happened to be signing in at that moment
-        # (Errno 104 at signin — a different test set each run). Credential
-        # errors still fail fast: they never fix themselves.
+        # A reset anywhere in the connect-and-prepare window is the same
+        # transient class _query already retries (S-01). Every live-gated test
+        # opens its own connection, and the Integration CI job showed a single
+        # server hiccup mid-run aborting whichever test was connecting at that
+        # moment — Errno 104 at signin until #172 retried it, then at the
+        # handshake queries (`INFO FOR DB` inside apply_migrations) that run on
+        # the raw connection with no _query retry to protect them. Every
+        # prepare step is idempotent (IF-NOT-EXISTS schema, version-gated
+        # migrations), so the whole attempt can simply re-run on a fresh
+        # connection. Credential errors still fail fast: they never fix
+        # themselves, and neither do version-gate rejections.
         delays = (0.0, 1.0, 3.0)
         for attempt, delay in enumerate(delays, start=1):
             if delay:
@@ -576,6 +577,7 @@ class SurrealDBStorage(
                 self._conn = AsyncSurreal(self._url)
                 await self._conn.signin({"username": self._user, "password": self._password})
                 await self._conn.use(self._namespace, self._database)
+                await self._prepare_database()
                 break
             except Exception as exc:
                 if is_credential_error(exc):
@@ -586,11 +588,48 @@ class SurrealDBStorage(
                 if not _is_connection_error(exc) or attempt == len(delays):
                     raise
                 logger.warning(
-                    "SurrealDB signin attempt %d/%d failed: %s",
+                    "SurrealDB connect attempt %d/%d failed: %s",
                     attempt,
                     len(delays),
                     exc,
                 )
+
+        # Detect ISO GQL capability (SurrealDB 3.2+) once, non-fatally (2s budget).
+        # A labeled MATCH via eval::gql succeeds only when the server was started
+        # with --allow-experimental gql AND --allow-eval-query; otherwise it raises
+        # and get_path stays on BFS. The neuron LABEL is required — an unlabeled
+        # `MATCH (n)` fails to parse even when GQL is enabled.
+        try:
+            await asyncio.wait_for(
+                self._conn.query('RETURN eval::gql("MATCH (n:neuron) RETURN n LIMIT 1")'),
+                timeout=2,
+            )
+            self._gql_available = True
+        except Exception:
+            self._gql_available = False
+            logger.debug("ISO GQL not available; get_path will use BFS.", exc_info=True)
+
+        logger.info(
+            "SurrealDB connected: %s ns=%s db=%s (gql=%s)",
+            self._url,
+            self._namespace,
+            self._database,
+            self._gql_available,
+        )
+
+    async def _prepare_database(self) -> None:
+        """Gate on server version, then apply schema and migrations.
+
+        Runs on ``self._conn`` during :meth:`initialize`; every step is
+        idempotent, which is what makes the whole connect-and-prepare attempt
+        safely re-runnable after a dropped transport.
+        """
+        from surreal_memory.storage.surrealdb.connection import (
+            MIN_SERVER_VERSION,
+            StorageVersionError,
+            parse_server_version,
+        )
+        from surreal_memory.storage.surrealdb.migrations import apply_migrations
 
         # Hard version gate (>= 3.2.0): the synapse RELATION schema and the
         # auto-migration below require SurrealDB 3.2.0. A failed/unparsable probe
@@ -616,29 +655,6 @@ class SurrealDBStorage(
         await ensure_schema(self._conn, self._embedding_dim)
         # Auto-run the synapse->RELATE migration on first connect after upgrade.
         await apply_migrations(self._conn)
-
-        # Detect ISO GQL capability (SurrealDB 3.2+) once, non-fatally (2s budget).
-        # A labeled MATCH via eval::gql succeeds only when the server was started
-        # with --allow-experimental gql AND --allow-eval-query; otherwise it raises
-        # and get_path stays on BFS. The neuron LABEL is required — an unlabeled
-        # `MATCH (n)` fails to parse even when GQL is enabled.
-        try:
-            await asyncio.wait_for(
-                self._conn.query('RETURN eval::gql("MATCH (n:neuron) RETURN n LIMIT 1")'),
-                timeout=2,
-            )
-            self._gql_available = True
-        except Exception:
-            self._gql_available = False
-            logger.debug("ISO GQL not available; get_path will use BFS.", exc_info=True)
-
-        logger.info(
-            "SurrealDB connected: %s ns=%s db=%s (gql=%s)",
-            self._url,
-            self._namespace,
-            self._database,
-            self._gql_available,
-        )
 
     async def close(self) -> None:
         """Close the SurrealDB connection.

--- a/tests/unit/test_surrealdb_store.py
+++ b/tests/unit/test_surrealdb_store.py
@@ -103,13 +103,15 @@ class TestInitializeAuthFailFast:
 
 
 class TestInitializeTransientReset:
-    """A transient transport reset during signin/use retries with backoff.
+    """A transient transport reset during the connect-and-prepare window retries.
 
     The Integration CI job runs the live-gated tests against one container;
     each opens its own connection, and a single server hiccup mid-run aborted
-    whichever test was signing in at that moment (Errno 104 — a different
-    test set each run). _query already retries this class (S-01); signin
-    now does too. Credential errors never retry."""
+    whichever test was connecting at that moment (Errno 104 — a different
+    test set each run). _query already retries this class (S-01); #172
+    extended it to signin, and this now covers the handshake queries too
+    (`INFO FOR DB` inside apply_migrations was where the next flake moved
+    to). Credential errors never retry."""
 
     @pytest.mark.asyncio
     async def test_transient_reset_during_signin_is_retried(self, monkeypatch):
@@ -174,6 +176,70 @@ class TestInitializeTransientReset:
             await storage.initialize()
 
         assert storage._conn is conn2
+
+    @pytest.mark.asyncio
+    async def test_transient_reset_during_handshake_is_retried(self, monkeypatch):
+        """The exact Integration failure shape: signin succeeds, then the
+        schema/migration queries on the raw connection hit the reset —
+        no _query retry covers them, so the whole attempt must re-run."""
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        async def _no_sleep(_d: float) -> None:
+            return None
+
+        monkeypatch.setattr("surreal_memory.storage.surrealdb.store.asyncio.sleep", _no_sleep)
+
+        def _conn() -> AsyncMock:
+            c = AsyncMock()
+            c.version.return_value = "surrealdb-3.5.0"
+            return c
+
+        conn1, conn2 = _conn(), _conn()
+
+        ensure_schema = AsyncMock(
+            side_effect=[ConnectionResetError(104, "Connection reset by peer"), None]
+        )
+
+        storage = SurrealDBStorage()
+
+        with (
+            patch("surrealdb.AsyncSurreal", side_effect=[conn1, conn2], create=True),
+            patch("surreal_memory.storage.surrealdb.store.ensure_schema", ensure_schema),
+            patch(
+                "surreal_memory.storage.surrealdb.migrations.apply_migrations",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await storage.initialize()
+
+        assert storage._conn is conn2, "a fresh connection must back the retried attempt"
+        assert ensure_schema.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_version_gate_rejection_is_not_retried(self, monkeypatch):
+        """An old server never gets newer by reconnecting — fail fast."""
+        from surreal_memory.storage.surrealdb.connection import StorageVersionError
+        from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+        async def _no_sleep(_d: float) -> None:
+            return None
+
+        monkeypatch.setattr("surreal_memory.storage.surrealdb.store.asyncio.sleep", _no_sleep)
+
+        conns = []
+        for _ in range(3):  # if retried, the loop would consume these
+            c = AsyncMock()
+            c.version.return_value = "surrealdb-3.1.1"
+            conns.append(c)
+
+        storage = SurrealDBStorage()
+
+        with patch("surrealdb.AsyncSurreal", side_effect=conns, create=True):
+            with pytest.raises(StorageVersionError):
+                await storage.initialize()
+
+        assert conns[0].signin.await_count == 1
+        assert conns[1].signin.await_count == 0, "version-gate rejection must not reconnect"
 
     @pytest.mark.asyncio
     async def test_persistent_reset_exhausts_retries_and_raises(self, monkeypatch):


### PR DESCRIPTION
## Summary

- The version gate, schema apply and migrations moved into `_prepare_database()`, and the connect-and-prepare sequence (signin → use → prepare) re-runs as one unit on a fresh connection when a connection-class error hits anywhere in it.
- Version-gate rejections still fail fast — an old server does not get newer by reconnecting. Credential errors unchanged: first-attempt `StorageAuthError`.
- Two new tests: a reset during the handshake queries (the exact Integration failure shape) is retried on a fresh connection, and a version-gate rejection does not reconnect.

## Why

#172 made signin retry, and the Integration flake moved instead of disappearing: the next red run on #169 died at `INFO FOR DB` inside `apply_migrations` — a handshake query on the raw `conn`, where no `_query` retry reaches. The whole post-signin window had the same single-blip-aborts-the-caller shape S-01 fixed for queries, and every step in it is idempotent (IF-NOT-EXISTS schema, version-gated migrations), so re-running the unit on a fresh connection is safe — safer than retrying steps piecemeal, which would need per-step reconnect plumbing.

## Test plan

- [x] `pytest tests/unit/test_surrealdb_store.py` — 28 passed (2 new).
- [x] `pytest tests/unit/test_check_dead_modules.py` — 18 passed.
- [x] `pytest tests/unit/test_dashboard_brains_scope.py` sequential — 10 passed.
- [x] `ruff check src/ tests/` clean; format clean.
- [x] `mypy src/ --ignore-missing-imports` — the one error (`google.genai`) reproduces identically on the base commit; none introduced.
- [x] Live smoke: `initialize()` against a running SurrealDB 3.5.0 over ws, first attempt.

## Verified by

@acidkill.