### PR TITLE
fix(dashboard): route every diagnostics read through one cached report

### DIFF
--- a/src/surreal_memory/server/routes/dashboard_api.py
+++ b/src/surreal_memory/server/routes/dashboard_api.py
@@ -18,7 +18,13 @@ logger = logging.getLogger(__name__)
 # Full diagnostics (grade/purity) aggregates over the whole synapse graph — a few
 # seconds on a large brain. The grade is slow-moving, so cache it per brain for a
 # short window; the overview's counts are computed live (cheap) around it.
-_GRADE_CACHE = TTLCache()
+# Diagnostics gets its OWN window, far longer than the shared default. The
+# report costs tens of seconds on a large brain, so a 60 s entry expired before
+# most visitors came back: the cache existed but only paid off during continuous
+# use, and anyone opening the dashboard occasionally paid full price every time.
+# A health grade does not meaningfully move within five minutes.
+_HEALTH_TTL_SECONDS = 300.0
+_GRADE_CACHE = TTLCache(ttl=_HEALTH_TTL_SECONDS)
 
 # Brain-wide uncertainty overview is bounded/cheap, but cached per brain for a short
 # window anyway to keep the dashboard's polling off the storage hot path (same
@@ -313,9 +319,7 @@ async def list_brains_api(
                 grade = "F"
                 purity = 0.0
                 try:
-                    from surreal_memory.engine.diagnostics import DiagnosticsEngine
-
-                    report = await DiagnosticsEngine(brain_storage).analyze(name)
+                    report = await _cached_health_report(brain_storage, name)
                     grade = report.grade
                     purity = report.purity_score
                 except Exception:
@@ -1498,11 +1502,8 @@ async def get_config_status(
 
     # ── 6. Orphan Rate ──────────────────────────────────
     try:
-        from surreal_memory.engine.diagnostics import DiagnosticsEngine
-
         brain_name = cfg.current_brain
-        diag = DiagnosticsEngine(storage)
-        report = await diag.analyze(brain_name)
+        report = await _cached_health_report(storage, brain_name)
         orphan_pct = round(report.orphan_rate * 100, 1)
 
         if report.orphan_rate > 0.20:
@@ -1723,9 +1724,7 @@ async def get_storage_status(
         logger.debug("Storage status: get_stats failed", exc_info=True)
 
     try:
-        from surreal_memory.engine.diagnostics import DiagnosticsEngine
-
-        report = await DiagnosticsEngine(storage).analyze(brain_name)
+        report = await _cached_health_report(storage, brain_name)
         health_grade = report.grade
     except Exception:
         logger.debug("Storage status: diagnostics failed", exc_info=True)

--- a/tests/unit/test_dashboard_cache.py
+++ b/tests/unit/test_dashboard_cache.py
@@ -175,3 +175,61 @@ class TestHealthReportCache:
         await api._cached_health_report(object(), "brain-b")
 
         assert seen == ["brain-a", "brain-b"], "one brain's health served another's"
+
+
+class TestNoEndpointRecomputesDiagnosticsDirectly:
+    """One cached report, or four endpoints paying for it separately.
+
+    `/health` was given a cached diagnostics report, but `/brains`,
+    `/config-status` and `/storage/status` each kept calling
+    `DiagnosticsEngine.analyze` directly — so the expensive analysis ran once
+    per endpoint per load instead of once per brain per TTL window. Fixing them
+    one at a time is what left three behind the first time, so this is a scan,
+    not four separate assertions.
+    """
+
+    def test_analyze_is_only_called_through_the_cache(self) -> None:
+        import ast
+        import pathlib
+
+        path = (
+            pathlib.Path(__file__).resolve().parents[2]
+            / "src/surreal_memory/server/routes/dashboard_api.py"
+        )
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+
+        offenders = []
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            if node.name == "_cached_health_report":
+                continue  # the one place allowed to compute it
+            for inner in ast.walk(node):
+                # Only DiagnosticsEngine — EvolutionEngine.analyze is a
+                # different, unrelated analysis with its own cost profile.
+                if (
+                    isinstance(inner, ast.Call)
+                    and isinstance(inner.func, ast.Attribute)
+                    and inner.func.attr == "analyze"
+                    and isinstance(inner.func.value, ast.Call)
+                    and getattr(inner.func.value.func, "id", "") == "DiagnosticsEngine"
+                ):
+                    offenders.append(f"{node.name}:{inner.lineno}")
+
+        assert not offenders, (
+            "these handlers recompute diagnostics instead of using "
+            f"_cached_health_report: {offenders}"
+        )
+
+
+class TestHealthReportTTL:
+    def test_diagnostics_ttl_is_long_enough_to_ever_hit(self) -> None:
+        """A 60 s window cannot amortise a multi-second report.
+
+        With the shared default, a dashboard visited less often than once a
+        minute missed every time and paid full price on every load — the cache
+        existed but only helped during continuous use.
+        """
+        from surreal_memory.server.routes.dashboard_api import _HEALTH_TTL_SECONDS
+
+        assert _HEALTH_TTL_SECONDS >= 300


### PR DESCRIPTION
## What

Four endpoints each called `DiagnosticsEngine.analyze` directly, so the same
multi-second analysis ran **once per endpoint per page load** instead of once per
brain per window.

| endpoint | before | after (cold) | after (warm) |
|---|---|---|---|
| `/api/dashboard/brains` | 29.6 s | **1.7 s** | 1.4 s |
| `/api/dashboard/config-status` | 27.5 s | **1.6 s** | 1.6 s |
| `/api/dashboard/storage/status` | 30.3 s | **1.5 s** | 1.3 s |
| `/api/dashboard/health` | 26 s | 25.3 s | **1.7 ms** |

Measured against a real brain. The three non-`health` endpoints get their speedup
by *sharing* the report the first caller computed — they no longer each pay for
their own.

## Why the guard is a scan, not four assertions

`/health` was converted to the cached report in #182 and the other three were
missed. Fixing them individually is precisely the failure mode that left them
behind, so this adds an AST scan asserting that `DiagnosticsEngine.analyze` is
reachable from exactly one function — `_cached_health_report`.

It immediately found a **fourth** call site that was not on my list.

The scan is deliberately narrowed to `DiagnosticsEngine`: `/evolution` calls
`EvolutionEngine.analyze`, an unrelated analysis, and a broader match flagged it
as a false positive.

## TTL

The diagnostics cache no longer shares the 60 s default; it gets `_HEALTH_TTL_SECONDS = 300`.

A report costing tens of seconds cannot amortise inside a 60 s window — anyone
opening the dashboard less often than once a minute missed every single time and
paid full price. The cache existed but only helped during continuous use, which is
why `/health` still measured ~28 s in practice after #182. Five minutes, on the
argument that a health grade does not meaningfully move faster than that.

## Deliberately out of scope

`/evolution` still recomputes on every load (~14.5 s). It is a different engine
with a different cost and invalidation profile, and folding it into a cache whose
staleness rules were reasoned about for diagnostics only would be assuming, not
knowing. Left as a separate, visible debt.

## Verification

- Full suite: **7252 passed**, 0 failed (run serially — the `-n auto` failures
  seen previously are live-DB tests colliding on a shared database).
- lint / format clean.
- Latency figures above are end-to-end HTTP against a live brain, cold and warm.