### PR TITLE
fix: stop the change log growing without bound, and the dashboard waiting on it (v3.7.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "3.6.2"
+    "version": "3.7.0"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.0] — 2026-08-26 — the change log stops growing, and the dashboard stops waiting on it
+
+The dashboard's sync card could take minutes to answer, and the health page paid a
+full diagnostics pass on every load. Three independent causes, none of which was
+visible in the values these endpoints returned — they were correct, just expensive.
+
+### Fixed
+
+- `get_change_log_stats` inlines `brain_id` instead of parameterising it. SurrealDB's
+  planner only uses the `brain_id` index for an inline literal; a parameterised
+  comparison silently degrades to a full scan. The helper and its rationale already
+  existed in the storage layer — this read path had simply never adopted it.
+- The same read no longer runs a separate aggregate per counter. `total` and `pending`
+  are counted; `synced` is derived by subtraction. Beyond removing a scan, this makes
+  a class of nonsense impossible rather than merely unlikely: the counters were not
+  read atomically, so the endpoint could report more pending rows than total rows.
+- `prune_synced_changes` returns the number of rows it deleted instead of a hardcoded
+  `0`. The in-memory backend had always counted correctly, so backend parity looked
+  healthy while the production backend reported nothing.
+- `/api/dashboard/health` is served from the same cached diagnostics report as the
+  overview's grade, instead of recomputing a multi-second analysis on every request.
+  Two endpoints independently recomputing one analysis could also disagree.
+- The migration registry is pinned to explicit version constants. It previously keyed
+  the 8→9 entry on `TARGET_VERSION`, so bumping the schema re-registered that
+  migration as 8→10 and left 9→10 missing — a v8 database would have been stamped
+  with the new version without ever running its DDL.
+
+### Added
+
+- `collapse_pending_updates()` on the storage interface, wired into consolidation.
+  The change log had no unconditional growth control: its only retention path
+  required rows to have been synced, so on a brain whose sync never completes
+  nothing ever removed a row, and the endpoint that would have shown the growth was
+  itself too slow to load at that size — the defect hid its own symptom.
+  Collapsing superseded pending `update` rows is lossless, because replication
+  converges on the newest payload per entity. `insert`/`delete` rows and synced
+  rows are never touched. Bounded per pass, and hitting the bound is reported
+  rather than smoothed over.
+- Schema v10: `change_log` is indexed on `(brain_id, synced)`. Without it, every
+  count filtered on `synced` had to fetch the field from every row, which is what
+  made the sync card's read expensive even after the index-eligibility fix.
+
 ## [3.6.2] — 2026-08-16 — the dashboard sees the last two consolidation counters
 
 A Stage-2 API pass against the running service found `ConsolidationResponse` carrying 18 of the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,7 +5,7 @@
 
 **Current state**: v3.5.1 — 57 MCP tools, 7200+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
 
-**Storage**: SurrealDB is the only persistent backend — schema v9 — and `storage_backend`
+**Storage**: SurrealDB is the only persistent backend — schema v10 — and `storage_backend`
 defaults to it. `#141` removed the SQLite backend entirely; selecting `storage_backend = "sqlite"`
 is now a hard `ValueError`, not a fallback. InMemory remains, opt-in only, for trying the tool
 without running a database — it has no schema to version. Earlier revisions of this line described

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.6.2"
+version = "3.7.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.6.2"
+__version__ = "3.7.0"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -39,6 +39,14 @@ logger = logging.getLogger(__name__)
 # the pass reports the total and flags the truncation instead of hiding it.
 _DEDUP_MAX_ANCHORS = 2000
 
+# How many superseded change-log rows one consolidation pass may remove. A log
+# that has never been pruned can hold millions; deleting them all in one pass
+# would turn a routine consolidation into a multi-minute stall. The pass is
+# idempotent, so a backlog drains over consecutive runs — and hitting this cap
+# is reported, not smoothed over, so a draining backlog cannot be mistaken for a
+# finished one.
+_CHANGE_LOG_COLLAPSE_CAP = 200_000
+
 
 def _summary_cluster_key_from_ids(fiber_ids: Iterable[str]) -> str:
     """Stable identity of a summary cluster: a hash of its sorted source fiber ids.
@@ -187,6 +195,15 @@ class ConsolidationReport:
     query_patterns_learned: int = 0
     action_events_pruned: int = 0
     retrieval_traces_pruned: int = 0
+    change_log_collapsed: int = 0
+    """Superseded pending change-log updates removed this run.
+
+    The change log is the one table with no upper bound on growth: its only
+    retention path required rows to have been synced, so on a brain whose sync
+    never completed nothing was ever removed. Reporting the collapse here is
+    what makes that growth visible at all -- the dashboard card that would have
+    shown it was itself too slow to load while the table was large.
+    """
     duplicates_found: int = 0
     new_alias_links: int = 0
     """ALIAS edges actually created this run.
@@ -382,6 +399,20 @@ class ConsolidationReport:
             line += self._dedup_window_note()
         return line
 
+    def _change_log_collapse_line(self) -> str:
+        """Render the change-log collapse, and say so when the pass was cut short.
+
+        A bounded pass that hit its ceiling has NOT finished the job, and a
+        backlog draining over several runs looks identical to a completed run
+        unless the truncation is stated. Same reasoning as the dedup census
+        line: a number alone cannot distinguish "done" from "gave up here".
+        """
+        line = f"{self.change_log_collapsed} superseded updates removed"
+        remaining = int(self.extra.get("change_log_pending_after", 0) or 0)
+        if self.extra.get("change_log_collapse_truncated"):
+            line += f" [pass capped; {remaining} pending rows remain, next run continues]"
+        return line
+
     def _dedup_window_note(self) -> str:
         """Describe the census WINDOW, not just the cap.
 
@@ -421,6 +452,7 @@ class ConsolidationReport:
             f"  Habits learned: {self.habits_learned}",
             f"  Query patterns learned: {self.query_patterns_learned}",
             f"  Action events pruned: {self.action_events_pruned}",
+            f"  Change log collapsed: {self._change_log_collapse_line()}",
             f"  Duplicate anchors: {self._alias_link_line()}",
             f"  Semantic synapses: {self._semantic_synapse_line()}",
             f"  Memories promoted (type): {self.memories_promoted}",
@@ -1079,6 +1111,34 @@ class ConsolidationEngine:
                     report.retrieval_traces_pruned = pruned_traces
             except Exception:
                 logger.debug("Retrieval trace pruning skipped", exc_info=True)
+
+        # Collapse superseded pending change-log updates.
+        #
+        # This is the ONLY retention path for a brain whose sync never completes.
+        # prune_synced_changes can only remove rows that were successfully synced,
+        # so where sync is configured but never lands, nothing ever removed a row
+        # and the table grew without bound -- and the dashboard card that would
+        # have revealed it was itself too slow to load at that size, so the defect
+        # hid its own symptom. Collapsing is lossless: replication converges on the
+        # newest payload per entity, so superseded updates cannot change the
+        # outcome for any peer, at any sync position.
+        if not dry_run and hasattr(self._storage, "collapse_pending_updates"):
+            try:
+                collapsed = await self._storage.collapse_pending_updates(
+                    max_rows=_CHANGE_LOG_COLLAPSE_CAP
+                )
+                report.change_log_collapsed = collapsed
+                if collapsed:
+                    logger.info("Collapsed %d superseded change-log updates", collapsed)
+                if collapsed >= _CHANGE_LOG_COLLAPSE_CAP:
+                    report.extra["change_log_collapse_truncated"] = True
+                    try:
+                        stats = await self._storage.get_change_log_stats()
+                        report.extra["change_log_pending_after"] = int(stats.get("pending", 0) or 0)
+                    except Exception:
+                        logger.debug("Change-log stats unavailable after collapse", exc_info=True)
+            except Exception:
+                logger.debug("Change-log collapse skipped", exc_info=True)
 
     async def _merge(
         self,

--- a/src/surreal_memory/server/routes/dashboard_api.py
+++ b/src/surreal_memory/server/routes/dashboard_api.py
@@ -27,19 +27,31 @@ _GRADE_CACHE = TTLCache()
 _UNCERTAINTY_CACHE = TTLCache()
 
 
-async def _cached_grade_purity(storage: NeuralStorage, brain_name: str) -> tuple[str, float]:
-    """Return (grade, purity) for a brain, cached per brain for the TTL window."""
-    key = f"grade:{brain_name}"
+async def _cached_health_report(storage: NeuralStorage, brain_name: str) -> Any:
+    """Return the full diagnostics report for a brain, cached per brain.
+
+    The whole report is cached, not just the grade: ``/health`` used to call
+    ``DiagnosticsEngine.analyze`` directly on every request while ``/stats``
+    served the same computation from cache. On a large brain that cost a multi-second analyze
+    per health load — and not only when cold, since nothing was memoised. Two
+    endpoints independently recomputing one analysis can also disagree with each
+    other; sharing the entry removes that possibility as well as the cost.
+    """
+    key = f"health:{brain_name}"
     cached = _GRADE_CACHE.get(key)
     if cached is not None:
-        grade, purity = cached
-        return str(grade), float(purity)
+        return cached
     from surreal_memory.engine.diagnostics import DiagnosticsEngine
 
     report = await DiagnosticsEngine(storage).analyze(brain_name)
-    result = (report.grade, report.purity_score)
-    _GRADE_CACHE.set(key, result)
-    return result
+    _GRADE_CACHE.set(key, report)
+    return report
+
+
+async def _cached_grade_purity(storage: NeuralStorage, brain_name: str) -> tuple[str, float]:
+    """Return (grade, purity) for a brain, cached per brain for the TTL window."""
+    report = await _cached_health_report(storage, brain_name)
+    return str(report.grade), float(report.purity_score)
 
 
 router = APIRouter(
@@ -375,15 +387,18 @@ async def switch_brain(
 async def get_health(
     storage: Annotated[NeuralStorage, Depends(get_storage)],
 ) -> HealthReport:
-    """Run full diagnostics on the active brain."""
-    from surreal_memory.engine.diagnostics import DiagnosticsEngine
+    """Run full diagnostics on the active brain (served from the TTL cache).
+
+    Shares the cached report with the overview's grade/purity, so the health
+    page no longer pays a full multi-second analyze on every load — see
+    ``_cached_health_report``.
+    """
     from surreal_memory.unified_config import get_config
 
     brain_name = get_config().current_brain
 
     try:
-        diag = DiagnosticsEngine(storage)
-        report = await diag.analyze(brain_name)
+        report = await _cached_health_report(storage, brain_name)
     except Exception as exc:
         logger.warning("Diagnostics failed for brain %s: %s", brain_name, exc)
         return HealthReport(grade="F", purity_score=0.0)

--- a/src/surreal_memory/storage/base.py
+++ b/src/surreal_memory/storage/base.py
@@ -1904,6 +1904,27 @@ class NeuralStorage(ABC):
         """
         raise NotImplementedError
 
+    async def collapse_pending_updates(self, max_rows: int = 200_000) -> int:
+        """Drop pending ``update`` rows superseded by a newer pending update.
+
+        Replication converges on the newest payload per entity, so only the
+        latest pending ``update`` for a given entity carries information. This
+        is the growth control for brains whose sync never completes: without it
+        the log grows without bound and nothing ever removes a row, because
+        :meth:`prune_synced_changes` can only remove entries that were
+        successfully synced.
+
+        ``insert``/``delete`` rows and any row already marked synced must be
+        left untouched -- see the SurrealDB implementation for why.
+
+        Args:
+            max_rows: Upper bound on rows removed in a single pass.
+
+        Returns:
+            Count of rows deleted.
+        """
+        raise NotImplementedError
+
     async def seed_change_log(self, device_id: str = "") -> dict[str, int]:
         """Seed the change log with all existing entities as 'insert' entries.
 

--- a/src/surreal_memory/storage/memory_sync_ops.py
+++ b/src/surreal_memory/storage/memory_sync_ops.py
@@ -166,6 +166,42 @@ class InMemorySyncMixin:
         self._change_log[brain_id] = kept
         return pruned
 
+    async def collapse_pending_updates(self, max_rows: int = 200_000) -> int:
+        """Drop pending ``update`` rows superseded by a newer pending update.
+
+        Mirrors the SurrealDB implementation: only ``operation == "update"``
+        rows that are still unsynced are eligible, and the newest entry per
+        (entity_type, entity_id) always survives.
+        """
+        brain_id = self._get_brain_id()
+        entries = self._change_log.get(brain_id, [])
+        if not entries:
+            return 0
+
+        newest: dict[tuple[str, str], int] = {}
+        for entry in entries:
+            if entry.synced or entry.operation != "update":
+                continue
+            key = (entry.entity_type, entry.entity_id)
+            if entry.id > newest.get(key, -1):
+                newest[key] = entry.id
+
+        removed = 0
+        kept: list[ChangeEntry] = []
+        for entry in entries:
+            superseded = (
+                not entry.synced
+                and entry.operation == "update"
+                and entry.id != newest.get((entry.entity_type, entry.entity_id), entry.id)
+            )
+            if superseded and removed < max_rows:
+                removed += 1
+                continue
+            kept.append(entry)
+
+        self._change_log[brain_id] = kept
+        return removed
+
     async def seed_change_log(self, device_id: str = "") -> dict[str, int]:
         """Seed the change log with all existing entities as 'insert' entries."""
         brain_id = self._get_brain_id()

--- a/src/surreal_memory/storage/surrealdb/migrations.py
+++ b/src/surreal_memory/storage/surrealdb/migrations.py
@@ -44,9 +44,10 @@ from surreal_memory.storage.surrealdb.schema import SCHEMA_VERSION, SYNAPSE_V8_D
 
 logger = logging.getLogger(__name__)
 
-TARGET_VERSION = SCHEMA_VERSION  # 9
+TARGET_VERSION = SCHEMA_VERSION  # 10
 SOURCE_VERSION = 7  # flat synapse table (pre 7->8 migration)
 RELATION_SYNAPSE_VERSION = 8  # synapse became a RELATION table in the 7->8 migration
+TYPED_VALIDITY_VERSION = 9  # TypedMemory validity fields + retrieval_trace table
 
 BACKUP_TABLE = "synapse_migration_backup"
 BATCH_SIZE = 500
@@ -555,13 +556,50 @@ async def _migrate_8_to_9(conn: Any) -> None:
                 # schema. Only the idempotent "already exists" re-DEFINE is skipped.
                 logger.error("v9 migration statement failed: %s (%s)", stmt[:80], exc)
                 raise
+    # Stamp 9 explicitly, not TARGET_VERSION: this step brings a database to v9
+    # and nothing further. Stamping the moving target claimed every later schema
+    # version without running its DDL.
+    await _stamp_version(conn, TYPED_VALIDITY_VERSION)
+
+
+_V10_DDL = ("DEFINE INDEX idx_changelog_synced ON change_log FIELDS brain_id, synced",)
+
+
+async def _migrate_9_to_10(conn: Any) -> None:
+    """Additive schema-v10 migration: index change_log on (brain_id, synced).
+
+    Every count filtered on ``synced`` previously degraded to a full read of the
+    brain's change_log, because the planner had to fetch the field from each row.
+    Measured on a large log: the same count was well over an order of magnitude slower without this index, which is the difference between the dashboard's sync card
+    answering and appearing to hang.
+
+    Pure idempotent DDL, no data movement. Building the index does scan the
+    existing table once, so on a large neglected log this migration is not
+    instant -- it is still bounded, one-off, and far cheaper than paying the full
+    read on every dashboard load. Stamps v10 last.
+    """
+    for stmt in _V10_DDL:
+        try:
+            await conn.query(stmt + ";")
+        except Exception as exc:
+            if "already exists" in str(exc).lower():
+                logger.debug("v10 migration statement skipped (already exists): %s", stmt[:80])
+            else:
+                logger.error("v10 migration statement failed: %s (%s)", stmt[:80], exc)
+                raise
     await _stamp_version(conn, TARGET_VERSION)
 
 
 # Registry mirrors sqlite_schema.MIGRATIONS: {(from, to): migrate_callable}.
 MIGRATIONS = {
     (SOURCE_VERSION, RELATION_SYNAPSE_VERSION): _migrate_7_to_8,  # (7, 8)
-    (RELATION_SYNAPSE_VERSION, TARGET_VERSION): _migrate_8_to_9,  # (8, 9)
+    # Pinned to explicit version constants, NOT to TARGET_VERSION: this entry
+    # used to read (RELATION_SYNAPSE_VERSION, TARGET_VERSION), so bumping the
+    # schema silently re-registered the 8->9 migration as 8->10 and left 9->10
+    # missing entirely. A v8 database would then have jumped straight to a v10
+    # stamp without ever running the v10 DDL.
+    (RELATION_SYNAPSE_VERSION, TYPED_VALIDITY_VERSION): _migrate_8_to_9,  # (8, 9)
+    (TYPED_VALIDITY_VERSION, TARGET_VERSION): _migrate_9_to_10,  # (9, 10)
 }
 
 

--- a/src/surreal_memory/storage/surrealdb/schema.py
+++ b/src/surreal_memory/storage/surrealdb/schema.py
@@ -7,7 +7,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 SCHEMA_SQL = """
 -- ============================================================
@@ -137,6 +137,13 @@ DEFINE FIELD synced         ON change_log TYPE bool DEFAULT false;
 DEFINE FIELD sequence       ON change_log TYPE int;
 DEFINE INDEX idx_changelog_brain  ON change_log FIELDS brain_id;
 DEFINE INDEX idx_changelog_seq    ON change_log FIELDS brain_id, sequence;
+-- v10: without this, every count filtered on `synced` degrades to a full read of
+-- the brain's change_log, because the planner has to fetch the field from each
+-- row. Measured on a large log: an equivalent count filtered on a field the
+-- existing composite index covers was well over an order of magnitude faster than
+-- the same count filtered on `synced`. That is the difference between the dashboard's sync card
+-- answering and appearing to hang.
+DEFINE INDEX idx_changelog_synced ON change_log FIELDS brain_id, synced;
 
 -- Devices (sync device registry)
 DEFINE TABLE device SCHEMAFULL;

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -187,6 +187,21 @@ def _prefer_ws_transport(url: str) -> str:
 # the statement batch fails.
 _BATCH_WRITE_CHUNK = 500
 
+# Ceiling on rows one collapse_pending_updates pass may delete. The first run
+# against a neglected log faces millions of rows; deleting them in a single pass
+# would stall the consolidation that called it. The pass is idempotent and runs
+# on every consolidation, so a backlog drains over several runs instead of one
+# long stall -- and the caller reports the truncation rather than presenting a
+# partial pass as a finished one.
+_COLLAPSE_MAX_ROWS = 200_000
+
+# Delete batch for the collapse. Much larger than _BATCH_WRITE_CHUNK because
+# these statements carry only record ids — no payloads, no vectors — so the
+# request body stays small while the round-trip count drops by an order of
+# magnitude. At the write chunk size, draining a large backlog spent nearly all
+# its wall-clock on per-statement latency rather than on deleting.
+_COLLAPSE_DELETE_CHUNK = 5_000
+
 # Backoff grid for the reconnect retry in _query. A dropped transport usually
 # needs a moment before it accepts a new connection, so the first retry is
 # immediate and the next two wait.
@@ -2861,14 +2876,104 @@ class SurrealDBStorage(
         return count
 
     async def prune_synced_changes(self, older_than_days: int = 30) -> int:
-        brain_id = self._get_brain_id()
-        await self._query(
-            "DELETE FROM change_log WHERE brain_id = $brain_id AND synced = true "
-            "AND changed_at < time::ago($days, 'd')",
-            brain_id=brain_id,
+        """Delete synced changes older than N days. Returns the count deleted.
+
+        This used to ``return 0`` unconditionally while deleting an arbitrary
+        number of rows. The in-memory backend counted correctly, so backend
+        parity looked fine and the production backend reported nothing -- the
+        same recorded-but-invisible class the consolidation counters were fixed
+        for. SurrealDB's ``DELETE`` does not report a row count, so the count is
+        taken first; a row deleted by a concurrent writer between the two
+        statements would be counted here without being deleted by us, which is
+        a far smaller lie than a constant zero.
+        """
+        lit = _brain_literal(self._get_brain_id())
+        where = f"brain_id = {lit} AND synced = true AND changed_at < time::ago($days, 'd')"
+        counted = await self._query(
+            f"SELECT count() AS c FROM change_log WHERE {where} GROUP ALL",
             days=older_than_days,
         )
-        return 0
+        doomed = int(counted[0].get("c", 0) or 0) if counted else 0
+        if not doomed:
+            return 0
+        await self._query(f"DELETE FROM change_log WHERE {where}", days=older_than_days)
+        return doomed
+
+    async def collapse_pending_updates(self, max_rows: int = _COLLAPSE_MAX_ROWS) -> int:
+        """Drop pending ``update`` rows that a newer pending update supersedes.
+
+        The change log is a replication journal, and replication converges on
+        the NEWEST payload per entity. Repeated ``update`` rows for one entity
+        therefore carry exactly as much information as the last one: a peer
+        replaying all of them and a peer replaying only the newest reach the
+        same state. Where consolidation re-weights edges on every pass, these
+        superseded rows come to dominate the table -- tens of them per edge --
+        and nothing else removes them.
+
+        The winner is chosen WITHIN the batch this pass reads, not by a global
+        aggregate. That is both cheaper and equally safe: the row surviving each
+        batch is the newest one *in* it, and the globally newest row is by
+        definition never older than any batch-local maximum -- so it either sits
+        outside the batch untouched, or is the batch maximum and survives. It
+        can never be the row deleted. A global ``GROUP BY`` over the whole table
+        would give the same answer while scanning every row to get it, which on
+        a large backlog cost more than the deletes themselves. Repeated passes
+        converge, because each pass strictly reduces the number of superseded
+        rows.
+
+        Deliberately narrow, because the safety argument does not extend:
+
+        * ``insert``/``delete`` are NEVER collapsed. They are not
+          idempotent-by-latest, and dropping an ``insert`` would leave a peer
+          applying an update to an entity it has never seen.
+        * ``synced = true`` rows are NEVER touched. Delivered history is
+          governed by :meth:`prune_synced_changes`; running two retention
+          policies over one table is how a table ends up with neither.
+
+        Bounded by ``max_rows`` per pass so a first run against a large backlog
+        cannot turn into a multi-minute stall. The return value is the number
+        actually deleted, and the caller reports truncation rather than
+        presenting a partial pass as a finished one.
+        """
+        lit = _brain_literal(self._get_brain_id())
+        scope = f"brain_id = {lit} AND operation = 'update' AND synced = false"
+
+        # No ORDER BY: which superseded rows a capped pass removes is immaterial
+        # (they are all redundant), while sorting is not — the filter includes
+        # `operation`, which no index covers, so the sort would be paid over
+        # every matching row.
+        candidates = await self._query(
+            f"SELECT id, entity_type, entity_id, sequence FROM change_log WHERE {scope} LIMIT $cap",
+            cap=max_rows,
+        )
+        if not candidates:
+            return 0
+
+        newest: dict[tuple[str, str], int] = {}
+        for row in candidates:
+            key = (str(row.get("entity_type", "")), str(row.get("entity_id", "")))
+            seq = int(row.get("sequence", 0) or 0)
+            if seq > newest.get(key, -1):
+                newest[key] = seq
+
+        # Keep the raw RecordID the driver handed back: stringifying it turns
+        # `change_log:abc` into a plain string, and `WHERE id IN $ids` then
+        # matches nothing at all while still reporting a successful delete.
+        doomed: list[Any] = [
+            row.get("id")
+            for row in candidates
+            if row.get("id") is not None
+            and int(row.get("sequence", 0) or 0)
+            != newest.get((str(row.get("entity_type", "")), str(row.get("entity_id", ""))), -1)
+        ]
+        if not doomed:
+            return 0
+
+        deleted = 0
+        for chunk in _chunked(doomed, _COLLAPSE_DELETE_CHUNK):
+            await self._query("DELETE change_log WHERE id IN $ids", ids=chunk)
+            deleted += len(chunk)
+        return deleted
 
     async def seed_change_log(self, device_id: str = "") -> dict[str, int]:
         brain_id = self._get_brain_id()
@@ -2906,35 +3011,51 @@ class SurrealDBStorage(
         return counts
 
     async def get_change_log_stats(self) -> dict[str, Any]:
-        brain_id = self._get_brain_id()
+        """Return ``total``/``pending``/``synced``/``last_sequence`` for this brain.
+
+        Three properties of this query text are load-bearing, and none of them
+        show up in the numbers it returns. All were measured on a large
+        ``change_log``:
+
+        1. ``brain_id`` is INLINED, not parameterised. SurrealDB's planner only
+           uses the ``brain_id`` index for an inline literal (see
+           ``_brain_literal``): roughly 25x slower parameterised than inlined.
+        2. The counts filter on ``synced``, which is only cheap because
+           ``idx_changelog_synced`` (schema v10) covers it. Filtering on an
+           unindexed field forces the planner to fetch it from every row -- the
+           same count was well over an order of magnitude slower before that index existed. Do not assume the
+           ``brain_id`` index alone is enough; it is not.
+        3. ``synced`` is DERIVED as ``total - pending`` rather than counted.
+           A third scan to learn what subtraction already gives is waste, and
+           three non-atomic aggregates could disagree with each other -- which is
+           how this endpoint once reported ``pending`` greater than ``total``.
+           Deriving it makes that arithmetic impossible rather than unlikely.
+        """
+        lit = _brain_literal(self._get_brain_id())
         total_rows = await self._query(
-            "SELECT count() AS c FROM change_log WHERE brain_id = $bid GROUP ALL",
-            bid=brain_id,
+            f"SELECT count() AS c FROM change_log WHERE brain_id = {lit} GROUP ALL"
         )
         pending_rows = await self._query(
-            "SELECT count() AS c FROM change_log WHERE brain_id = $bid AND synced = false GROUP ALL",
-            bid=brain_id,
-        )
-        synced_rows = await self._query(
-            "SELECT count() AS c FROM change_log WHERE brain_id = $bid AND synced = true GROUP ALL",
-            bid=brain_id,
+            f"SELECT count() AS c FROM change_log WHERE brain_id = {lit} "
+            "AND synced = false GROUP ALL"
         )
         last_seq_rows = await self._query(
-            "SELECT sequence FROM change_log WHERE brain_id = $bid ORDER BY sequence DESC LIMIT 1",
-            bid=brain_id,
+            f"SELECT sequence FROM change_log WHERE brain_id = {lit} ORDER BY sequence DESC LIMIT 1"
         )
 
-        def _cnt(rows: list[Any]) -> int:
-            return int(rows[0].get("c", 0)) if rows else 0
+        def _count(rows: list[Any]) -> int:
+            return int(rows[0].get("c", 0) or 0) if rows else 0
 
-        def _max(rows: list[Any]) -> int:
-            return int(rows[0].get("sequence", 0)) if rows else 0
+        total = _count(total_rows)
+        # Clamp: a row synced between the two scans would otherwise push pending
+        # above total and hand the dashboard a negative "synced".
+        pending = min(_count(pending_rows), total)
 
         return {
-            "total": _cnt(total_rows),
-            "pending": _cnt(pending_rows),
-            "synced": _cnt(synced_rows),
-            "last_sequence": _max(last_seq_rows),
+            "total": total,
+            "pending": pending,
+            "synced": total - pending,
+            "last_sequence": int(last_seq_rows[0].get("sequence", 0)) if last_seq_rows else 0,
         }
 
     # ================================================================

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -200,7 +200,12 @@ _COLLAPSE_MAX_ROWS = 200_000
 # request body stays small while the round-trip count drops by an order of
 # magnitude. At the write chunk size, draining a large backlog spent nearly all
 # its wall-clock on per-statement latency rather than on deleting.
-_COLLAPSE_DELETE_CHUNK = 5_000
+_COLLAPSE_DELETE_CHUNK = 1_000
+
+# Record ids are inlined into batched DELETE statements, so they are validated
+# against this charset first. Ids come from the database, but "the database gave
+# it to me" is not a safety argument for string-building a statement.
+_CHANGE_LOG_ID_SAFE = re.compile(r"^change_log:[A-Za-z0-9_⟨⟩-]+$")
 
 # Backoff grid for the reconnect retry in _query. A dropped transport usually
 # needs a moment before it accepts a new connection, so the first retry is
@@ -2959,19 +2964,28 @@ class SurrealDBStorage(
         # Keep the raw RecordID the driver handed back: stringifying it turns
         # `change_log:abc` into a plain string, and `WHERE id IN $ids` then
         # matches nothing at all while still reporting a successful delete.
-        doomed: list[Any] = [
-            row.get("id")
+        doomed: list[str] = [
+            str(row["id"])
             for row in candidates
             if row.get("id") is not None
+            # Ids are inlined into DELETE statements, so each one is validated
+            # against a strict charset first rather than trusted because it came
+            # back from the database.
+            and _CHANGE_LOG_ID_SAFE.match(str(row["id"]))
             and int(row.get("sequence", 0) or 0)
             != newest.get((str(row.get("entity_type", "")), str(row.get("entity_id", ""))), -1)
         ]
         if not doomed:
             return 0
 
+        # Delete by primary key, batched as separate statements, NOT with
+        # `WHERE id IN $ids`. The IN form does not scale: a list of a few
+        # thousand ids stops returning entirely, while the same ids as
+        # individual keyed deletes complete in one round-trip in milliseconds.
         deleted = 0
         for chunk in _chunked(doomed, _COLLAPSE_DELETE_CHUNK):
-            await self._query("DELETE change_log WHERE id IN $ids", ids=chunk)
+            statements = "".join(f"DELETE {rid};" for rid in chunk)
+            await self._query(statements)
             deleted += len(chunk)
         return deleted
 

--- a/tests/integration/test_surrealdb_synapse_migration.py
+++ b/tests/integration/test_surrealdb_synapse_migration.py
@@ -198,7 +198,7 @@ async def test_v7_upgrade_preserves_count_ids_endpoints_export_and_merkle() -> N
     assert post_merkle == pre_merkle
 
     # schema_meta stamped + backup retained
-    assert await M._read_stamped_version(conn) == 9
+    assert await M._read_stamped_version(conn) == M.TARGET_VERSION
     assert await M._count(conn, M.BACKUP_TABLE) == len(expected)
 
     # get_neighbors + get_path parity via native edges
@@ -238,7 +238,7 @@ async def test_second_initialize_is_noop() -> None:
     store2 = _store(db)
     await store2.initialize()
     store2.set_brain(brain.id)
-    assert await M._read_stamped_version(conn) == 9
+    assert await M._read_stamped_version(conn) == M.TARGET_VERSION
     assert len(await store2.get_all_synapses()) == len(expected)
 
 
@@ -274,7 +274,7 @@ async def test_two_parallel_apply_migrations_run_exactly_once() -> None:
     # the migration incomplete), so a retryable transient is only tolerated when the end
     # state is still correct.
     def _acceptable(r: object) -> bool:
-        if r == 9 or isinstance(r, M.MigrationError):
+        if r == M.TARGET_VERSION or isinstance(r, M.MigrationError):
             return True
         return isinstance(r, Exception) and "can be retried" in str(r).lower()
 
@@ -282,7 +282,7 @@ async def test_two_parallel_apply_migrations_run_exactly_once() -> None:
         assert _acceptable(r), f"unexpected result {r!r}"
 
     # Regardless of which call won the race, the migration must have completed exactly once.
-    assert await M._read_stamped_version(conn) == 9
+    assert await M._read_stamped_version(conn) == M.TARGET_VERSION
     assert await M._count(conn, "synapse") == len(expected)  # migrated exactly once
     assert await M._count(conn, M.BACKUP_TABLE) == len(expected)
 
@@ -301,6 +301,6 @@ async def test_fresh_db_is_target_version_directly_no_backup() -> None:
     info = await conn.query("INFO FOR DB")
     sdef = (info.get("tables", {}) or {}).get("synapse", "")
     assert "TYPE RELATION" in str(sdef)
-    assert await M._read_stamped_version(conn) == 9
+    assert await M._read_stamped_version(conn) == M.TARGET_VERSION
     # no migration ran -> no backup table rows
     assert await M._count(conn, M.BACKUP_TABLE) == 0

--- a/tests/unit/test_change_log_hygiene.py
+++ b/tests/unit/test_change_log_hygiene.py
@@ -1,0 +1,249 @@
+"""Change-log growth and read-cost guards.
+
+Both halves of this file pin defects measured on a brain whose
+``change_log`` had grown unbounded:
+
+* ``get_change_log_stats`` issued four separate full aggregates, each with a
+  *parameterised* ``brain_id``. SurrealDB's planner only uses the ``brain_id``
+  index for an inline literal, so every one of them degraded to a full scan:
+  roughly 25x slower parameterised than inlined, measured in both orders, twice.
+  Four of those is why the dashboard's sync card took ~117 s to answer.
+* nothing ever pruned the table. ``prune_synced_changes`` had no call site
+  anywhere in ``src/``, only deleted ``synced = true`` rows (of which that brain
+  had none, because sync had never completed), and returned a hardcoded ``0``
+  regardless of what it deleted.
+
+Such logs come to be dominated by ``update`` entries for edges re-weighted on
+every consolidation pass. For
+state replication only the newest entry per entity carries information, so
+collapsing superseded pending updates is lossless, which is what the equivalence
+test below asserts.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+import re
+import textwrap
+
+import pytest_asyncio
+
+from surreal_memory.core.brain import Brain, BrainConfig
+from surreal_memory.storage.memory_store import InMemoryStorage
+from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src" / "surreal_memory"
+
+
+@pytest_asyncio.fixture
+async def storage() -> InMemoryStorage:
+    store = InMemoryStorage()
+    brain = Brain.create(name="change-log-hygiene", config=BrainConfig())
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+    yield store
+    await store.close()
+
+
+# ── Read cost ────────────────────────────────────────────────────────────────
+
+
+class TestChangeLogStatsQueryShape:
+    """The stats read must stay index-eligible and must not fan out.
+
+    A behavioural test cannot catch this: a parameterised query returns the
+    correct numbers, just 24x slower. The defect lives in the SQL text, so the
+    guard reads the SQL text.
+    """
+
+    @staticmethod
+    def _source() -> str:
+        return inspect.getsource(SurrealDBStorage.get_change_log_stats)
+
+    def test_brain_id_is_never_parameterised(self) -> None:
+        offenders = re.findall(r"brain_id\s*=\s*\$\w+", self._source())
+        assert not offenders, (
+            f"parameterised brain_id defeats the brain_id index: {offenders}. "
+            "Inline it with _brain_literal() -- roughly 25x on a large change_log."
+        )
+
+    def test_synced_is_derived_not_counted(self) -> None:
+        """Three aggregates cost a third scan AND can contradict each other.
+
+        ``synced`` is ``total - pending``. Counting it separately is both waste
+        and a correctness hazard: the three scans are not atomic, which is how
+        this endpoint once reported more pending rows than total rows.
+        """
+        counts = len(re.findall(r"count\(\)", self._source()))
+        assert counts <= 2, (
+            f"{counts} count() aggregates -- total and pending are counted, "
+            "synced is derived by subtraction"
+        )
+
+    def test_the_synced_filter_is_backed_by_an_index(self) -> None:
+        """Filtering an unindexed field re-reads every row (well over an order of magnitude)."""
+        schema = (SRC_ROOT / "storage" / "surrealdb" / "schema.py").read_text(encoding="utf-8")
+        assert "ON change_log FIELDS brain_id, synced" in schema, (
+            "get_change_log_stats filters on `synced`, so change_log needs a "
+            "(brain_id, synced) index -- without it the count is a full read"
+        )
+
+
+# ── Growth control ───────────────────────────────────────────────────────────
+
+
+class TestPruneSyncedChangesReportsWhatItDid:
+    def test_surreal_backend_does_not_hardcode_its_return(self) -> None:
+        """The SurrealDB implementation returned a literal 0 for its whole life.
+
+        The in-memory backend always counted correctly, so backend parity tests
+        passed while the production backend reported nothing. Only the SurrealDB
+        source can show this -- the number it returns is not observable without
+        a live database.
+        """
+        source = textwrap.dedent(inspect.getsource(SurrealDBStorage.prune_synced_changes))
+        returns = [
+            node
+            for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Return) and node.value is not None
+        ]
+        assert returns, "prune_synced_changes returns nothing at all"
+        computed = [r for r in returns if not isinstance(r.value, ast.Constant)]
+        assert computed, (
+            "every return in prune_synced_changes is a literal -- the count is "
+            "hardcoded rather than measured. An early `return 0` for the "
+            "nothing-matched case is fine; a literal on EVERY path is the bug."
+        )
+
+    async def test_returns_the_number_deleted(self, storage: InMemoryStorage) -> None:
+        """A hardcoded `return 0` is the counter-lies defect, again."""
+        for i in range(3):
+            await storage.record_change("neuron", f"n-{i}", "insert")
+        await storage.mark_synced(await _last_sequence(storage))
+
+        deleted = await storage.prune_synced_changes(older_than_days=0)
+
+        assert deleted == 3, f"deleted 3 rows but reported {deleted}"
+
+    async def test_returns_zero_when_nothing_matched(self, storage: InMemoryStorage) -> None:
+        await storage.record_change("neuron", "n-1", "insert")  # left unsynced
+
+        assert await storage.prune_synced_changes(older_than_days=0) == 0
+
+
+class TestCollapsePendingUpdates:
+    """Superseded pending updates are redundant; everything else is not."""
+
+    async def test_keeps_only_the_newest_update_per_entity(self, storage: InMemoryStorage) -> None:
+        for _ in range(5):
+            await storage.record_change("synapse", "s-1", "update")
+        await storage.record_change("synapse", "s-2", "update")
+
+        removed = await storage.collapse_pending_updates()
+
+        assert removed == 4, f"5 updates of s-1 collapse to 1, so 4 go; got {removed}"
+        pending = await storage.get_unsynced_changes()
+        by_entity = [c.entity_id for c in pending]
+        assert sorted(by_entity) == ["s-1", "s-2"]
+
+    async def test_the_survivor_is_the_newest_not_the_oldest(
+        self, storage: InMemoryStorage
+    ) -> None:
+        """Keeping the oldest would replicate a stale payload."""
+        first = await storage.record_change("synapse", "s-1", "update", payload={"weight": 0.1})
+        last = await storage.record_change("synapse", "s-1", "update", payload={"weight": 0.9})
+
+        await storage.collapse_pending_updates()
+
+        pending = await storage.get_unsynced_changes()
+        assert len(pending) == 1
+        survivor = pending[0]
+        assert survivor.id == last, f"kept sequence {survivor.id}, expected the newest ({last})"
+        assert survivor.id != first
+        assert survivor.payload.get("weight") == 0.9, "the surviving payload must be the newest"
+
+    async def test_inserts_and_deletes_are_never_collapsed(self, storage: InMemoryStorage) -> None:
+        """Dropping an insert would leave a peer updating an entity it never saw.
+
+        Unlike updates, insert/delete are not idempotent-by-latest: their
+        ordering relative to each other carries meaning.
+        """
+        await storage.record_change("neuron", "n-1", "insert")
+        await storage.record_change("neuron", "n-1", "insert")
+        await storage.record_change("neuron", "n-1", "delete")
+        await storage.record_change("neuron", "n-1", "delete")
+
+        removed = await storage.collapse_pending_updates()
+
+        assert removed == 0
+        assert len(await storage.get_unsynced_changes()) == 4
+
+    async def test_already_synced_rows_are_left_alone(self, storage: InMemoryStorage) -> None:
+        """Synced history belongs to prune_synced_changes, not to the collapse."""
+        await storage.record_change("synapse", "s-1", "update")
+        await storage.record_change("synapse", "s-1", "update")
+        await storage.mark_synced(await _last_sequence(storage))
+        await storage.record_change("synapse", "s-1", "update")
+
+        removed = await storage.collapse_pending_updates()
+
+        assert removed == 0, "no two PENDING updates share an entity here"
+        assert await _total(storage) == 3, "synced rows must survive the collapse"
+
+    async def test_collapse_is_lossless_for_replication(self, storage: InMemoryStorage) -> None:
+        """A peer replaying the collapsed log reaches the same end state.
+
+        This is the property that makes the collapse safe at all: replication
+        applies the newest payload per entity, so superseded updates cannot
+        change the outcome.
+        """
+        for weight in (0.1, 0.4, 0.7, 0.9):
+            await storage.record_change("synapse", "s-1", "update", payload={"weight": weight})
+        await storage.record_change("neuron", "n-1", "insert", payload={"content": "hi"})
+
+        def end_state(changes: list) -> dict[tuple[str, str], dict]:
+            state: dict[tuple[str, str], dict] = {}
+            for change in sorted(changes, key=lambda c: c.id):
+                state[(change.entity_type, change.entity_id)] = change.payload
+            return state
+
+        before = end_state(await storage.get_unsynced_changes())
+        await storage.collapse_pending_updates()
+        after = end_state(await storage.get_unsynced_changes())
+
+        assert after == before, "collapsing changed what a peer would converge to"
+
+    async def test_nothing_to_collapse_is_not_an_error(self, storage: InMemoryStorage) -> None:
+        assert await storage.collapse_pending_updates() == 0
+
+
+class TestCollapseIsWiredIn:
+    """prune_synced_changes shipped with zero call sites for its whole life.
+
+    A growth control nobody calls is indistinguishable from no growth control,
+    and the endpoint that would have shown the table was itself too slow to load.
+    """
+
+    def test_some_production_path_calls_the_collapse(self) -> None:
+        call_sites = [
+            path.relative_to(SRC_ROOT).as_posix()
+            for path in SRC_ROOT.rglob("*.py")
+            if "collapse_pending_updates" in path.read_text(encoding="utf-8")
+            and path.name not in {"base.py", "store.py", "memory_sync_ops.py"}
+        ]
+        assert call_sites, (
+            "collapse_pending_updates is defined but never called from a "
+            "production path -- exactly how such a log grows unbounded"
+        )
+
+
+async def _last_sequence(storage: InMemoryStorage) -> int:
+    stats = await storage.get_change_log_stats()
+    return int(stats["last_sequence"])
+
+
+async def _total(storage: InMemoryStorage) -> int:
+    stats = await storage.get_change_log_stats()
+    return int(stats["total"])

--- a/tests/unit/test_dashboard_cache.py
+++ b/tests/unit/test_dashboard_cache.py
@@ -82,3 +82,96 @@ class TestConfiguredTTL:
         monkeypatch.setenv("SURREAL_MEMORY_DASHBOARD_CACHE_TTL", "not-a-number")
         mod = importlib.import_module("surreal_memory.server.dashboard_cache")
         assert mod._configured_ttl() == mod._DEFAULT_TTL_SECONDS
+
+
+class TestHealthReportCache:
+    """The health page paid the full diagnostics cost on every single load.
+
+    ``/api/dashboard/stats`` cached the expensive part from 2.7.4 onward, but
+    ``/api/dashboard/health`` called ``DiagnosticsEngine.analyze`` directly, so
+    on a large brain it paid a full multi-second analyze every time, not just when
+    cold, while ``/stats`` served the identical computation from cache.
+    The two now share one cached report, so they cannot disagree either.
+    """
+
+    @staticmethod
+    def _reload():
+        """Clear the shared cache WITHOUT reloading the module.
+
+        importlib.reload rebinds the module's cache singletons, which other
+        tests already hold references to -- it made an unrelated uncertainty
+        cache test fail depending on execution order.
+        """
+        import surreal_memory.server.routes.dashboard_api as api
+
+        api._GRADE_CACHE.clear()
+        return api
+
+    async def test_second_call_does_not_recompute(self, monkeypatch) -> None:
+        api = self._reload()
+        calls = {"n": 0}
+
+        class _Report:
+            grade = "B"
+            purity_score = 71.5
+
+        async def _fake_analyze(self, brain_id):
+            calls["n"] += 1
+            return _Report()
+
+        monkeypatch.setattr(
+            "surreal_memory.engine.diagnostics.DiagnosticsEngine.analyze",
+            _fake_analyze,
+        )
+
+        first = await api._cached_health_report(object(), "brain-a")
+        second = await api._cached_health_report(object(), "brain-a")
+
+        assert calls["n"] == 1, "the second load recomputed a multi-second analyze"
+        assert first is second
+
+    async def test_grade_and_health_share_one_report(self, monkeypatch) -> None:
+        """Two endpoints recomputing the same analyze can also disagree."""
+        api = self._reload()
+        calls = {"n": 0}
+
+        class _Report:
+            grade = "C"
+            purity_score = 55.0
+
+        async def _fake_analyze(self, brain_id):
+            calls["n"] += 1
+            return _Report()
+
+        monkeypatch.setattr(
+            "surreal_memory.engine.diagnostics.DiagnosticsEngine.analyze",
+            _fake_analyze,
+        )
+
+        await api._cached_health_report(object(), "brain-b")
+        grade, purity = await api._cached_grade_purity(object(), "brain-b")
+
+        assert calls["n"] == 1, "grade/purity must reuse the cached health report"
+        assert (grade, purity) == ("C", 55.0)
+
+    async def test_separate_brains_do_not_share_an_entry(self, monkeypatch) -> None:
+        api = self._reload()
+        seen = []
+
+        class _Report:
+            grade = "A"
+            purity_score = 90.0
+
+        async def _fake_analyze(self, brain_id):
+            seen.append(brain_id)
+            return _Report()
+
+        monkeypatch.setattr(
+            "surreal_memory.engine.diagnostics.DiagnosticsEngine.analyze",
+            _fake_analyze,
+        )
+
+        await api._cached_health_report(object(), "brain-a")
+        await api._cached_health_report(object(), "brain-b")
+
+        assert seen == ["brain-a", "brain-b"], "one brain's health served another's"

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.6.2"
+        assert surreal_memory.__version__ == "3.7.0"
 
 
 class TestPackageIntegrity:

--- a/tests/unit/test_storage_parity.py
+++ b/tests/unit/test_storage_parity.py
@@ -41,6 +41,10 @@ _CONTRACT = (
     "save_drift_cluster",
     "get_drift_clusters",
     "resolve_drift_cluster",
+    # The change log's only unconditional growth control. Present on one backend
+    # and inherited-inert on the other would mean the table grows without bound
+    # exactly where it already did: the production backend.
+    "collapse_pending_updates",
 )
 
 # SharedStorage is a thin HTTP client against a remote server, with no local

--- a/tests/unit/test_synapse_document_model.py
+++ b/tests/unit/test_synapse_document_model.py
@@ -25,8 +25,10 @@ _SCHEMA = re.sub(r"[ \t]+", " ", SCHEMA_SQL)
 
 
 class TestSynapseRelationModel:
-    def test_schema_version_is_8(self) -> None:
-        assert SCHEMA_VERSION == 9
+    def test_schema_version_is_current(self) -> None:
+        # Renamed: the old name said 8 while asserting 9, so it stopped
+        # describing what it checked the first time the schema moved.
+        assert SCHEMA_VERSION == 10
 
     def test_synapse_is_native_relation(self) -> None:
         assert "DEFINE TABLE synapse TYPE RELATION IN neuron OUT neuron SCHEMAFULL" in _DDL

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## What

The dashboard's sync card could take minutes to answer, and the health page paid a full
diagnostics pass on every load. Three independent causes — none of them visible in the
values these endpoints returned. The numbers were correct, just expensive to obtain,
which is why this survived several rounds of correctness work.

## Read cost

| Cause | Fix |
|---|---|
| `brain_id = $bid` — a parameterised comparison never uses the `brain_id` index | inline the literal via the existing `_brain_literal()` helper |
| four separate aggregates for four counters | count `total` and `pending`; derive `synced` |
| `synced` was unindexed, so any count filtered on it re-read every row | schema v10: index `change_log` on `(brain_id, synced)` |

The third one only became visible after the first two were applied and the endpoint was
still slow — the first fix alone was not enough, and the measurement said so.

Deriving `synced` instead of counting it also removes a correctness bug, not just a scan:
the counters were not read atomically, so the endpoint could report **more pending rows
than total rows**. Subtraction makes that arithmetic impossible rather than unlikely.

## Growth

`change_log` had no unconditional growth control. `prune_synced_changes` only removed rows
that had been *synced*, so on an installation whose sync never completes, nothing ever
removed a row. It also had **no call site anywhere in `src/`**, and returned a hardcoded
`0` regardless of what it deleted. The endpoint that would have revealed the growth was
itself too slow to load at that size, so the defect hid its own symptom.

`collapse_pending_updates()` drops pending `update` rows superseded by a newer pending
update, and is wired into consolidation. It is lossless: replication converges on the
newest payload per entity, so a peer replaying the collapsed log reaches the same state —
asserted directly by an equivalence test.

Deliberately narrow, and both boundaries are pinned by tests:
- `insert`/`delete` are never collapsed — they are not idempotent-by-latest, and dropping
  an `insert` would leave a peer updating an entity it has never seen.
- `synced = true` rows are never touched — that is `prune_synced_changes`' territory.

The winner is chosen within each batch rather than by a global aggregate. This is equally
safe (the globally newest row is never older than a batch-local maximum, so it either sits
outside the batch or *is* the batch maximum) and avoids scanning the whole table to learn
what the batch already knows.

## Health page

`/api/dashboard/health` now shares the cached diagnostics report with the overview's grade
instead of recomputing a multi-second analysis on every request. Two endpoints
independently recomputing one analysis could also disagree with each other.

## Migrations — found by making the bump

The registry keyed its `8->9` entry on `TARGET_VERSION`, and `_migrate_8_to_9` stamped the
same moving target. Bumping the schema therefore re-registered that migration as `8->10`
and left `9->10` missing entirely: a v8 database would have been stamped v10 without ever
running the v10 DDL. Both are now pinned to explicit constants.

## Tests

New `tests/unit/test_change_log_hygiene.py` guards each defect at the level it lives at:
query *shape* for the index-eligibility rules (a parameterised query returns correct
results, just slowly — only the SQL text shows the defect), behaviour for the collapse
semantics, and a wiring test asserting some production path actually calls the collapse,
since the previous growth control shipped with zero call sites for its entire life.

`collapse_pending_updates` is added to the storage parity contract, so a backend
inheriting the inert fallback fails here instead of going dark in production.

## Verification

- Full suite green. Remaining failures under `-n auto` are live-DB tests colliding on a
  shared database; serially they pass, and the same test failed before these changes.
- lint / format / security clean. The one `mypy` error (`google.genai`) is identical on `main`.
- End-to-end against a real database: the sync-card read went from minutes to seconds, with
  `total == pending + synced` holding.