### PR TITLE
fix(reasoning): don't apply the per-session injection marker to per-subagent events

### DIFF
--- a/src/surreal_memory/engine/reasoning_injection.py
+++ b/src/surreal_memory/engine/reasoning_injection.py
@@ -235,19 +235,29 @@ async def get_reasoning_context(hook_input: dict[str, Any]) -> str:
     """Resolve the active model, build its reasoning block, mark the session.
 
     Shared by the SessionStart and UserPromptSubmit hooks. Opt-in via
-    reasoning_training.injection_enabled; injects at most once per session via the
-    marker (already_injected/mark_injected), so whichever hook fires first wins and
-    the other is a no-op. Storage is opened on the current brain and always closed.
-    Returns "" when injection is disabled, already done this session, or nothing
-    matched.
+    reasoning_training.injection_enabled. Those two fire for the same session and
+    race each other, so they inject at most once per session via the marker
+    (already_injected/mark_injected) — whichever gets there first wins.
+
+    The marker is keyed on ``session_id``, so it is only correct for events that
+    fire once per session. A per-subagent event (``SubagentStart``, which a user
+    can wire to this same entry point) carries the PARENT session's id, so
+    honouring the marker there would return "" for every subagent after the
+    first — and silently, since "" is also the legitimate "nothing matched"
+    answer. Such events are exempt from the marker and do not set it.
+
+    Storage is opened on the current brain and always closed. Returns "" when
+    injection is disabled, already done this session (session-scoped events
+    only), or nothing matched.
     """
     from surreal_memory.unified_config import get_config, get_shared_storage
 
     config = get_config()
     if not config.reasoning_training.injection_enabled:
         return ""
+    per_session = str(hook_input.get("hook_event_name") or "") != "SubagentStart"
     session_id = str(hook_input.get("session_id") or "")
-    if already_injected(session_id):
+    if per_session and already_injected(session_id):
         return ""
 
     model = resolve_active_model(hook_input)
@@ -260,7 +270,7 @@ async def get_reasoning_context(hook_input: dict[str, Any]) -> str:
         except Exception:
             logger.debug("reasoning storage.close() failed (non-fatal)", exc_info=True)
 
-    if block:
+    if block and per_session:
         mark_injected(session_id)
     return block
 

--- a/tests/unit/test_reasoning_injection.py
+++ b/tests/unit/test_reasoning_injection.py
@@ -350,6 +350,46 @@ async def test_get_reasoning_context_skips_when_already_injected(
     assert result == ""
 
 
+async def test_subagent_start_injects_every_time_despite_session_marker(
+    clean_env: Path, tmp_path: Path
+) -> None:
+    # SubagentStart fires once per spawned subagent; the payload carries the
+    # PARENT session_id, so honoring the per-session marker would starve every
+    # subagent after the first injection. It must inject regardless of the
+    # marker — and must NOT set it (the marker belongs to main-session hooks).
+    mark_injected("s-parent")  # parent session already injected via SessionStart
+    storage = InMemoryStorage()
+    storage.set_brain("default")
+    await _add_pattern(storage, "claude-fable-5", "debugging", "debugging: verify", "s", 1.0, 3)
+    cfg = _ucfg(tmp_path, injection_map=(("claude-opus-*", "claude-fable-5"),))
+    with (
+        patch("surreal_memory.unified_config.get_config", return_value=cfg),
+        patch(
+            "surreal_memory.unified_config.get_shared_storage",
+            new=AsyncMock(return_value=storage),
+        ),
+    ):
+        block = await get_reasoning_context(
+            {
+                "session_id": "s-parent",
+                "model": "claude-opus-4-8",
+                "hook_event_name": "SubagentStart",
+            }
+        )
+        # A fresh session id via SubagentStart must not consume the session marker.
+        fresh = await get_reasoning_context(
+            {
+                "session_id": "s-fresh",
+                "model": "claude-opus-4-8",
+                "hook_event_name": "SubagentStart",
+            }
+        )
+
+    assert "learned from claude-fable-5" in block
+    assert "learned from claude-fable-5" in fresh
+    assert already_injected("s-fresh") is False
+
+
 # ── session idempotency markers ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- The per-session injection marker is no longer applied to events that fire once per *subagent* rather than once per session.
- Such events also no longer *set* the marker, so they cannot starve `SessionStart` / `UserPromptSubmit` in turn.
- Adds a regression test pinning both halves.

## Why

`get_reasoning_context()` is the shared entry point behind the reasoning-strategy hooks, and it applies the session-scoped idempotency marker to every caller alike. That is right for `SessionStart` and `UserPromptSubmit`: both fire for the same session and race, so whichever arrives first should win and the other should be a no-op.

It is wrong for any event that fires once per spawned subagent. The marker is keyed on `session_id`, and a subagent payload carries the **parent** session's id — so once the parent has been injected, `already_injected(session_id)` is true for every subagent that parent will ever spawn, and each one gets `""` back.

The failure is silent by construction. `""` is also the legitimate "injection is disabled, or nothing matched" answer, so there is no log line and no error to notice: a long-running session simply stops handing strategies to its subagents after the first one, and nothing says so.

A note on scope, since it affects how you'll want to read this. The repo does not ship a `SubagentStart` hook — there is no such entry point in `pyproject.toml` and no reference to it under `src/`. `get_reasoning_context()` is nonetheless event-agnostic and users wire it to the events they want; `SubagentStart` is simply the case that exposes the mismatch between a session-keyed marker and a per-subagent event. So for a stock install this change is a **no-op**: `hook_event_name` never takes that value through the shipped wiring. I'm sending it because the guard belongs with the marker rather than with whatever wires it, and because the next person to point a per-subagent event at this function would hit the same silent floor. If you'd rather this waited for the repo to ship such a hook, that's a completely reasonable call and I'll withdraw it.

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` passes locally — 7062 passed, 146 skipped, 1 xfailed (baseline on `main` is 7061; the delta is this PR's test).
- [x] `ruff check src/ tests/` clean.
- [x] `ruff format --check src/ tests/` clean — 730 files already formatted.
- [x] `mypy src/ --ignore-missing-imports` clean — no issues in 353 source files.
- [x] The new test was proven to fail without the fix: with `src/surreal_memory/engine/reasoning_injection.py` reverted to `main` and the test in place, it fails on `assert "learned from claude-fable-5" in block` with `block == ''` — the empty-block starvation this PR removes.
- [x] Diff touches `engine/` and `tests/` only; no server routes or dashboard assets, so no live-instance check applies.

## Verified by

@RobertSigmundsson
