### PR TITLE
fix(consolidation): say that the dedup census window is rotating (v3.6.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "3.6.0"
+    "version": "3.6.1"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1] — 2026-08-16 — the dedup census line says the window is moving
+
+3.6.0 made the dedup census window rotate instead of re-comparing a frozen prefix, but the
+report kept the old wording: `[census truncated at anchor cap: 2000 of 3859 anchors compared]`.
+That reads exactly like the behaviour it replaced — it says work was cut and nothing about the
+window advancing, so a healthy rotating census and a permanently stuck one rendered identically.
+
+### Fixed
+
+- The dedup line now names the window, its position and the coverage horizon, e.g.
+  `[census window 2000-3859 of 3859 anchors, wraps; rotates per run, full pass every 2 runs]`.
+  A wrap past the end of the population is marked rather than printed as an out-of-range slice.
+- `dedup_window_start` was written into the report and never rendered — the same
+  recorded-but-invisible defect class 3.6.0 set out to eliminate. It had been added to the
+  counter-contract test's exemption list instead of being surfaced; the exemption is removed,
+  so the contract test now guards this key like every other.
+
 ## [3.6.0] — 2026-08-16 — consolidation stops manufacturing work, and its counters stop lying
 
 Running `smem consolidate` twice in a row on an unchanged brain was not a no-op. It

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.6.0"
+version = "3.6.1"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.6.0"
+__version__ = "3.6.1"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -379,10 +379,30 @@ class ConsolidationReport:
             if problems:
                 line += f" [{', '.join(problems)}]"
         if self.extra.get("dedup_anchors_truncated"):
-            total = self.extra.get("dedup_anchors_total")
-            scanned = self.extra.get("dedup_anchors_scanned")
-            line += f" [census truncated at anchor cap: {scanned} of {total} anchors compared]"
+            line += self._dedup_window_note()
         return line
+
+    def _dedup_window_note(self) -> str:
+        """Describe the census WINDOW, not just the cap.
+
+        "truncated at anchor cap: 2000 of 3859" reads exactly like the frozen-prefix
+        behaviour this pass was rebuilt to end: it reports that work was cut and says
+        nothing about the window advancing, so a rotating window and a permanent blind
+        spot render identically. Naming the slice and how many runs make a full pass is
+        what tells them apart at a glance.
+        """
+        total = int(self.extra.get("dedup_anchors_total") or 0)
+        scanned = int(self.extra.get("dedup_anchors_scanned") or 0)
+        start = int(self.extra.get("dedup_window_start") or 0)
+        if not total or not scanned:
+            return ""
+        end = start + scanned
+        runs_for_full_pass = -(-total // scanned)  # ceil division
+        wrapped = ", wraps" if end > total else ""
+        return (
+            f" [census window {start}-{min(end, total)} of {total} anchors{wrapped};"
+            f" rotates per run, full pass every {runs_for_full_pass} runs]"
+        )
 
     def summary(self) -> str:
         """Generate human-readable summary."""

--- a/tests/unit/test_consolidation_integrity.py
+++ b/tests/unit/test_consolidation_integrity.py
@@ -214,7 +214,6 @@ _EXTRA_KEYS_NOT_RENDERED = {
     "dedup_anchors_total": "feeds the dedup census line",
     "dedup_anchors_scanned": "feeds the dedup census line",
     "dedup_anchors_truncated": "feeds the dedup census line",
-    "dedup_window_start": "diagnostic for the rotating dedup window",
     "alias_ledger_pairs": "ledger diagnostics, exported over MCP",
     "alias_ledger_complete": "ledger diagnostics, exported over MCP",
     "alias_ledger_load_failed": "ledger diagnostics, exported over MCP",
@@ -334,6 +333,37 @@ class TestCounterContract:
         )
         # The wire field must NOT be renamed — that is an API/dashboard contract.
         assert "consolidation_ratio" in render
+
+    def test_dedup_line_shows_the_window_is_rotating(self) -> None:
+        """A rotating window must not render like the old frozen prefix.
+
+        The pre-3.6.0 line said only "truncated at anchor cap: N of M", which is what a
+        permanently-stuck census also looks like. The operator has to be able to see the
+        window move without reading Brain.metadata.
+        """
+        report = ConsolidationReport()
+        report.duplicates_found = 801
+        report.extra["dedup_anchors_truncated"] = True
+        report.extra["dedup_anchors_total"] = 3859
+        report.extra["dedup_anchors_scanned"] = 2000
+        report.extra["dedup_window_start"] = 2000
+
+        text = report.summary()
+        assert "census window 2000-3859" in text, "the window's position must be visible"
+        assert "rotates per run" in text, "it must be clear the window advances"
+        assert "full pass every 2 runs" in text, "coverage horizon must be stated"
+
+    def test_dedup_window_wrap_is_marked(self) -> None:
+        """A window running off the end wraps; say so rather than showing a bogus range."""
+        report = ConsolidationReport()
+        report.extra["dedup_anchors_truncated"] = True
+        report.extra["dedup_anchors_total"] = 3859
+        report.extra["dedup_anchors_scanned"] = 2000
+        report.extra["dedup_window_start"] = 3000
+
+        text = report.summary()
+        assert "wraps" in text
+        assert "3000-3859" in text, "the range must be clamped to the population"
 
     def test_recorded_failures_reach_the_summary(self) -> None:
         """semantic_link_failures / compress_fibers_deferred were written, never shown."""

--- a/tests/unit/test_dedup_alias_edges.py
+++ b/tests/unit/test_dedup_alias_edges.py
@@ -689,7 +689,11 @@ class TestDedupReportAccounting:
         assert report.extra["dedup_anchors_scanned"] == 5
         assert report.extra["dedup_anchors_truncated"] is True
         assert report.duplicates_found == 4
-        assert "census truncated at anchor cap" in report.summary()
+        # The line must name the WINDOW and its rotation, not just that work was cut —
+        # "truncated at cap" alone reads identically to the old frozen-prefix census.
+        text = report.summary()
+        assert "census window 0-5 of 7 anchors" in text
+        assert "rotates per run" in text
 
     @pytest.mark.asyncio
     async def test_routine_truncation_does_not_raise_a_warning(

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.6.0"
+        assert surreal_memory.__version__ == "3.6.1"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
Follow-up to #178, prompted by a real observation on a live brain: after upgrading to 3.6.0 the
dedup line still read

```
Duplicate anchors: 801 pairs (census), 11 new links, 790 already linked
  [census truncated at anchor cap: 2000 of 3859 anchors compared]
```

and that reads exactly like the defect 3.6.0 set out to fix.

## What was actually wrong

The mechanism was fine — the window *was* rotating. Verified on the live brain:
`Brain.metadata._dedup_anchor_cursor` had advanced to `2000`, and the run produced **11 new
alias links** where every pre-3.6.0 run produced zero, forever. The rotation works.

The **report** was wrong. "truncated at anchor cap: 2000 of 3859" states that work was cut and
says nothing about the window advancing, so a healthy rotating census and a permanently stuck
one render identically. From the operator's seat there was no way to tell 3.6.0 had changed
anything — which is a fair reading, and the reason this PR exists.

Root cause: `dedup_window_start` was written into the report and never rendered. That is
precisely the recorded-but-invisible counter class #178 existed to eliminate. Worse, instead of
being surfaced it had been added to the counter-contract test's exemption list — so the guard
built to catch exactly this was switched off for the one key that needed it.

## The fix

The line now names the slice, marks a wrap, and states the coverage horizon:

```
Duplicate anchors: 801 pairs (census), 11 new links, 790 already linked
  [census window 2000-3859 of 3859 anchors, wraps; rotates per run, full pass every 2 runs]
```

The exemption is removed, so `TestCounterContract` now guards `dedup_window_start` like every
other key — the contract test would have caught this on its own had I not exempted it.

## Scope

Report wording and a test exemption. **No behaviour change**: the cap, the cursor, the rotation
and the comparison logic are untouched. Two new tests pin the window rendering and the wrap case;
one existing assertion in `test_dedup_alias_edges.py` is updated to the richer wording.

## Verification

- `uv run make verify` — green: **7266 passed, 4 skipped, 1 xfailed**, coverage **72.94%** (gate 67%), mypy clean
- `uv run python scripts/pre_ship.py` — all checks pass, version parity across all sixteen sites
- Rendering confirmed against the real counters from the live run quoted above

Version **3.6.1** (patch — wording and a test guard, no functional change).
