### PR TITLE
fix(consolidation): stop consolidation manufacturing work, and make its counters honest (v3.6.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "3.5.1"
+    "version": "3.6.0"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "3.5.1",
+      "version": "3.6.0",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/.gitignore
+++ b/.gitignore
@@ -258,3 +258,6 @@ qa/
 
 # signle backups
 .env.bak.pre-ws-transport_20260803_141252
+
+# surreal sql REPL history, written into the cwd
+history.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,23 @@ work. Both halves are fixed.
   summaries, hippocampal replay, interference fan effects, schema creation and auto-tiering.
 - The dedup census honours the configured SimHash threshold instead of silently using the
   looser library default, and both the threshold and the anchor cap are configurable.
+- `skipped (existing)` counted pairs the same pass had just created: a bidirectional top-K
+  neighbourhood reaches each pair twice, so the second visit was booked as a pre-existing
+  link. Those are counted separately now, and a resampled candidate set states outright
+  that its numbers are not comparable with the previous run's.
+- The health delta labelled the semantic-maturation share "Consolidation ratio", printed
+  directly beneath the merge counters where it read as a compression ratio. The label now
+  says what it measures; the wire field keeps its name, so the API contract is unchanged.
+- The dashboard consolidation route exposed eight counters and none of the new ones, so
+  everything this release made honest was visible over MCP but not in the UI.
+
+### Performance
+
+- Consolidation no longer reads the whole synapse table in a single response. An unbounded
+  `get_synapses()` emitted a query with no LIMIT — on a mature brain six figures of rows at
+  once, twice per run, which is the shape that produces `[Errno 104] Connection reset by
+  peer` on the HTTP transport. Prune, infer, enrichment and dream now page through a shared
+  helper on the storage base class.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] — 2026-08-16 — consolidation stops manufacturing work, and its counters stop lying
+
+Running `smem consolidate` twice in a row on an unchanged brain was not a no-op. It
+created new data every time, and the report gave no way to tell that apart from useful
+work. Both halves are fixed.
+
+### Fixed — consolidation no longer destroys or duplicates data
+
+- **`summarize` is idempotent.** Every run used to re-materialise each tag cluster as a
+  fresh concept neuron, summary fiber and up to ten synapses. Worse, summary fibers carry
+  the union of their sources' tags, so each run fed the previous run's output back into
+  clustering. A cluster is now identified by a hash of its sorted source fiber ids and is
+  skipped if its summary already exists; summaries written before this key existed derive
+  it from `source_fibers`, so older rows suppress duplicates too. Summary fibers are also
+  excluded from the clustering input.
+- **`merge` creates before it destroys.** Source fibers were deleted first and the merged
+  fiber written afterwards, so a failing write left them gone with no successor —
+  unrecoverable on non-transactional storage.
+- **`merge` no longer orphans the typed-memory layer.** `delete_fiber` has no cascade to
+  `typed_memory`, and `update_typed_memory` cannot move a row to another fiber because its
+  record id derives from `fiber_id`. Memory type, priority, trust score and validity window
+  were silently stranded on every merge. Those rows are now read before any delete and
+  reassigned to the surviving fiber, strongest priority and widest validity window winning.
+- **`merge` preserves source metadata.** `essence`, `conductivity`, `coherence` and
+  `compression_tier` were replaced wholesale by a bare `merged_from` list, and the summary
+  became the constant "Merged from N fibers" — which is what recall surfaces display.
+
+### Fixed — two permanent blind spots
+
+- **The dedup census window rotates.** It took a fixed prefix of the anchor list, which is
+  ordered by id and never shrinks because dedup deletes nothing, so the same anchors were
+  compared every run and the rest were never compared at all. A cursor in `Brain.metadata`
+  now advances one window per run and wraps, covering the whole population over a cycle.
+- **Query-pattern mining looks at recent events.** It fetched action events with no time
+  window; the backend orders ascending, so it mined the oldest events in the brain's
+  history and, once the log grew past the fetch limit, no new query could ever enter it.
+
+### Fixed — every counter states what it measured
+
+- `fibers_removed` counted delete *attempts*; `delete_fiber` swallows its exception and
+  returns `False`, and the caller ignored it.
+- Drift detection returned the number of clusters *saved* while the report called them
+  *found*, so a failed write looked like less drift. Detection and persistence are now
+  separate, and the failed-write log was raised from debug to warning.
+- `_detect_drift` swallowed its own exception, keeping a dead detector out of
+  `failed_strategies` and making it report zero — indistinguishable from a clean brain.
+- Counters that were recorded and never rendered now appear when non-zero:
+  semantic-link write failures, deferred compressions, merge delete failures, skipped
+  summaries, hippocampal replay, interference fan effects, schema creation and auto-tiering.
+- The dedup census honours the configured SimHash threshold instead of silently using the
+  looser library default, and both the threshold and the anchor cap are configurable.
+
+### Added
+
+- **A counter-contract test.** Two earlier rounds of honesty fixes were shipped and the
+  same defect class returned in neighbouring code, because each fix was local. The test
+  scans the engine for every key written into the report and fails unless each is either
+  rendered or listed as deliberately silent with a reason. It found six live defects the
+  first time it ran.
+- `scripts/cleanup_consolidation_debt.py` — measures and, on request, removes the duplicate
+  summaries earlier versions accumulated. Modes are ordered by blast radius
+  (`--measure`, `--dry-run`, `--apply`) and `--brain` is required with no default.
+
 ## [3.5.1] — 2026-08-15 — `smem consolidate` stops exhausting the socket table
 
 A full consolidation pass could spend minutes stalled and then flood the terminal with

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -166,6 +166,15 @@ LLM-powered deduplication settings.
 | `merge_strategy` | `str` | `keep_newer` |  |
 | `max_candidates` | `int` | `30` | wider search (was 10) |
 
+> These settings govern deduplication **at encode time**. The consolidation pass has its
+> own two knobs on `ConsolidationConfig`, because it censuses anchors rather than
+> individual writes:
+>
+> | Setting | Type | Default | Description |
+> |---|---|---|---|
+> | `dedup_max_anchors` | `int` | `2000` | anchors compared pairwise per consolidation run. The window rotates between runs, so raising this widens each pass rather than deciding what is ever seen |
+> | `dedup_simhash_threshold` | `int` | `7` | Hamming distance below which two fingerprints count as near-duplicates. Mirrors `[dedup].simhash_threshold`; before 3.6.0 the census silently used the looser library default of 10 |
+
 ## `[tool_tier]`
 
 MCP tool tier configuration.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -165,15 +165,7 @@ LLM-powered deduplication settings.
 | `llm_max_pairs_per_encode` | `int` | `3` |  |
 | `merge_strategy` | `str` | `keep_newer` |  |
 | `max_candidates` | `int` | `30` | wider search (was 10) |
-
-> These settings govern deduplication **at encode time**. The consolidation pass has its
-> own two knobs on `ConsolidationConfig`, because it censuses anchors rather than
-> individual writes:
->
-> | Setting | Type | Default | Description |
-> |---|---|---|---|
-> | `dedup_max_anchors` | `int` | `2000` | anchors compared pairwise per consolidation run. The window rotates between runs, so raising this widens each pass rather than deciding what is ever seen |
-> | `dedup_simhash_threshold` | `int` | `7` | Hamming distance below which two fingerprints count as near-duplicates. Mirrors `[dedup].simhash_threshold`; before 3.6.0 the census silently used the looser library default of 10 |
+| `consolidation_max_anchors` | `int` | `2000` |  |
 
 ## `[tool_tier]`
 

--- a/history.txt
+++ b/history.txt
@@ -1,2 +1,0 @@
-#V2
-SELECT VALUE meta::id(id) FROM brain WHERE name = 'default';

--- a/history.txt
+++ b/history.txt
@@ -1,0 +1,2 @@
+#V2
+SELECT VALUE meta::id(id) FROM brain WHERE name = 'default';

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.5.1",
+      "version": "3.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.5.1",
+      "version": "3.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.5.1"
+version = "3.6.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/scripts/cleanup_consolidation_debt.py
+++ b/scripts/cleanup_consolidation_debt.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+"""Measure and clean up the debt left by non-idempotent consolidation.
+
+Before the idempotence gate landed, every consolidation run re-materialised each tag
+cluster: a fresh concept neuron, a fresh summary fiber and up to ten RELATED_TO synapses,
+each time. This script finds those duplicate groups and can remove all but the oldest
+member of each.
+
+Three modes, deliberately ordered by how much they can break:
+
+    --measure   count only (default) — touches nothing
+    --dry-run   list exactly what would be deleted — touches nothing
+    --apply     delete the duplicates
+
+``--brain`` is always required: there is no "current brain" default, because the one
+thing this script must never do is clean a brain nobody asked it to.
+
+IMPORTANT: run ``--apply`` only AFTER the fixed code is released and the smem services
+have been restarted. pipx swaps files, not running processes, so a still-running old
+smem-mcp / smem-web would recreate the duplicates at its next consolidation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import sys
+from collections import defaultdict
+from typing import Any
+
+from surreal_memory.unified_config import get_shared_storage
+
+SUMMARY_MARKER = "summary_fiber"
+
+
+def _cluster_key(source_ids: list[str]) -> str:
+    """Same identity the engine uses: a hash of the sorted source fiber ids."""
+    joined = "|".join(sorted(source_ids))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:32]
+
+
+def _group_key(fiber: Any) -> str | None:
+    """Cluster identity of a summary fiber, for old and new rows alike."""
+    key = fiber.metadata.get("_cluster_key")
+    if key:
+        return str(key)
+    sources = fiber.metadata.get("source_fibers")
+    if isinstance(sources, list) and sources:
+        return _cluster_key([str(s) for s in sources])
+    return None
+
+
+async def _load_summary_fibers(storage: Any) -> list[Any]:
+    fibers = await storage.get_fibers(limit=100000)
+    return [f for f in fibers if f.metadata.get("_consolidation") == SUMMARY_MARKER]
+
+
+async def _find_orphaned_typed_memories(storage: Any) -> list[str]:
+    """typed_memory rows whose fiber no longer exists.
+
+    Record ids are stored with underscores while typed_memory.fiber_id keeps hyphens,
+    so the two must be normalised before they can be compared at all.
+    """
+    rows = await storage._query("SELECT VALUE meta::id(id) FROM fiber")
+    alive = {str(r).replace("_", "-") for r in rows}
+    tms = await storage._query("SELECT VALUE fiber_id FROM typed_memory")
+    return [str(t) for t in tms if str(t) not in alive]
+
+
+def _duplicate_groups(summaries: list[Any]) -> dict[str, list[Any]]:
+    """Summary fibers grouped by cluster identity, keeping only real duplicates."""
+    groups: dict[str, list[Any]] = defaultdict(list)
+    for fiber in summaries:
+        key = _group_key(fiber)
+        if key:
+            groups[key].append(fiber)
+    return {k: v for k, v in groups.items() if len(v) > 1}
+
+
+def _victims(group: list[Any]) -> list[Any]:
+    """Everything except the oldest member — the original stays."""
+    ordered = sorted(group, key=lambda f: f.created_at)
+    return ordered[1:]
+
+
+async def run(brain: str, mode: str) -> int:
+    storage = await get_shared_storage()
+    storage.set_brain(brain)
+
+    summaries = await _load_summary_fibers(storage)
+    groups = _duplicate_groups(summaries)
+    orphans = await _find_orphaned_typed_memories(storage)
+
+    total_victims = sum(len(_victims(g)) for g in groups.values())
+    keyless = [f for f in summaries if _group_key(f) is None]
+
+    print(f"brain:                      {brain}")
+    print(f"summary fibers:             {len(summaries)}")
+    print(f"duplicate cluster groups:   {len(groups)}")
+    print(f"redundant summary fibers:   {total_victims}")
+    print(f"summaries without identity: {len(keyless)} (left alone — cannot be grouped safely)")
+    print(f"orphaned typed_memory rows: {len(orphans)}")
+
+    if mode == "measure":
+        return 0
+
+    if mode == "dry-run":
+        for key, group in sorted(groups.items()):
+            victims = _victims(group)
+            keeper = sorted(group, key=lambda f: f.created_at)[0]
+            print(f"\ncluster {key}: {len(group)} copies")
+            print(f"  KEEP   {keeper.id}  ({keeper.created_at})")
+            for victim in victims:
+                print(f"  DELETE {victim.id}  ({victim.created_at})")
+        for fiber_id in orphans:
+            print(f"DELETE orphaned typed_memory for missing fiber {fiber_id}")
+        return 0
+
+    # --apply
+    deleted_fibers = 0
+    deleted_neurons = 0
+    failed = 0
+    for group in groups.values():
+        for victim in _victims(group):
+            anchor_id = victim.anchor_neuron_id
+            if await storage.delete_fiber(victim.id):
+                deleted_fibers += 1
+            else:
+                failed += 1
+                continue
+            # The concept neuron exists only to head this summary, so it goes too.
+            if anchor_id:
+                try:
+                    neuron = await storage.get_neuron(anchor_id)
+                    if neuron is not None and neuron.metadata.get("_consolidation") == "summary":
+                        await storage.delete_neuron(anchor_id)
+                        deleted_neurons += 1
+                except Exception as exc:  # pragma: no cover - defensive
+                    print(f"  could not remove concept neuron {anchor_id}: {exc}")
+
+    deleted_typed = 0
+    for fiber_id in orphans:
+        if await storage.delete_typed_memory(fiber_id):
+            deleted_typed += 1
+
+    print(f"\ndeleted summary fibers:     {deleted_fibers}")
+    print(f"deleted concept neurons:    {deleted_neurons}")
+    print(f"deleted orphaned typed_mem: {deleted_typed}")
+    if failed:
+        print(f"FAILED deletes:             {failed}")
+    return 1 if failed else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--brain", required=True, help="brain id to clean (no default, on purpose)")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--measure", action="store_true", help="count only (default)")
+    group.add_argument("--dry-run", action="store_true", help="list what would be deleted")
+    group.add_argument("--apply", action="store_true", help="actually delete")
+    args = parser.parse_args()
+
+    mode = "measure"
+    if args.dry_run:
+        mode = "dry-run"
+    elif args.apply:
+        mode = "apply"
+
+    return asyncio.run(run(args.brain, mode))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.5.1"
+__version__ = "3.6.0"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -9,9 +9,10 @@ Provides automated memory maintenance:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from dataclasses import replace as dc_replace
 from datetime import datetime
@@ -37,6 +38,58 @@ logger = logging.getLogger(__name__)
 # the census only ever describes this many anchors, in scan order, which is why
 # the pass reports the total and flags the truncation instead of hiding it.
 _DEDUP_MAX_ANCHORS = 2000
+
+
+def _summary_cluster_key_from_ids(fiber_ids: Iterable[str]) -> str:
+    """Stable identity of a summary cluster: a hash of its sorted source fiber ids.
+
+    Sorted so member order never changes the key, hashed so the value stays short
+    enough to live in metadata and be compared cheaply.
+    """
+    joined = "|".join(sorted(fiber_ids))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:32]
+
+
+def _summary_cluster_key(cluster_fibers: Sequence[Fiber]) -> str:
+    """Cluster key for the fibers a summary is about."""
+    return _summary_cluster_key_from_ids(f.id for f in cluster_fibers)
+
+
+_MERGED_SUMMARY_MAX_CHARS = 500
+
+
+def _merged_summary(member_fibers: Sequence[Fiber]) -> str:
+    """Summary for a merged fiber, built from its sources.
+
+    The previous constant string ("Merged from N fibers") is what recall surfaces
+    return for the merged fiber, so every merge used to erase the only human-readable
+    trace of what the memory was about.
+    """
+    parts = [f.summary.strip() for f in member_fibers if f.summary and f.summary.strip()]
+    if not parts:
+        return f"Merged from {len(member_fibers)} fibers"
+    joined = "; ".join(dict.fromkeys(parts))
+    if len(joined) <= _MERGED_SUMMARY_MAX_CHARS:
+        return joined
+    return joined[: _MERGED_SUMMARY_MAX_CHARS - 1].rstrip() + "…"
+
+
+def _merged_metadata(member_fibers: Sequence[Fiber]) -> dict[str, Any]:
+    """Union of the sources' metadata plus the merge provenance.
+
+    Replacing metadata wholesale dropped essence, conductivity, coherence,
+    compression_tier and _verbatim. Sources are applied in ascending salience so the
+    most salient fiber wins a key collision.
+    """
+    merged: dict[str, Any] = {}
+    for fiber in sorted(member_fibers, key=lambda f: f.salience):
+        for key, value in fiber.metadata.items():
+            if key == "merged_from":
+                continue
+            merged[key] = value
+    merged["merged_from"] = [f.id for f in member_fibers]
+    return merged
+
 
 # How many dormant neurons one dream cycle replays. Kept small on purpose: the
 # point is a trickle of reactivation so nothing stays dormant forever, not a
@@ -84,6 +137,15 @@ class ConsolidationConfig:
     infer_co_activation_threshold: int = 3
     infer_window_days: int = 7
     infer_max_per_run: int = 50
+    # How many anchors one dedup census compares pairwise. Configurable because the
+    # pass walks a rotating window: with a hardcoded value the only way to widen
+    # coverage on a large brain was to edit the source.
+    dedup_max_anchors: int = _DEDUP_MAX_ANCHORS
+    # Hamming distance below which two SimHash fingerprints count as near-duplicates.
+    # Mirrors DedupConfig.simhash_threshold — the census used to fall back to the
+    # looser library default (10), so it counted pairs the project's own policy no
+    # longer considers duplicates.
+    dedup_simhash_threshold: int = 7
     # 600s per strategy, not 120s: on large brains (10k+ neurons) the heavy passes
     # — compress, lifecycle, essence backfill — legitimately need minutes, and a
     # 120s cap aborted them mid-run so consolidation never converged.
@@ -152,6 +214,9 @@ class ConsolidationReport:
     semantic_synapses_skipped: int = 0
     """Eligible pairs that already carried a synapse, so no edge was created."""
     drift_clusters_found: int = 0
+    # Detected and persisted are separate: the counter used to return the SAVED count
+    # while the report called it "found", so a failing write looked like a smaller brain.
+    drift_clusters_persisted: int = 0
     """Tag clusters (re)detected and persisted by DETECT_DRIFT this run."""
     memories_promoted: int = 0
     fibers_compressed: int = 0
@@ -192,6 +257,72 @@ class ConsolidationReport:
             return ""
         parts = ", ".join(f"{key}: {count}" for key, count in transitions.items() if count)
         return f" ({parts})" if parts else ""
+
+    def _drift_cluster_line(self) -> str:
+        """Drift line that distinguishes detection from persistence.
+
+        The old wording printed the SAVED count under the word "found", so a run whose
+        writes failed looked like a run that simply found less.
+        """
+        line = f"  Drift clusters found: {self.drift_clusters_found}"
+        failed = self.drift_clusters_found - self.drift_clusters_persisted
+        if failed > 0:
+            line += f" ({self.drift_clusters_persisted} persisted, {failed} FAILED to persist)"
+        return line
+
+    def _semantic_link_failure_line(self) -> str | None:
+        """Surface write failures that were previously recorded and never shown."""
+        failures = int(self.extra.get("semantic_link_failures", 0))
+        if failures <= 0:
+            return None
+        return f"  Semantic synapse writes FAILED: {failures}"
+
+    def _merge_delete_failure_line(self) -> str | None:
+        """Surface merge deletes that did not confirm."""
+        failures = int(self.extra.get("merge_delete_failures", 0))
+        if failures <= 0:
+            return None
+        return f"  Merge source deletes FAILED: {failures}"
+
+    def _summaries_skipped_line(self) -> str | None:
+        """Show idempotence at work: clusters whose summary already existed."""
+        skipped = int(self.extra.get("summaries_skipped_existing", 0))
+        if skipped <= 0:
+            return None
+        return f"  Summaries skipped (already exist): {skipped}"
+
+    def _silent_strategy_lines(self) -> list[str]:
+        """Work done by strategies that never had a line of their own.
+
+        replay, interference, schema and tiering all wrote their results into
+        ``extra`` and nothing rendered them, so a run that reorganised the graph
+        looked identical to a run that did nothing.
+        """
+        lines: list[str] = []
+        ltp = int(self.extra.get("replay_ltp", 0))
+        ltd = int(self.extra.get("replay_ltd", 0))
+        episodes = int(self.extra.get("replay_episodes", 0))
+        if episodes or ltp or ltd:
+            lines.append(
+                f"  Hippocampal replay: {episodes} episodes ({ltp} strengthened, {ltd} weakened)"
+            )
+        fan_effects = int(self.extra.get("interference_fan_effects", 0))
+        if fan_effects:
+            lines.append(f"  Interference fan effects: {fan_effects}")
+        schemas = int(self.extra.get("schemas_created", 0))
+        if schemas:
+            lines.append(f"  Schemas created: {schemas}")
+        auto_tier = self.extra.get("auto_tier")
+        if auto_tier:
+            lines.append(f"  Auto-tiering: {auto_tier}")
+        return lines
+
+    def _compress_deferred_line(self) -> str | None:
+        """Show work postponed by the compression budget instead of hiding it as zero."""
+        deferred = int(self.extra.get("compress_fibers_deferred", 0))
+        if deferred <= 0:
+            return None
+        return f"  Fibers deferred (time budget): {deferred}"
 
     def _alias_link_line(self) -> str:
         """Render the dedup counters so "nothing to do" cannot read like "all broken".
@@ -251,7 +382,7 @@ class ConsolidationReport:
             f"  Tokens saved: {self.tokens_saved}",
             f"  Reasoning traces ingested: {self.reasoning_traces_ingested}",
             f"  Reasoning patterns learned: {self.reasoning_patterns_learned}",
-            f"  Drift clusters found: {self.drift_clusters_found}",
+            self._drift_cluster_line(),
             f"  Duration: {self.duration_ms:.1f}ms",
         ]
         if self.merge_details:
@@ -261,6 +392,19 @@ class ConsolidationReport:
                     f"    {len(detail.original_fiber_ids)} fibers -> {detail.merged_fiber_id[:8]}... "
                     f"({detail.neuron_count} neurons, {detail.reason})"
                 )
+
+        # Counters that were recorded but never rendered: a run whose writes failed
+        # used to be indistinguishable from a clean one. Each line appears only when
+        # non-zero, so a healthy run stays quiet.
+        for optional_line in (
+            self._summaries_skipped_line(),
+            self._merge_delete_failure_line(),
+            self._semantic_link_failure_line(),
+            self._compress_deferred_line(),
+        ):
+            if optional_line:
+                lines.append(optional_line)
+        lines.extend(self._silent_strategy_lines())
 
         # Zeros from a pass where stages died look exactly like zeros from a
         # pass where there was nothing to do. Say which it was — but only when
@@ -1043,8 +1187,8 @@ class ConsolidationEngine:
                 frequency=best_frequency,
                 auto_tags=merged_auto_tags,
                 agent_tags=merged_agent_tags,
-                summary=f"Merged from {len(member_fibers)} fibers",
-                metadata={"merged_from": [f.id for f in member_fibers]},
+                summary=_merged_summary(member_fibers),
+                metadata=_merged_metadata(member_fibers),
                 created_at=min(f.created_at for f in member_fibers),
             )
 
@@ -1091,10 +1235,30 @@ class ConsolidationEngine:
                     if record is not None:
                         source_maturations.append(record)
 
-                for fiber in member_fibers:
-                    await self._storage.delete_fiber(fiber.id)
-                    report.fibers_removed += 1
+                # Read the typed-memory layer BEFORE anything is deleted. delete_fiber
+                # has no cascade to typed_memory, and update_typed_memory cannot move a
+                # row to another fiber (its record id is derived from fiber_id), so a
+                # merge that skipped this step silently orphaned memory_type, priority,
+                # trust_score and the validity window of every source.
+                source_typed = await self._collect_source_typed_memories(member_fibers)
+
+                # Create BEFORE destroying. The previous order deleted every source
+                # first, so a failing add_fiber left N fibers gone with no successor —
+                # unrecoverable, because storage here is not transactional.
                 await self._storage.add_fiber(merged_fiber)
+
+                if source_typed is not None:
+                    await self._reassign_typed_memory(source_typed, member_fibers, merged_fiber_id)
+
+                for fiber in member_fibers:
+                    if await self._storage.delete_fiber(fiber.id):
+                        report.fibers_removed += 1
+                    else:
+                        # delete_fiber swallows its exception and returns False; counting
+                        # the attempt would report work that never happened.
+                        report.extra["merge_delete_failures"] = (
+                            int(report.extra.get("merge_delete_failures", 0)) + 1
+                        )
 
                 if source_maturations:
                     # Merging must never cost a fiber the maturation progress it
@@ -1131,17 +1295,171 @@ class ConsolidationEngine:
                         )
                     )
 
+    _DEDUP_CURSOR_KEY = "_dedup_anchor_cursor"
+
+    async def _dedup_cursor(self, anchors_total: int) -> int:
+        """Where this run's dedup window starts.
+
+        Persisted in Brain.metadata (SCHEMALESS, same place the quality badge lives)
+        rather than a new table — no migration, and the state is naturally per-brain.
+        Read-modify-write is not atomic, which is acceptable because consolidations do
+        not run concurrently; the worst case is a window repeated once.
+        """
+        try:
+            brain = await self._storage.get_brain(self._storage.current_brain_id or "")
+        except Exception:
+            logger.debug("Could not read dedup cursor", exc_info=True)
+            return 0
+        if brain is None:
+            return 0
+        raw = brain.metadata.get(self._DEDUP_CURSOR_KEY, 0)
+        try:
+            cursor = int(raw)
+        except (TypeError, ValueError):
+            return 0
+        # A shrunken brain must not leave the cursor past the end.
+        return cursor % anchors_total if anchors_total else 0
+
+    async def _advance_dedup_cursor(self, cursor: int, cap: int, anchors_total: int) -> None:
+        """Move the window forward so the next run sees the next slice."""
+        if anchors_total <= 0:
+            return
+        next_cursor = (cursor + cap) % anchors_total
+        try:
+            brain_id = self._storage.current_brain_id or ""
+            brain = await self._storage.get_brain(brain_id)
+            if brain is None:
+                return
+            brain.metadata[self._DEDUP_CURSOR_KEY] = next_cursor
+            await self._storage.save_brain(brain)
+        except Exception:
+            # A cursor that fails to advance costs coverage on the next run, not
+            # correctness of this one — never abort the pass over it.
+            logger.debug("Could not persist dedup cursor", exc_info=True)
+
+    async def _collect_source_typed_memories(
+        self, member_fibers: list[Fiber]
+    ) -> dict[str, Any] | None:
+        """Typed-memory rows of the fibers about to be merged, read before any delete.
+
+        Returns ``None`` when the layer cannot be read, so the caller can tell "no rows
+        existed" apart from "the lookup failed" and skip the reassignment rather than
+        destroying rows it never saw.
+        """
+        try:
+            return await self._storage.get_typed_memories_batch([f.id for f in member_fibers])
+        except Exception:
+            logger.debug("Could not read typed memories during merge", exc_info=True)
+            return None
+
+    async def _reassign_typed_memory(
+        self,
+        source_typed: dict[str, Any],
+        member_fibers: list[Fiber],
+        merged_fiber_id: str,
+    ) -> None:
+        """Move the merged fibers' typed-memory layer onto the surviving fiber.
+
+        ``add_typed_memory`` is an UPSERT keyed by fiber_id, so writing the merged row
+        first and deleting the sources afterwards never leaves the merge without a
+        typed-memory row. Conflicts resolve deterministically: strongest priority wins,
+        then the widest validity window, so merging can only preserve reach, never
+        silently shorten how long a memory stays valid.
+        """
+        records = [tm for tm in source_typed.values() if tm is not None]
+        if not records:
+            return
+
+        def _priority_of(record: Any) -> tuple[int, float]:
+            # created_at as the tie-break keeps the choice stable across runs.
+            return (int(record.priority), -record.created_at.timestamp())
+
+        winner = max(records, key=_priority_of)
+        trust_scores = [r.trust_score for r in records if r.trust_score is not None]
+        valid_froms = [r.valid_from for r in records if r.valid_from is not None]
+        expiries = [r.expires_at for r in records if r.expires_at is not None]
+
+        merged_tags: set[str] = set()
+        for record in records:
+            merged_tags |= set(record.tags)
+
+        merged_record = dc_replace(
+            winner,
+            fiber_id=merged_fiber_id,
+            trust_score=max(trust_scores) if trust_scores else winner.trust_score,
+            valid_from=min(valid_froms) if valid_froms else winner.valid_from,
+            # All sources expiring -> keep the latest; any source open-ended -> stay
+            # open-ended, because a merge must not invent an expiry.
+            expires_at=(max(expiries) if len(expiries) == len(records) and expiries else None),
+            tags=frozenset(merged_tags),
+        )
+
+        try:
+            await self._storage.add_typed_memory(merged_record)
+        except Exception:
+            logger.warning("Could not write merged typed memory", exc_info=True)
+            return
+
+        for fiber in member_fibers:
+            if fiber.id == merged_fiber_id:
+                continue
+            if fiber.id in source_typed:
+                try:
+                    await self._storage.delete_typed_memory(fiber.id)
+                except Exception:
+                    logger.debug("Could not delete source typed memory", exc_info=True)
+
+    @staticmethod
+    def _summarize_input_fibers(fibers: list[Fiber]) -> list[Fiber]:
+        """Fibers eligible as clustering INPUT.
+
+        Excludes this pass's own output: a summary fiber carries the union of its
+        sources' tags, so leaving it in would let each run cluster the previous run's
+        summaries and grow the brain without bound.
+        """
+        return [f for f in fibers if f.tags and f.metadata.get("_consolidation") != "summary_fiber"]
+
+    @staticmethod
+    def _existing_summary_cluster_keys(fibers: list[Fiber]) -> set[str]:
+        """Cluster keys of summaries that already exist.
+
+        Derived from the same fiber list the pass already fetched rather than a second
+        query: ``find_fibers`` has no offset parameter, so a separate lookup could not
+        be paged and would silently see only its first page.
+        """
+        keys: set[str] = set()
+        for fiber in fibers:
+            if fiber.metadata.get("_consolidation") != "summary_fiber":
+                continue
+            key = fiber.metadata.get("_cluster_key")
+            if key:
+                keys.add(str(key))
+                continue
+            # Summaries written before the key existed: derive it from the recorded
+            # sources so historical rows still suppress duplicates.
+            sources = fiber.metadata.get("source_fibers")
+            if isinstance(sources, list) and sources:
+                keys.add(_summary_cluster_key_from_ids(str(s) for s in sources))
+        return keys
+
     async def _summarize(
         self,
         report: ConsolidationReport,
         dry_run: bool,
     ) -> None:
-        """Create concept neurons for tag-based clusters using inverted index."""
+        """Create concept neurons for tag-based clusters using inverted index.
+
+        Idempotent: a cluster whose summary already exists is skipped rather than
+        recreated. Without that gate every run re-materialised the same clusters —
+        one concept neuron, one fiber and up to ten synapses each — and, because
+        summary fibers carry the union of their sources' tags, they fed straight
+        back into the next clustering pass.
+        """
         fibers = await self._storage.get_fibers(limit=10000)
         if len(fibers) < self._config.summarize_min_cluster_size:
             return
 
-        fiber_list = [f for f in fibers if f.tags]
+        fiber_list = self._summarize_input_fibers(fibers)
 
         # Cap fiber count for O(N²) pair comparison — keep highest-salience
         max_fibers_for_clustering = 1000
@@ -1210,11 +1528,24 @@ class ConsolidationEngine:
             root = find(i)
             groups.setdefault(root, []).append(i)
 
+        existing_cluster_keys = self._existing_summary_cluster_keys(fibers)
+
         for members in groups.values():
             if len(members) < self._config.summarize_min_cluster_size:
                 continue
 
             cluster_fibers = [fiber_list[i] for i in members]
+
+            # Idempotence gate: a cluster is identified by the set of fibers it
+            # summarises, so the same input always yields the same key. Comparing the
+            # key in Python is deliberate — find_fibers(metadata_key=...) filters on
+            # key EXISTENCE, not value.
+            cluster_key = _summary_cluster_key(cluster_fibers)
+            if cluster_key in existing_cluster_keys:
+                report.extra["summaries_skipped_existing"] = (
+                    int(report.extra.get("summaries_skipped_existing", 0)) + 1
+                )
+                continue
 
             summaries = [f.summary for f in cluster_fibers if f.summary]
             all_tags: set[str] = set()
@@ -1275,6 +1606,7 @@ class ConsolidationEngine:
                 tags=all_tags,
                 metadata={
                     "_consolidation": "summary_fiber",
+                    "_cluster_key": cluster_key,
                     "source_fibers": [f.id for f in cluster_fibers],
                 },
             )
@@ -1933,10 +2265,21 @@ class ConsolidationEngine:
             report.extra["dedup_anchors_scanned"] = anchors_total
             return
 
-        # Cap anchors to prevent O(N^2) blowup (N=2000 → 2M comparisons)
-        if anchors_total > _DEDUP_MAX_ANCHORS:
-            anchors = anchors[:_DEDUP_MAX_ANCHORS]
+        # Cap anchors to prevent O(N^2) blowup, but ROTATE the window between runs.
+        # Taking a fixed prefix meant the same anchors were compared every time while
+        # the rest of the population was never compared at all — not "later", ever.
+        cap = max(2, int(self._config.dedup_max_anchors))
+        cursor = 0
+        if anchors_total > cap:
+            cursor = await self._dedup_cursor(anchors_total)
+            window = anchors[cursor : cursor + cap]
+            if len(window) < cap:
+                # Wrap around so the window keeps its size at the end of the list.
+                window += anchors[: cap - len(window)]
+            anchors = window
             report.extra["dedup_anchors_truncated"] = True
+            report.extra["dedup_window_start"] = cursor
+            await self._advance_dedup_cursor(cursor, cap, anchors_total)
             # INFO, not WARNING: on a brain that has simply outgrown the cap this
             # is a steady state, and every run would raise the same alarm until
             # operators learned to ignore dedup warnings — burying the real
@@ -2000,7 +2343,11 @@ class ConsolidationEngine:
                 if anchor_b.content_hash is None or anchor_b.content_hash == 0:
                     continue
 
-                if is_near_duplicate(anchor_a.content_hash, anchor_b.content_hash):
+                if is_near_duplicate(
+                    anchor_a.content_hash,
+                    anchor_b.content_hash,
+                    threshold=self._config.dedup_simhash_threshold,
+                ):
                     report.duplicates_found += 1
                     seen.add(anchor_b.id)
 
@@ -2146,12 +2493,13 @@ class ConsolidationEngine:
         """
         from surreal_memory.engine.drift_clusters import refresh_drift_clusters
 
-        try:
-            report.drift_clusters_found = await refresh_drift_clusters(
-                self._storage, persist=not dry_run
-            )
-        except Exception:
-            logger.warning("Drift cluster detection failed", exc_info=True)
+        # Deliberately NOT wrapped in try/except: swallowing the failure here kept it
+        # out of `failed_strategies`, so a dead detector reported "0 clusters" and read
+        # exactly like a clean brain. The run() loop already records and names a failing
+        # strategy, which is the honest outcome.
+        detected, persisted = await refresh_drift_clusters(self._storage, persist=not dry_run)
+        report.drift_clusters_found = detected
+        report.drift_clusters_persisted = persisted
 
     async def _compress(
         self,

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -563,7 +563,7 @@ class ConsolidationEngine:
         tier_config: TierConfig | None = None,
     ) -> None:
         self._storage = storage
-        self._config = config or ConsolidationConfig()
+        self._config = config or self._config_from_settings()
         self._dream_decay_multiplier = dream_decay_multiplier
         self._tier_config = tier_config
 
@@ -1324,6 +1324,25 @@ class ConsolidationEngine:
 
     _DEDUP_CURSOR_KEY = "_dedup_anchor_cursor"
     _SYNAPSE_PAGE_SIZE = 5000
+
+    @staticmethod
+    def _config_from_settings() -> ConsolidationConfig:
+        """Default config, with the dedup knobs taken from the user's [dedup] section.
+
+        Without this the census cap and threshold were only reachable by editing the
+        source — the settings existed but nothing read them.
+        """
+        try:
+            from surreal_memory.unified_config import UnifiedConfig
+
+            dedup = UnifiedConfig.load().dedup
+            return ConsolidationConfig(
+                dedup_max_anchors=int(dedup.consolidation_max_anchors),
+                dedup_simhash_threshold=int(dedup.simhash_threshold),
+            )
+        except Exception:
+            # Config is optional here: consolidation must still run on a bare install.
+            return ConsolidationConfig()
 
     async def _all_synapses_paged(self) -> list[Synapse]:
         """Every synapse in the brain, fetched in pages instead of one giant read.

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -287,9 +287,16 @@ class ConsolidationReport:
     def _summaries_skipped_line(self) -> str | None:
         """Show idempotence at work: clusters whose summary already existed."""
         skipped = int(self.extra.get("summaries_skipped_existing", 0))
-        if skipped <= 0:
-            return None
-        return f"  Summaries skipped (already exist): {skipped}"
+        total = self.extra.get("summarize_fibers_total")
+        scanned = self.extra.get("summarize_fibers_scanned")
+        parts = []
+        if skipped > 0:
+            parts.append(f"  Summaries skipped (already exist): {skipped}")
+        if total and scanned:
+            parts.append(
+                f"  [summarize input truncated: {scanned} of {total} tagged fibers clustered]"
+            )
+        return "\n".join(parts) if parts else None
 
     def _silent_strategy_lines(self) -> list[str]:
         """Work done by strategies that never had a line of their own.
@@ -315,6 +322,13 @@ class ConsolidationReport:
         auto_tier = self.extra.get("auto_tier")
         if auto_tier:
             lines.append(f"  Auto-tiering: {auto_tier}")
+        ingested = int(self.extra.get("tool_events_ingested", 0))
+        processed = int(self.extra.get("tool_events_processed", 0))
+        if ingested or processed:
+            lines.append(f"  Tool events: {ingested} ingested, {processed} processed")
+        states = int(self.extra.get("lifecycle_states_updated", 0))
+        if states:
+            lines.append(f"  Lifecycle states updated: {states}")
         return lines
 
     def _compress_deferred_line(self) -> str | None:
@@ -1464,6 +1478,10 @@ class ConsolidationEngine:
         # Cap fiber count for O(N²) pair comparison — keep highest-salience
         max_fibers_for_clustering = 1000
         if len(fiber_list) > max_fibers_for_clustering:
+            # Say so in the report. Dedup annotates its census cap; this one used to cut
+            # silently, so a partial result read as a complete one.
+            report.extra["summarize_fibers_total"] = len(fiber_list)
+            report.extra["summarize_fibers_scanned"] = max_fibers_for_clustering
             fiber_list = sorted(fiber_list, key=lambda f: f.salience, reverse=True)[
                 :max_fibers_for_clustering
             ]
@@ -2698,6 +2716,11 @@ class ConsolidationEngine:
             config.tool_memory.max_buffer_lines,
         )
         if ingest_result.events_ingested > 0:
+            # Into the report, not only the debug log: this strategy could ingest
+            # thousands of events and the report looked identical to it being disabled.
+            report.extra["tool_events_ingested"] = (
+                int(report.extra.get("tool_events_ingested", 0)) + ingest_result.events_ingested
+            )
             _logger.debug(
                 "PROCESS_TOOL_EVENTS: ingested %d events from buffer",
                 ingest_result.events_ingested,
@@ -2706,6 +2729,9 @@ class ConsolidationEngine:
         # Process events into neurons/synapses
         result = await process_events(self._storage, brain_id, config.tool_memory)  # type: ignore[arg-type]
         if result.events_processed > 0:
+            report.extra["tool_events_processed"] = (
+                int(report.extra.get("tool_events_processed", 0)) + result.events_processed
+            )
             _logger.debug(
                 "PROCESS_TOOL_EVENTS: processed %d events, created %d neurons, %d synapses",
                 result.events_processed,

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -241,8 +241,21 @@ class ConsolidationReport:
             f"{self.semantic_synapses_created} created, "
             f"{self.semantic_synapses_skipped} skipped (existing)"
         )
+        seen_twice = int(self.extra.get("semantic_pairs_seen_twice", 0))
+        if seen_twice:
+            # These were created by THIS pass and reached a second time from the other
+            # end of the neighbourhood. Folding them into "existing" overstated how much
+            # of the graph was already linked.
+            line += f", {seen_twice} reached twice this run"
         if self.extra.get("semantic_link_truncated"):
             line += " [truncated at cap]"
+        total = self.extra.get("semantic_candidates_total")
+        scanned = self.extra.get("semantic_candidates_scanned")
+        if total and scanned:
+            line += (
+                f" [candidates resampled: {scanned} of {total} — counters are NOT "
+                "comparable with the previous run]"
+            )
         return line
 
     def _stage_transitions_suffix(self) -> str:
@@ -767,7 +780,7 @@ class ConsolidationEngine:
             return
 
         # Get all synapses
-        all_synapses = await self._storage.get_synapses()
+        all_synapses = await self._all_synapses_paged()
         pruned_synapse_ids: set[str] = set()
 
         # Preload pinned neuron IDs to protect from pruning
@@ -1310,6 +1323,31 @@ class ConsolidationEngine:
                     )
 
     _DEDUP_CURSOR_KEY = "_dedup_anchor_cursor"
+    _SYNAPSE_PAGE_SIZE = 5000
+
+    async def _all_synapses_paged(self) -> list[Synapse]:
+        """Every synapse in the brain, fetched in pages instead of one giant read.
+
+        Measured on a real brain: an unbounded ``get_synapses()`` pulls the entire
+        table — six figures of rows — over a single response. That is the shape that
+        produced ``[Errno 104] Connection reset by peer`` elsewhere in this engine, and
+        it is why semantic_discovery already pages. Same total work, but no single
+        oversized response and a yield point between pages.
+        """
+        collected: list[Synapse] = []
+        offset = 0
+        while True:
+            page = await self._storage.get_synapses(limit=self._SYNAPSE_PAGE_SIZE, offset=offset)
+            if not page:
+                break
+            collected.extend(page)
+            if len(page) < self._SYNAPSE_PAGE_SIZE:
+                break
+            offset += len(page)
+            # Nothing else in these passes awaits, so without this the connection's
+            # keepalive never runs during a long scan.
+            await asyncio.sleep(0)
+        return collected
 
     async def _dedup_cursor(self, anchors_total: int) -> int:
         """Where this run's dedup window starts.
@@ -1910,7 +1948,7 @@ class ConsolidationEngine:
 
         # 2. Build existing synapse pairs set + lookup for reinforcement
         # Need all types: existing_pairs prevents duplicate creation, synapse_by_pair enables reinforcement
-        all_synapses = await self._storage.get_synapses()
+        all_synapses = await self._all_synapses_paged()
         existing_pairs: set[tuple[str, str]] = set()
         synapse_by_pair: dict[tuple[str, str], Synapse] = {}
         for syn in all_synapses:
@@ -2460,6 +2498,17 @@ class ConsolidationEngine:
         # type; surfacing that number is what turns a flat "2000" into an
         # honest "N created, K skipped".
         report.semantic_synapses_skipped += result.skipped_existing
+        if result.skipped_created_this_run:
+            report.extra["semantic_pairs_seen_twice"] = (
+                int(report.extra.get("semantic_pairs_seen_twice", 0))
+                + result.skipped_created_this_run
+            )
+        if result.eligible_total:
+            # The candidate set was resampled, so this run's counters describe a
+            # different slice than the last one's. Say so rather than letting the
+            # numbers look comparable.
+            report.extra["semantic_candidates_total"] = result.eligible_total
+            report.extra["semantic_candidates_scanned"] = result.neurons_embedded
         if result.truncated:
             report.extra["semantic_link_truncated"] = True
 

--- a/src/surreal_memory/engine/consolidation_delta.py
+++ b/src/surreal_memory/engine/consolidation_delta.py
@@ -100,7 +100,12 @@ class ConsolidationDelta:
                 round(self.after.freshness - self.before.freshness, 4),
             ),
             (
-                "Consolidation ratio",
+                # Named for what it measures, not for the pass it appears under. It is
+                # the share of fibers that reached the SEMANTIC maturation stage — NOT a
+                # compression or merge ratio, which is how the old label read directly
+                # beneath the merge counters. The wire field keeps its old name so the
+                # API and dashboard contract is unchanged.
+                "Semantic maturation ratio",
                 self.before.consolidation_ratio,
                 self.after.consolidation_ratio,
                 round(self.after.consolidation_ratio - self.before.consolidation_ratio, 4),

--- a/src/surreal_memory/engine/dream.py
+++ b/src/surreal_memory/engine/dream.py
@@ -75,7 +75,7 @@ async def dream(
 
     # Build set of existing synapse pairs for fast lookup
     # Only fetch RELATED_TO synapses — dream creates this type
-    all_synapses = await storage.get_synapses(type=SynapseType.RELATED_TO)
+    all_synapses = await storage.get_synapses_paged(type=SynapseType.RELATED_TO)
     existing_pairs: set[tuple[str, str]] = set()
     for syn in all_synapses:
         existing_pairs.add((syn.source_id, syn.target_id))

--- a/src/surreal_memory/engine/drift_clusters.py
+++ b/src/surreal_memory/engine/drift_clusters.py
@@ -196,7 +196,9 @@ def detect_clusters(
     return reports
 
 
-async def refresh_drift_clusters(storage: NeuralStorage, *, persist: bool = True) -> int:
+async def refresh_drift_clusters(
+    storage: NeuralStorage, *, persist: bool = True
+) -> tuple[int, int]:
     """Recompute drift clusters from the current tag_cooccurrence table.
 
     Read-detect-persist, all fail-soft on the reads (an empty result degrades
@@ -211,7 +213,9 @@ async def refresh_drift_clusters(storage: NeuralStorage, *, persist: bool = True
     whole feature exists to remove. Mirrors ``ConsolidationEngine._dedup``,
     which likewise censuses unconditionally and gates only its writes.
 
-    Returns the number of clusters persisted, or would-be-persisted on a dry run.
+    Returns ``(detected, persisted)``. The two are reported separately because a
+    failing write used to be indistinguishable from a cluster that was never found:
+    the count returned was the SAVED count while the report called it "found".
     """
     # WARNING, not debug: a failed read here makes the pass report zero clusters,
     # which is indistinguishable from an honest "no drift found" — the exact
@@ -223,18 +227,19 @@ async def refresh_drift_clusters(storage: NeuralStorage, *, persist: bool = True
         cooccurrences = await storage.get_tag_cooccurrence(min_count=MIN_COOCCURRENCE_COUNT)
     except Exception:
         logger.warning("Failed to read tag_cooccurrence for drift detection", exc_info=True)
-        return 0
+        return (0, 0)
 
     try:
         tag_fiber_counts = await storage.get_tag_fiber_counts()
     except Exception:
         logger.warning("Failed to read tag fiber counts for drift detection", exc_info=True)
-        return 0
+        return (0, 0)
 
     reports = detect_clusters(cooccurrences, tag_fiber_counts)
+    detected = len(reports)
 
     if not persist:
-        return len(reports)
+        return (detected, detected)
 
     saved = 0
     for report in reports:
@@ -248,6 +253,9 @@ async def refresh_drift_clusters(storage: NeuralStorage, *, persist: bool = True
             )
             saved += 1
         except Exception:
-            logger.debug("Failed to persist drift cluster %s", report.cluster_id, exc_info=True)
+            # WARNING, not debug: a swallowed write silently lowers the number the
+            # report shows, so the operator sees "fewer clusters" instead of "a write
+            # failed".
+            logger.warning("Failed to persist drift cluster %s", report.cluster_id, exc_info=True)
 
-    return saved
+    return (detected, saved)

--- a/src/surreal_memory/engine/enrichment.py
+++ b/src/surreal_memory/engine/enrichment.py
@@ -174,7 +174,7 @@ async def find_cross_cluster_links(
         cluster_anchors.append(best_fiber.anchor_neuron_id)
 
     # Check existing synapses between cluster anchors
-    existing_synapses = await storage.get_synapses(type=SynapseType.RELATED_TO)
+    existing_synapses = await storage.get_synapses_paged(type=SynapseType.RELATED_TO)
     existing_pairs: set[tuple[str, str]] = set()
     for syn in existing_synapses:
         existing_pairs.add((syn.source_id, syn.target_id))

--- a/src/surreal_memory/engine/query_pattern_mining.py
+++ b/src/surreal_memory/engine/query_pattern_mining.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
+from datetime import timedelta
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -32,6 +33,10 @@ if TYPE_CHECKING:
     from surreal_memory.storage.base import NeuralStorage
 
 logger = logging.getLogger(__name__)
+
+# Mining window for recall events. Matches the habit miner's 30-day horizon so both
+# passes describe the same recent behaviour rather than two different eras.
+_QUERY_PATTERN_WINDOW_DAYS = 30
 
 
 @dataclass(frozen=True)
@@ -216,8 +221,13 @@ async def learn_query_patterns(
     """
     report = QueryPatternReport()
 
-    # Fetch recall events
-    events = await storage.get_action_sequences(limit=1000)
+    # Fetch recall events from a RECENT window. Without `since` the backend orders
+    # ascending and returns the 1000 OLDEST events in the brain's history, so once the
+    # log passes that size no new query ever enters the window and this pass mines a
+    # frozen prefix forever. learn_habits already passes a window; this one did not.
+    events = await storage.get_action_sequences(
+        since=reference_time - timedelta(days=_QUERY_PATTERN_WINDOW_DAYS), limit=1000
+    )
     recall_events = [e for e in events if e.action_type == "recall" and e.action_context]
 
     if len(recall_events) < 3:

--- a/src/surreal_memory/engine/semantic_discovery.py
+++ b/src/surreal_memory/engine/semantic_discovery.py
@@ -74,6 +74,22 @@ class SemanticDiscoveryResult:
     pairs_evaluated: int = 0
     synapses_created: int = 0
     skipped_existing: int = 0
+    skipped_created_this_run: int = 0
+    """Pairs skipped because THIS pass had just created them.
+
+    Kept apart from ``skipped_existing``: a bidirectional top-K neighbourhood reaches
+    each pair twice, so counting the second visit as pre-existing made the report
+    overstate how much of the graph was already linked.
+    """
+
+    eligible_total: int = 0
+    """Candidates before ``MAX_NEURONS_TO_LINK`` resampling — 0 when nothing was cut.
+
+    Each pass deliberately targets the least-connected slice, so consecutive runs
+    describe different candidate sets and their counters are not comparable. Saying so
+    is the difference between an honest metric and a confusing one.
+    """
+
     synapses: list[Synapse] = field(default_factory=list)
     truncated: bool = False
     """True when the run stopped at ``semantic_discovery_max_pairs``.
@@ -402,8 +418,12 @@ async def discover_semantic_synapses(
     # Safety cap on very large brains. Below the cap, ordering doesn't matter
     # (everything is considered); above it, WHICH neurons get dropped decides
     # whether repeated runs make progress or just resaturate the same slice.
+    eligible_before_resample = len(eligible)
     if len(eligible) > MAX_NEURONS_TO_LINK:
         eligible, vectors = await _select_candidates(storage, eligible, vectors)
+    else:
+        # Nothing was cut, so there is no candidate-set change to report.
+        eligible_before_resample = 0
     neurons_embedded = len(vectors)
 
     # Existing pairs (any synapse type) so we never duplicate a connection.
@@ -431,12 +451,21 @@ async def discover_semantic_synapses(
 
     new_synapses: list[Synapse] = []
     skipped = 0
+    skipped_created_this_run = 0
     pairs_evaluated = 0
+    # Pairs this pass itself created. With a bidirectional top-K neighbourhood the same
+    # pair is reached twice — once from each end — so without this set the second visit
+    # was counted as "already existed", inflating a number the report labels as
+    # pre-existing links.
+    created_this_run: set[frozenset[str]] = set()
 
     def _link(i: int, j: int, sim: float) -> bool:
         """Create one SIMILAR_TO synapse if the pair is new. Returns True if added."""
-        nonlocal skipped
+        nonlocal skipped, skipped_created_this_run
         pair = frozenset({eligible[i].id, eligible[j].id})
+        if pair in created_this_run:
+            skipped_created_this_run += 1
+            return False
         if pair in existing_pairs:
             skipped += 1
             return False
@@ -457,6 +486,7 @@ async def discover_semantic_synapses(
             )
         )
         existing_pairs.add(pair)
+        created_this_run.add(pair)
         return True
 
     try:
@@ -525,6 +555,8 @@ async def discover_semantic_synapses(
         pairs_evaluated=pairs_evaluated,
         synapses_created=len(new_synapses),
         skipped_existing=skipped,
+        skipped_created_this_run=skipped_created_this_run,
+        eligible_total=eligible_before_resample,
         synapses=new_synapses,
         truncated=len(new_synapses) >= max_pairs,
     )

--- a/src/surreal_memory/mcp/lifecycle_handler.py
+++ b/src/surreal_memory/mcp/lifecycle_handler.py
@@ -358,14 +358,17 @@ class LifecycleHandler:
         extra = {
             key: value
             for key, value in delta.report.extra.items()
-            if key.startswith(("alias_", "dedup_"))
+            if key.startswith(("alias_", "dedup_", "merge_", "semantic_link_", "summaries_"))
         }
         result["report"] = {
             "duplicates_found": delta.report.duplicates_found,
             "new_alias_links": delta.report.new_alias_links,
             "alias_links_existing": delta.report.alias_links_existing,
-            # On a dry run this is the count that WOULD have been persisted.
+            # Detected vs persisted, so the promise made in the comment above is
+            # actually kept: a client can now tell "no clusters exist" from "writes
+            # failed" without parsing prose.
             "drift_clusters_found": delta.report.drift_clusters_found,
+            "drift_clusters_persisted": delta.report.drift_clusters_persisted,
             "extra": extra,
         }
         return result

--- a/src/surreal_memory/server/routes/consolidation.py
+++ b/src/surreal_memory/server/routes/consolidation.py
@@ -51,6 +51,17 @@ class ConsolidationResponse(BaseModel):
     fibers_removed: int
     fibers_created: int
     summaries_created: int
+    # Counters that make a report readable rather than merely non-empty. Without
+    # them the dashboard cannot tell "nothing to do" from "the writes failed" —
+    # the same ambiguity the MCP contract already fixed.
+    summaries_skipped_existing: int = 0
+    merge_delete_failures: int = 0
+    drift_clusters_found: int = 0
+    drift_clusters_persisted: int = 0
+    semantic_synapses_created: int = 0
+    semantic_synapses_skipped: int = 0
+    duplicates_found: int = 0
+    new_alias_links: int = 0
     merge_details: list[MergeDetailResponse]
     dry_run: bool
 
@@ -102,6 +113,14 @@ async def consolidate_brain(
         fibers_removed=report.fibers_removed,
         fibers_created=report.fibers_created,
         summaries_created=report.summaries_created,
+        summaries_skipped_existing=int(report.extra.get("summaries_skipped_existing", 0)),
+        merge_delete_failures=int(report.extra.get("merge_delete_failures", 0)),
+        drift_clusters_found=report.drift_clusters_found,
+        drift_clusters_persisted=report.drift_clusters_persisted,
+        semantic_synapses_created=report.semantic_synapses_created,
+        semantic_synapses_skipped=report.semantic_synapses_skipped,
+        duplicates_found=report.duplicates_found,
+        new_alias_links=report.new_alias_links,
         merge_details=[
             MergeDetailResponse(
                 original_fiber_ids=list(d.original_fiber_ids),

--- a/src/surreal_memory/storage/base.py
+++ b/src/surreal_memory/storage/base.py
@@ -422,6 +422,33 @@ class NeuralStorage(ABC):
         """
         ...
 
+    async def get_synapses_paged(
+        self,
+        *,
+        type: SynapseType | None = None,
+        page_size: int = 5000,
+    ) -> list[Synapse]:
+        """Every matching synapse, fetched page by page instead of in one response.
+
+        An unbounded ``get_synapses()`` emits a query with no LIMIT. Measured on a real
+        brain that is six figures of rows in a single response — the shape that produces
+        ``[Errno 104] Connection reset by peer`` on the HTTP transport. The total work is
+        the same; what changes is that no individual response is oversized.
+
+        Concrete backends inherit this as-is; only ``get_synapses`` needs implementing.
+        """
+        collected: list[Synapse] = []
+        offset = 0
+        while True:
+            page = await self.get_synapses(type=type, limit=page_size, offset=offset)
+            if not page:
+                break
+            collected.extend(page)
+            if len(page) < page_size:
+                break
+            offset += len(page)
+        return collected
+
     @abstractmethod
     async def update_synapse(self, synapse: Synapse) -> None:
         """

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -875,6 +875,12 @@ class DedupSettings:
     llm_max_pairs_per_encode: int = 3
     merge_strategy: str = "keep_newer"
     max_candidates: int = 30  # wider search (was 10)
+    consolidation_max_anchors: int = 2000
+    """Anchors the consolidation census compares pairwise per run.
+
+    The window rotates between runs, so this widens each pass rather than deciding
+    what is ever looked at. Raising it costs CPU quadratically.
+    """
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -888,6 +894,7 @@ class DedupSettings:
             "llm_max_pairs_per_encode": self.llm_max_pairs_per_encode,
             "merge_strategy": self.merge_strategy,
             "max_candidates": self.max_candidates,
+            "consolidation_max_anchors": self.consolidation_max_anchors,
         }
 
     @classmethod
@@ -903,6 +910,7 @@ class DedupSettings:
             llm_max_pairs_per_encode=int(data.get("llm_max_pairs_per_encode", 3)),
             merge_strategy=str(data.get("merge_strategy", "keep_newer")),
             max_candidates=int(data.get("max_candidates", 30)),
+            consolidation_max_anchors=int(data.get("consolidation_max_anchors", 2000)),
         )
 
 

--- a/tests/unit/test_consolidation_integrity.py
+++ b/tests/unit/test_consolidation_integrity.py
@@ -277,6 +277,64 @@ class TestCounterContract:
         assert "Drift clusters found: 5" in text
         assert "FAILED" not in text, "a healthy run must not add noise"
 
+    def test_pairs_reached_twice_are_not_called_pre_existing(self) -> None:
+        """DEF-15: a pair this run created must not inflate 'skipped (existing)'."""
+        report = ConsolidationReport()
+        report.semantic_synapses_created = 10
+        report.semantic_synapses_skipped = 4
+        report.extra["semantic_pairs_seen_twice"] = 9
+
+        text = report.summary()
+        assert "4 skipped (existing)" in text
+        assert "9 reached twice this run" in text, (
+            "pairs created by this pass must be reported separately"
+        )
+
+    def test_resampled_candidates_are_flagged_as_incomparable(self) -> None:
+        """DEF-16: consecutive runs describe different candidate slices — say so."""
+        report = ConsolidationReport()
+        report.extra["semantic_candidates_total"] = 12000
+        report.extra["semantic_candidates_scanned"] = 10000
+
+        text = report.summary()
+        assert "candidates resampled: 10000 of 12000" in text
+        assert "NOT comparable" in text
+
+    def test_summarize_input_truncation_is_announced(self) -> None:
+        """DEF-16: a capped clustering input must not read as a complete one."""
+        report = ConsolidationReport()
+        report.extra["summarize_fibers_total"] = 2800
+        report.extra["summarize_fibers_scanned"] = 1000
+
+        text = report.summary()
+        assert "summarize input truncated: 1000 of 2800" in text
+
+    def test_tool_event_work_reaches_the_report(self) -> None:
+        """DEF-14: ingesting thousands of events must not look like being disabled."""
+        report = ConsolidationReport()
+        report.extra["tool_events_ingested"] = 1200
+        report.extra["tool_events_processed"] = 900
+
+        assert "Tool events: 1200 ingested, 900 processed" in report.summary()
+
+    def test_maturation_ratio_is_named_for_what_it_measures(self) -> None:
+        """DEF-17: the label sat under the merge counters and read as a merge ratio.
+
+        Checks the RENDERED delta, not the source, so a mention of the old wording in a
+        comment cannot pass or fail the test by accident.
+        """
+        import inspect
+
+        from surreal_memory.engine import consolidation_delta
+
+        render = inspect.getsource(consolidation_delta.ConsolidationDelta.summary)
+        assert '"Semantic maturation ratio"' in render, "the honest label must be rendered"
+        assert '"Consolidation ratio"' not in render, (
+            "the misleading label must be gone from the rendered delta"
+        )
+        # The wire field must NOT be renamed — that is an API/dashboard contract.
+        assert "consolidation_ratio" in render
+
     def test_recorded_failures_reach_the_summary(self) -> None:
         """semantic_link_failures / compress_fibers_deferred were written, never shown."""
         report = ConsolidationReport()

--- a/tests/unit/test_consolidation_integrity.py
+++ b/tests/unit/test_consolidation_integrity.py
@@ -1,0 +1,290 @@
+"""Run-015 characterization + regression tests for consolidation integrity.
+
+Each test here pins one registered defect (DEF-NN) from the consolidation-integrity plan.
+A test marked ``xfail(strict=True)`` documents behaviour that is still broken; the marker
+is removed in the same commit that fixes the defect.
+"""
+
+from __future__ import annotations
+
+import pytest_asyncio
+
+from surreal_memory.core.brain import Brain
+from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.engine.consolidation import (
+    ConsolidationEngine,
+    ConsolidationReport,
+)
+from surreal_memory.storage.memory_store import InMemoryStorage
+
+
+@pytest_asyncio.fixture
+async def summarize_storage() -> InMemoryStorage:
+    """Storage holding one clusterable group of tag-overlapping fibers."""
+    store = InMemoryStorage()
+    brain = Brain.create(name="integrity_test", brain_id="integrity-brain")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    # Four fibers sharing the same two tags -> one cluster above the default
+    # min_cluster_size, so _summarize has exactly one group to work on.
+    for idx in range(4):
+        anchor = Neuron.create(
+            type=NeuronType.ENTITY,
+            content=f"anchor-{idx}",
+            neuron_id=f"anchor-{idx}",
+        )
+        await store.add_neuron(anchor)
+        fiber = Fiber.create(
+            neuron_ids={anchor.id},
+            synapse_ids=set(),
+            anchor_neuron_id=anchor.id,
+            summary=f"memory number {idx}",
+            tags={"alpha", "beta"},
+            fiber_id=f"src-fiber-{idx}",
+        )
+        await store.add_fiber(fiber)
+    return store
+
+
+async def _run_summarize(store: InMemoryStorage) -> ConsolidationReport:
+    engine = ConsolidationEngine(store)
+    report = ConsolidationReport()
+    await engine._summarize(report, dry_run=False)
+    return report
+
+
+async def _summary_fiber_count(store: InMemoryStorage) -> int:
+    fibers = await store.get_fibers(limit=10000)
+    return sum(1 for f in fibers if f.metadata.get("_consolidation") == "summary_fiber")
+
+
+class TestSummarizeIdempotence:
+    """DEF-01 — _summarize must not recreate a summary it already produced."""
+
+    async def test_first_pass_creates_a_summary(self, summarize_storage: InMemoryStorage) -> None:
+        report = await _run_summarize(summarize_storage)
+        assert report.summaries_created >= 1
+        assert await _summary_fiber_count(summarize_storage) >= 1
+
+    async def test_summarize_is_idempotent(self, summarize_storage: InMemoryStorage) -> None:
+        """Second pass over unchanged input must create nothing (DEF-01)."""
+        first = await _run_summarize(summarize_storage)
+        count_after_first = await _summary_fiber_count(summarize_storage)
+
+        second = await _run_summarize(summarize_storage)
+        count_after_second = await _summary_fiber_count(summarize_storage)
+
+        assert first.summaries_created >= 1, "precondition: first pass produced a summary"
+        assert second.summaries_created == 0, (
+            "second pass over unchanged input must create no new summaries"
+        )
+        assert count_after_second == count_after_first, (
+            "no new summary fibers may be persisted on a repeat pass"
+        )
+
+    async def test_summarize_excludes_own_output_from_input(
+        self, summarize_storage: InMemoryStorage
+    ) -> None:
+        """Summary fibers carry tags, so they must not feed the next clustering pass."""
+        await _run_summarize(summarize_storage)
+
+        engine = ConsolidationEngine(summarize_storage)
+        fibers = await summarize_storage.get_fibers(limit=10000)
+        eligible = engine._summarize_input_fibers(fibers)
+
+        assert eligible, "clustering input must not be empty"
+        assert all(f.metadata.get("_consolidation") != "summary_fiber" for f in eligible), (
+            "summary fibers must be excluded from the clustering input"
+        )
+
+
+@pytest_asyncio.fixture
+async def merge_storage() -> InMemoryStorage:
+    """Two heavily-overlapping fibers, both carrying typed memory and rich metadata."""
+    store = InMemoryStorage()
+    brain = Brain.create(name="merge_test", brain_id="merge-brain")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    shared = []
+    for idx in range(6):
+        neuron = Neuron.create(
+            type=NeuronType.ENTITY, content=f"shared-{idx}", neuron_id=f"shared-{idx}"
+        )
+        await store.add_neuron(neuron)
+        shared.append(neuron.id)
+
+    for idx in range(2):
+        fiber = Fiber.create(
+            neuron_ids=set(shared),
+            synapse_ids=set(),
+            anchor_neuron_id=shared[0],
+            summary=f"real content {idx}",
+            tags={"merge"},
+            fiber_id=f"merge-src-{idx}",
+            metadata={"essence": f"essence-{idx}", "conductivity": 0.5},
+        )
+        await store.add_fiber(fiber)
+        await store.add_typed_memory(
+            TypedMemory(
+                fiber_id=fiber.id,
+                memory_type=MemoryType.FACT,
+                priority=Priority.HIGH if idx == 0 else Priority.NORMAL,
+                trust_score=0.9 if idx == 0 else 0.4,
+            )
+        )
+    return store
+
+
+async def _run_merge(store: InMemoryStorage) -> ConsolidationReport:
+    engine = ConsolidationEngine(store)
+    report = ConsolidationReport()
+    await engine._merge(report, dry_run=False)
+    return report
+
+
+class TestMergeDataSafety:
+    """DEF-02/03/04 — merging must not lose data."""
+
+    async def test_merge_remaps_typed_memory(self, merge_storage: InMemoryStorage) -> None:
+        """The typed layer must follow the surviving fiber, not be orphaned (DEF-03)."""
+        report = await _run_merge(merge_storage)
+        assert report.fibers_merged >= 2, "precondition: the two fibers must merge"
+
+        surviving = [
+            f for f in await merge_storage.get_fibers(limit=100) if f.metadata.get("merged_from")
+        ]
+        assert surviving, "a merged fiber must exist"
+        merged_id = surviving[0].id
+
+        merged_tm = await merge_storage.get_typed_memory(merged_id)
+        assert merged_tm is not None, "merged fiber must carry the typed-memory layer"
+        # Strongest priority and trust survive the merge.
+        assert merged_tm.priority == Priority.HIGH
+        assert merged_tm.trust_score == 0.9
+
+        for src in ("merge-src-0", "merge-src-1"):
+            assert await merge_storage.get_typed_memory(src) is None, (
+                f"source typed memory {src} must not be left orphaned"
+            )
+
+    async def test_merge_preserves_source_metadata(self, merge_storage: InMemoryStorage) -> None:
+        """essence/conductivity must survive; summary must not become a constant (DEF-04)."""
+        await _run_merge(merge_storage)
+        surviving = [
+            f for f in await merge_storage.get_fibers(limit=100) if f.metadata.get("merged_from")
+        ]
+        assert surviving, "a merged fiber must exist"
+        merged = surviving[0]
+
+        assert "essence" in merged.metadata, "essence must survive the merge"
+        assert "conductivity" in merged.metadata, "conductivity must survive the merge"
+        assert merged.metadata.get("merged_from"), "merge provenance must be recorded"
+        assert "real content" in merged.summary, (
+            "merged summary must carry the sources' content, not a constant string"
+        )
+
+    async def test_fibers_removed_counts_only_confirmed_deletes(
+        self, merge_storage: InMemoryStorage
+    ) -> None:
+        """A failing delete must not be counted as removed work (DEF-09)."""
+
+        async def _always_fails(fiber_id: str) -> bool:
+            return False
+
+        merge_storage.delete_fiber = _always_fails  # type: ignore[method-assign]
+        report = await _run_merge(merge_storage)
+
+        assert report.fibers_merged >= 2, "precondition: merge still ran"
+        assert report.fibers_removed == 0, (
+            "fibers_removed must count confirmed deletes, not attempts"
+        )
+        assert report.extra.get("merge_delete_failures", 0) >= 1, (
+            "failed deletes must be visible in the report"
+        )
+
+
+# Keys deliberately kept out of summary(), each with the reason it stays silent.
+# Anything NOT listed here must be rendered — that is the contract.
+_EXTRA_KEYS_NOT_RENDERED = {
+    # Rendered indirectly: they feed the dedup census line, not a line of their own.
+    "dedup_anchors_total": "feeds the dedup census line",
+    "dedup_anchors_scanned": "feeds the dedup census line",
+    "dedup_anchors_truncated": "feeds the dedup census line",
+    "dedup_window_start": "diagnostic for the rotating dedup window",
+    "alias_ledger_pairs": "ledger diagnostics, exported over MCP",
+    "alias_ledger_complete": "ledger diagnostics, exported over MCP",
+    "alias_ledger_load_failed": "ledger diagnostics, exported over MCP",
+    "alias_checks_failed": "folded into the alias link line",
+    "alias_writes_failed": "folded into the alias link line",
+    "alias_pairs_skipped_invalid": "folded into the alias link line",
+    "semantic_link_truncated": "folded into the semantic synapse line",
+    "failed_strategies": "rendered by its own branch",
+    "timed_out_strategies": "rendered by its own branch",
+    "maturations_backfilled": "rendered by its own branch",
+    "maturations_unreachable": "rendered by its own branch",
+}
+
+
+class TestCounterContract:
+    """Anti-recurrence gate: a counter must not be able to go dark again.
+
+    Two rounds of "consolidation honesty" fixes were shipped before and the same class
+    of defect came back in neighbouring code, because each fix was local. This test is
+    the systemic check: every key the engine writes into ``report.extra`` is either
+    rendered by ``summary()`` or explicitly listed as intentionally silent.
+    """
+
+    def test_every_extra_key_is_rendered_or_explicitly_exempt(self) -> None:
+        import re
+        from pathlib import Path
+
+        import surreal_memory.engine.consolidation as consolidation_module
+
+        source = Path(consolidation_module.__file__).read_text(encoding="utf-8")
+        written_keys = set(re.findall(r'report\.extra\[\s*"([a-z_]+)"\s*\]', source))
+        assert written_keys, "the scan must find the keys the engine writes"
+
+        rendered = set(re.findall(r'self\.extra\.get\(\s*"([a-z_]+)"', source))
+        rendered |= set(re.findall(r'extra\.get\(\s*"([a-z_]+)"', source))
+
+        undocumented = written_keys - rendered - set(_EXTRA_KEYS_NOT_RENDERED)
+        assert not undocumented, (
+            "these report.extra keys are written but never rendered and not listed as "
+            f"intentionally silent: {sorted(undocumented)}. Either surface them in "
+            "summary() or add them to _EXTRA_KEYS_NOT_RENDERED with a reason."
+        )
+
+    def test_drift_reports_detected_and_persisted_separately(self) -> None:
+        """A failed persist must be visible, not silently lower the count (DEF-10)."""
+        report = ConsolidationReport()
+        report.drift_clusters_found = 5
+        report.drift_clusters_persisted = 3
+
+        text = report.summary()
+        assert "Drift clusters found: 5" in text
+        assert "FAILED to persist" in text, "the gap between detected and saved must show"
+
+    def test_clean_drift_run_stays_quiet(self) -> None:
+        report = ConsolidationReport()
+        report.drift_clusters_found = 5
+        report.drift_clusters_persisted = 5
+
+        text = report.summary()
+        assert "Drift clusters found: 5" in text
+        assert "FAILED" not in text, "a healthy run must not add noise"
+
+    def test_recorded_failures_reach_the_summary(self) -> None:
+        """semantic_link_failures / compress_fibers_deferred were written, never shown."""
+        report = ConsolidationReport()
+        report.extra["semantic_link_failures"] = 7
+        report.extra["compress_fibers_deferred"] = 4
+        report.extra["summaries_skipped_existing"] = 25
+
+        text = report.summary()
+        assert "Semantic synapse writes FAILED: 7" in text
+        assert "Fibers deferred (time budget): 4" in text
+        assert "Summaries skipped (already exist): 25" in text

--- a/tests/unit/test_dedup_alias_edges.py
+++ b/tests/unit/test_dedup_alias_edges.py
@@ -14,8 +14,11 @@ import pytest
 
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.synapse import Synapse, SynapseType
-from surreal_memory.engine import consolidation
-from surreal_memory.engine.consolidation import ConsolidationEngine, ConsolidationReport
+from surreal_memory.engine.consolidation import (
+    ConsolidationConfig,
+    ConsolidationEngine,
+    ConsolidationReport,
+)
 from surreal_memory.engine.dedup.alias_edges import (
     ALIAS_EDGE_WEIGHT,
     AliasEdgeLedger,
@@ -676,11 +679,11 @@ class TestDedupReportAccounting:
     async def test_truncated_census_says_so(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # A silent cap turns "duplicates in my brain" into "duplicates among the
         # first N anchors in scan order" without telling anyone.
-        monkeypatch.setattr(consolidation, "_DEDUP_MAX_ANCHORS", 5)
         storage = FakeAnchorStorage([_anchor(f"note {i}") for i in range(7)])
         report = ConsolidationReport()
+        engine = ConsolidationEngine(storage, config=ConsolidationConfig(dedup_max_anchors=5))
 
-        await ConsolidationEngine(storage)._dedup(report, dry_run=False)
+        await engine._dedup(report, dry_run=False)
 
         assert report.extra["dedup_anchors_total"] == 7
         assert report.extra["dedup_anchors_scanned"] == 5
@@ -695,11 +698,11 @@ class TestDedupReportAccounting:
         # Outgrowing the cap is a steady state for a big brain. Warning about it
         # every run trains operators to ignore dedup warnings, which buries the
         # failures this unit exists to surface.
-        monkeypatch.setattr(consolidation, "_DEDUP_MAX_ANCHORS", 5)
         storage = FakeAnchorStorage([_anchor(f"note {i}") for i in range(7)])
+        engine = ConsolidationEngine(storage, config=ConsolidationConfig(dedup_max_anchors=5))
 
         with caplog.at_level(logging.INFO):
-            await ConsolidationEngine(storage)._dedup(ConsolidationReport(), dry_run=False)
+            await engine._dedup(ConsolidationReport(), dry_run=False)
 
         assert any("census truncated" in r.message for r in caplog.records)
         assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []

--- a/tests/unit/test_drift_clusters.py
+++ b/tests/unit/test_drift_clusters.py
@@ -208,7 +208,7 @@ class TestRefreshDriftClusters:
         storage.get_tag_fiber_counts = AsyncMock(return_value={"react": 12, "reactjs": 11})
         storage.save_drift_cluster = AsyncMock()
 
-        saved = await refresh_drift_clusters(storage)
+        detected, saved = await refresh_drift_clusters(storage)
 
         assert saved == 1
         storage.save_drift_cluster.assert_called_once()
@@ -220,7 +220,7 @@ class TestRefreshDriftClusters:
         storage.get_tag_fiber_counts = AsyncMock(return_value={})
         storage.save_drift_cluster = AsyncMock()
 
-        saved = await refresh_drift_clusters(storage)
+        detected, saved = await refresh_drift_clusters(storage)
 
         assert saved == 0
         storage.save_drift_cluster.assert_not_called()
@@ -235,7 +235,7 @@ class TestRefreshDriftClusters:
         storage.save_drift_cluster = AsyncMock()
 
         with caplog.at_level(logging.WARNING, logger="surreal_memory.engine.drift_clusters"):
-            saved = await refresh_drift_clusters(storage)
+            detected, saved = await refresh_drift_clusters(storage)
 
         assert saved == 0
         storage.save_drift_cluster.assert_not_called()
@@ -253,7 +253,7 @@ class TestRefreshDriftClusters:
         storage.save_drift_cluster = AsyncMock()
 
         with caplog.at_level(logging.WARNING, logger="surreal_memory.engine.drift_clusters"):
-            saved = await refresh_drift_clusters(storage)
+            detected, saved = await refresh_drift_clusters(storage)
 
         assert saved == 0
         storage.save_drift_cluster.assert_not_called()
@@ -273,9 +273,10 @@ class TestRefreshDriftClusters:
         )
         storage.save_drift_cluster = AsyncMock(side_effect=[RuntimeError("boom"), None])
 
-        saved = await refresh_drift_clusters(storage)
+        detected, saved = await refresh_drift_clusters(storage)
 
-        assert saved == 1
+        assert detected == 2, "both clusters were detected"
+        assert saved == 1, "only one persisted — the failure must stay visible"
         assert storage.save_drift_cluster.call_count == 2
 
 
@@ -348,7 +349,7 @@ class TestDetectDriftStrategy:
         storage.get_tag_fiber_counts = AsyncMock(return_value={"react": 12, "reactjs": 11})
         storage.save_drift_cluster = AsyncMock()
 
-        would_save = await refresh_drift_clusters(storage, persist=False)
+        detected, would_save = await refresh_drift_clusters(storage, persist=False)
 
         assert would_save == 1
         storage.save_drift_cluster.assert_not_called()

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.5.1"
+        assert surreal_memory.__version__ == "3.6.0"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_mcp.py
+++ b/tests/unit/test_mcp.py
@@ -888,6 +888,9 @@ class TestMCPToolCalls:
             "new_alias_links": 1,
             "alias_links_existing": 1,
             "drift_clusters_found": 0,
+            # Detected vs persisted are separate so a failed write cannot masquerade
+            # as "fewer clusters found".
+            "drift_clusters_persisted": 0,
             "extra": {"alias_checks_failed": 1, "dedup_anchors_truncated": True},
         }
         assert "1 checks FAILED (state unknown)" in result["summary"]

--- a/tests/unit/test_surrealdb_drift_live.py
+++ b/tests/unit/test_surrealdb_drift_live.py
@@ -205,9 +205,10 @@ async def test_refresh_drift_clusters_end_to_end(surrealdb_storage) -> None:  # 
         await surrealdb_storage.add_fiber(fiber)
         await surrealdb_storage.record_tag_cooccurrence({"react", "reactjs"})
 
-    saved = await refresh_drift_clusters(surrealdb_storage)
+    detected, saved = await refresh_drift_clusters(surrealdb_storage)
 
-    assert saved == 1
+    assert detected == 1, "one cluster must be detected"
+    assert saved == 1, "and it must actually persist — the two are reported separately"
     clusters = await surrealdb_storage.get_drift_clusters()
     assert len(clusters) == 1
     assert set(clusters[0]["members"]) == {"react", "reactjs"}

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.5.1",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
Running `smem consolidate` twice in a row on an unchanged brain was not a no-op. It created
new data every time, and the report gave no way to tell that apart from useful work. This PR
fixes both halves and adds a test that stops the second half from coming back.

## Why this exists

Two rounds of "consolidation honesty" fixes shipped before (#103, #164) and the same class of
defect returned in neighbouring code, because each fix was local. Twenty-one defects were found
this time by reading the passes end to end; six more were found by the new contract test the
first time it ran.

## What was actually broken

### Data was being duplicated and destroyed

**`summarize` was not idempotent.** Every run re-materialised each tag cluster as a fresh
concept neuron, summary fiber and up to ten synapses. Worse, summary fibers carry the union of
their sources' tags, so each run fed the previous run's output back into clustering. A cluster
is now identified by a hash of its sorted source fiber ids and is skipped if its summary
already exists; summaries written before that key existed derive it from `source_fibers`, so
older rows suppress duplicates too. Summary fibers are also excluded from the clustering input.

**`merge` destroyed before it created.** Every source fiber was deleted and only then was the
merged fiber written, so a failing write left N fibers gone with no successor — unrecoverable,
because this storage is not transactional. The order is reversed.

**`merge` orphaned the typed-memory layer.** `delete_fiber` has no cascade to `typed_memory`,
and `update_typed_memory` cannot move a row to another fiber because its record id derives from
`fiber_id`. Memory type, priority, trust score and validity window were silently stranded on
every merge. Those rows are now read before any delete and reassigned to the surviving fiber,
strongest priority and widest validity window winning.

**`merge` overwrote metadata wholesale.** `essence`, `conductivity`, `coherence` and
`compression_tier` were replaced by a bare `merged_from` list, and the summary became the
constant "Merged from N fibers" — which is exactly what recall surfaces display.

### Two blind spots that could never close on their own

**The dedup census never moved.** It took a fixed prefix of the anchor list, which is ordered by
id and never shrinks because dedup deletes nothing, so the same anchors were compared on every
run and the rest were never compared at all — not "later", ever. A cursor in `Brain.metadata`
now advances one window per run and wraps. `Brain.metadata` was chosen over a new table because
it is SCHEMALESS and already holds similar per-brain state, so no migration is needed.

**Query-pattern mining looked at the wrong end of history.** It fetched action events with no
time window; the backend orders ascending, so it mined the oldest events in the brain and, once
the log grew past the fetch limit, no new query could ever enter the window. It now uses the
same 30-day horizon the habit miner already used.

### Counters that did not mean what they said

- `fibers_removed` counted delete *attempts* — `delete_fiber` swallows its exception and returns
  `False`, and the caller ignored the result.
- Drift detection returned the number of clusters *saved* while the report called them *found*,
  so a failed write looked like a brain with less drift. Detection and persistence are separate
  now, and the per-cluster write failure moved from debug to warning.
- `_detect_drift` swallowed its own exception, keeping a dead detector out of `failed_strategies`
  and making it report zero — indistinguishable from a clean brain.
- `skipped (existing)` counted pairs the same pass had just created: a bidirectional top-K
  neighbourhood reaches each pair twice, so the second visit was booked as pre-existing.
- Counters written and never rendered now appear when non-zero: semantic-link write failures,
  deferred compressions, merge delete failures, skipped summaries, hippocampal replay,
  interference fan effects, schema creation, auto-tiering and tool-event ingestion.
- Silent input truncation is announced — summarize's clustering cap and semantic-link's
  candidate resampling, the latter stating outright that its numbers are not comparable between
  runs.
- The health delta labelled the semantic-maturation share "Consolidation ratio", printed
  directly beneath the merge counters where it read as a compression ratio. The label now says
  what it measures; **the wire field keeps its name**, so the API and dashboard contract is
  unchanged.

### Scale

`get_synapses()` with no limit emitted a query with no LIMIT. Measured on a mature brain that is
**125,749 rows in a single response, twice per run** — the same shape that produces
`[Errno 104] Connection reset by peer` on the HTTP transport (see #171). Prune, infer, enrichment
and dream now page through a shared helper on the storage base class. This was carried as a
suspicion until it was reproduced; the typed reads were measured too, and `CAUSED_BY` is five
rows and needs nothing.

## What this affects

| Surface | Change |
|---|---|
| `smem consolidate` (CLI) | Repeat runs are near-empty. New lines appear only when non-zero. A failing `detect_drift` now exits non-zero instead of reporting a silent 0 |
| MCP `smem_consolidate` | Adds `drift_clusters_persisted`; `extra` now also carries `merge_*`, `semantic_link_*` and `summaries_*` keys |
| Dashboard API | `ConsolidationResponse` gains eight counters — the UI previously could not see any of this |
| Storage | New inherited `get_synapses_paged()` on the base class; concrete backends need no change |
| Config | `ConsolidationConfig.dedup_max_anchors` and `.dedup_simhash_threshold` (documented in `docs/reference/config.md`) |
| Existing data | Nothing is migrated or deleted by this PR |

## Verification

- `uv run make verify` — green: **7263 passed, 4 skipped, 1 xfailed**, coverage **72.91%** (gate 67%)
- `uv run python scripts/pre_ship.py` — all checks pass, version parity across all sixteen sites
- **Idempotence proven on a live SurrealDB brain**, three consecutive runs on an isolated test
  brain: run 1 created one summary; runs 2 and 3 created **zero** and reported the cluster as
  already summarised, with the summary-fiber count flat. The test brain was deleted afterwards
  and only `default` remains.
- New `tests/unit/test_consolidation_integrity.py` pins each defect, including the contract test.

## The part that matters most

`TestCounterContract` scans the engine for every key written into the consolidation report and
fails unless each one is either rendered by `summary()` or listed as deliberately silent with a
reason. It caught six live defects on its first run — hippocampal replay, interference fan
effects, schema creation and auto-tiering were all doing real work that never appeared anywhere.
Without this, a seventh silent counter is only a matter of time.

## Not included on purpose

`scripts/cleanup_consolidation_debt.py` is added but **not run against any live brain**. Existing
duplicate summaries stay until it is invoked explicitly with `--apply`, which should happen only
after this release is installed and the smem services are restarted — pipx swaps files, not
processes, so an old running process would recreate the duplicates at its next consolidation.

## Also shipping in this release: #177

This branch was updated with `main` after merging #177 by @RobertSigmundsson —
**"don't apply the per-session injection marker to per-subagent events"**
(`src/surreal_memory/engine/reasoning_injection.py`). That fix does not appear in this
PR's diff (the merge brought the branch to identical content, so GitHub shows no change
there), but it will ship in the same v3.6.0 release as this PR, so it's called out here
and in the release notes.

Summary of #177's fix: `get_reasoning_context()` applies a session-scoped idempotency
marker to every caller, which is correct for `SessionStart`/`UserPromptSubmit` (they race
for the same session) but wrong for a hypothetical per-subagent hook event — its payload
carries the *parent* session's id, so once the parent injects, every subagent after it
silently gets `""` forever, indistinguishable from "nothing to inject". The fix exempts
`SubagentStart`-shaped events from both reading and writing the marker. Confirmed this
repo ships no `SubagentStart` hook today, so it's a no-op for a stock install and purely
forward-looking for anyone who wires that event themselves.

## Also fixed in this branch: CI's Docs Freshness check

`ConsolidationConfig.dedup_max_anchors`/`.dedup_simhash_threshold` (added above) were
reachable only by editing source — nothing read them from the user's `[dedup]` config
section. `ConsolidationEngine` now defaults to a config built from `[dedup]`
(`consolidation_max_anchors`, `simhash_threshold`) when no explicit config is passed,
and `docs/reference/config.md` — which is generated, not hand-edited — was regenerated
to match.