### PR TITLE
fix(server): expose the last two consolidation counters to the dashboard (v3.6.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "3.6.1"
+    "version": "3.6.2"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.2] — 2026-08-16 — the dashboard sees the last two consolidation counters
+
+A Stage-2 API pass against the running service found `ConsolidationResponse` carrying 18 of the
+20 counters the consolidation report produces: `semantic_link_failures` and `tool_events_ingested`
+were absent. On that surface a run whose semantic-link writes failed still rendered as clean —
+the blind spot 3.6.0 set out to close, surviving on the API because the earlier sweep verified the
+report and not the route's response model.
+
+### Fixed
+
+- `ConsolidationResponse` exposes `semantic_link_failures` and `tool_events_ingested`, so the
+  dashboard and any API client see the same failure signals the CLI already showed.
+
 ## [3.6.1] — 2026-08-16 — the dedup census line says the window is moving
 
 3.6.0 made the dedup census window rotate instead of re-comparing a frozen prefix, but the

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.6.1"
+version = "3.6.2"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.6.1"
+__version__ = "3.6.2"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/server/routes/consolidation.py
+++ b/src/surreal_memory/server/routes/consolidation.py
@@ -56,6 +56,11 @@ class ConsolidationResponse(BaseModel):
     # the same ambiguity the MCP contract already fixed.
     summaries_skipped_existing: int = 0
     merge_delete_failures: int = 0
+    # Write failures and ingested tool events reach the CLI report but were missing
+    # here, so the dashboard could not tell a run whose writes failed from a clean one
+    # — the same blind spot on a different surface.
+    semantic_link_failures: int = 0
+    tool_events_ingested: int = 0
     drift_clusters_found: int = 0
     drift_clusters_persisted: int = 0
     semantic_synapses_created: int = 0
@@ -115,6 +120,8 @@ async def consolidate_brain(
         summaries_created=report.summaries_created,
         summaries_skipped_existing=int(report.extra.get("summaries_skipped_existing", 0)),
         merge_delete_failures=int(report.extra.get("merge_delete_failures", 0)),
+        semantic_link_failures=int(report.extra.get("semantic_link_failures", 0)),
+        tool_events_ingested=int(report.extra.get("tool_events_ingested", 0)),
         drift_clusters_found=report.drift_clusters_found,
         drift_clusters_persisted=report.drift_clusters_persisted,
         semantic_synapses_created=report.semantic_synapses_created,

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.6.1"
+        assert surreal_memory.__version__ == "3.6.2"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
Found by running the Stage-2 API tester against the live service — the check the run-015
delivery contract mandated for any diff touching `mcp/`, `cli/`, `storage/` or `server/`, and
which I had skipped before declaring that work done.

## What it found

`ConsolidationResponse` carried **18 of the 20 counters** the consolidation report produces.
Missing: `semantic_link_failures` and `tool_events_ingested`.

The consequence is the exact blind spot 3.6.0 set out to close, surviving on a different
surface: the CLI report showed semantic-link write failures, and the dashboard could not — so on
that surface a run whose writes failed still rendered as clean. The earlier sweep verified the
report and never checked the route's response model.

## Fix

Both fields added to the response model and populated from the report, so every client sees the
same failure signals the CLI already showed. Schema goes from 18 to 20 fields.

## Verification

Evidence log: `qa/run-015/stage2-api-tester.log` (gitignored, local).

| Case | Result |
|---|---|
| `GET /health` | 200, `"version":"3.6.0"` |
| `POST /api/v1/brain/{unknown}/consolidate` | **404** `{"detail":"Brain not found"}` — not 5xx |
| `GET` on a POST-only route | **405** |
| `ConsolidationResponse` field coverage | 18 → **20**, verified against the model |

One negative case in that pass was an **invalid test on my part**, recorded rather than quietly
dropped: I sent `strategy` where the model takes `strategies: list[str]`, so the payload was
ignored and a full consolidation ran instead of returning 422. Whether a bogus value *inside*
`strategies` is rejected is **UNVERIFIED** — stated, not assumed.

- `uv run make verify` — green: **7266 passed, 4 skipped, 1 xfailed**, coverage **72.94%**, mypy clean
- `uv run python scripts/pre_ship.py` — all checks pass, version parity across all sixteen sites

Version **3.6.2** (patch — these two fields were meant to ship in 3.6.0 with the other eight;
this completes that fix rather than adding capability).
