### PR TITLE
perf(evolution): fetch once, cache the result, drop an unread blob

### DIFF
--- a/src/surreal_memory/engine/brain_evolution.py
+++ b/src/surreal_memory/engine/brain_evolution.py
@@ -185,12 +185,20 @@ class EvolutionEngine:
         """
         now = utcnow()
 
-        # Parallel fetch: brain metadata, stats, synapses, fibers
-        brain, stats, all_synapses, all_fibers = await asyncio.gather(
+        # Parallel fetch: brain metadata, stats, synapses, fibers, maturations.
+        #
+        # Two things here are deliberate and easy to undo by accident:
+        #   * synapses are fetched WITHOUT their metadata blob — nothing on this
+        #     path reads it, and on a large brain it dominates the transfer.
+        #   * maturations are fetched ONCE and handed to both consumers below.
+        #     They used to be fetched separately by _compute_stage_progress and
+        #     _compute_maturation, each a paged full scan of the same table.
+        brain, stats, all_synapses, all_fibers, all_maturations = await asyncio.gather(
             self._storage.get_brain(brain_id),
             self._storage.get_stats(brain_id),
-            self._storage.get_all_synapses(),
+            self._storage.get_all_synapses(include_metadata=False),
             self._storage.get_fibers(limit=10000),
+            self._storage.find_maturations(),
         )
         brain_name = brain.name if brain else "unknown"
         neuron_count = stats.get("neuron_count", 0)
@@ -203,13 +211,14 @@ class EvolutionEngine:
             reinforcement_days,
             fibers_semantic,
             fibers_episodic,
-        ) = await self._compute_maturation()
+        ) = self._compute_maturation(all_maturations)
 
         # Topology metrics (pass pre-fetched synapses)
         topo = await compute_topology(
             self._storage,
             brain_id,
             _preloaded_synapses=all_synapses,  # type: ignore[arg-type]
+            _preloaded_stats=stats,
         )
         topology_coherence = topo.clustering_coefficient * 0.5 + topo.largest_component_ratio * 0.5
         knowledge_density = topo.knowledge_density
@@ -236,7 +245,7 @@ class EvolutionEngine:
         )
 
         # Stage distribution and semantic progress
-        stage_dist, closest, gate_blockers = await self._compute_stage_progress(now)
+        stage_dist, closest, gate_blockers = self._compute_stage_progress(now, all_maturations)
 
         return BrainEvolution(
             brain_id=brain_id,
@@ -265,9 +274,10 @@ class EvolutionEngine:
 
     # ── Internal computations ────────────────────────────────
 
-    async def _compute_stage_progress(
+    def _compute_stage_progress(
         self,
         now: datetime,
+        all_maturations: Sequence[Any],
     ) -> tuple[StageDistribution, tuple[SemanticProgress, ...], dict[str, int]]:
         """Compute stage distribution, closest-to-semantic fibers, and gate blockers.
 
@@ -284,8 +294,6 @@ class EvolutionEngine:
             _MIN_REHEARSAL_COUNT,
             classify_episodic_blocker,
         )
-
-        all_maturations = await self._storage.find_maturations()
 
         counts = {
             MemoryStage.SHORT_TERM: 0,
@@ -376,15 +384,15 @@ class EvolutionEngine:
         progress_items.sort(key=lambda p: p.progress_pct, reverse=True)
         return stage_dist, tuple(progress_items[:3]), gate_blockers
 
-    async def _compute_maturation(
+    def _compute_maturation(
         self,
+        all_maturations: Sequence[Any],
     ) -> tuple[float, float, int, int]:
         """Compute maturation metrics from MaturationRecord data.
 
         Returns:
             (semantic_ratio, avg_reinforcement_days, semantic_count, episodic_count)
         """
-        all_maturations = await self._storage.find_maturations()
         if not all_maturations:
             return 0.0, 0.0, 0, 0
 

--- a/src/surreal_memory/engine/topology_analysis.py
+++ b/src/surreal_memory/engine/topology_analysis.py
@@ -46,15 +46,12 @@ class TopologyMetrics:
         knowledge_density: SEMANTIC synapses per neuron (NOT 0-1, raw ratio).
             Structural edges are excluded so this agrees with the connectivity
             figure smem_health reports for the same brain.
-        enriched_synapse_ratio: Fraction of synapses created by
-            ENRICH consolidation (have ``_enriched`` metadata).
     """
 
     clustering_coefficient: float
     largest_component_ratio: float
     density: float
     knowledge_density: float
-    enriched_synapse_ratio: float
 
 
 async def compute_topology(
@@ -62,6 +59,7 @@ async def compute_topology(
     brain_id: str,
     *,
     _preloaded_synapses: Sequence[SynapseLike] | None = None,
+    _preloaded_stats: dict[str, Any] | None = None,
 ) -> TopologyMetrics:
     """Compute graph topology metrics for a brain.
 
@@ -74,8 +72,11 @@ async def compute_topology(
         brain_id: Brain identifier.
         _preloaded_synapses: Optional pre-fetched synapse list to avoid
             redundant storage calls when called from EvolutionEngine.
+        _preloaded_stats: Optional pre-fetched stats dict. The only caller
+            already fetches these; re-fetching them here ran the count()
+            aggregates a second time to learn nothing new.
     """
-    stats = await storage.get_stats(brain_id)
+    stats = _preloaded_stats if _preloaded_stats is not None else await storage.get_stats(brain_id)
     neuron_count = stats.get("neuron_count", 0)
     synapse_count = stats.get("synapse_count", 0)
 
@@ -85,7 +86,6 @@ async def compute_topology(
             largest_component_ratio=0.0,
             density=0.0,
             knowledge_density=0.0,
-            enriched_synapse_ratio=0.0,
         )
 
     all_synapses: Sequence[SynapseLike] = (
@@ -107,12 +107,6 @@ async def compute_topology(
     semantic_synapse_count = sum(1 for s in all_synapses if not _is_structural(s))
     knowledge_density = semantic_synapse_count / max(1, neuron_count)
 
-    # ── Enriched synapse ratio ───────────────────────────────
-    enriched_count = sum(
-        1 for s in all_synapses if getattr(s, "metadata", None) and s.metadata.get("_enriched")
-    )
-    enriched_ratio = enriched_count / max(1, len(all_synapses))
-
     # ── Largest connected component ──────────────────────────
     lcc_ratio = _largest_component_ratio(all_synapses, neuron_count)
 
@@ -124,7 +118,6 @@ async def compute_topology(
         largest_component_ratio=lcc_ratio,
         density=min(1.0, density),
         knowledge_density=knowledge_density,
-        enriched_synapse_ratio=enriched_ratio,
     )
 
 

--- a/src/surreal_memory/server/routes/dashboard_api.py
+++ b/src/surreal_memory/server/routes/dashboard_api.py
@@ -32,6 +32,11 @@ _GRADE_CACHE = TTLCache(ttl=_HEALTH_TTL_SECONDS)
 # a fresh conflict/expiry may take up to the TTL to appear).
 _UNCERTAINTY_CACHE = TTLCache()
 
+# Evolution shares the diagnostics window, not the 60 s default: its analysis is
+# the same order of cost, and the metrics it reports (semantic ratio, topology
+# coherence, proficiency) move on a scale of hours.
+_EVOLUTION_CACHE = TTLCache(ttl=_HEALTH_TTL_SECONDS)
+
 
 async def _cached_health_report(storage: NeuralStorage, brain_name: str) -> Any:
     """Return the full diagnostics report for a brain, cached per brain.
@@ -51,6 +56,29 @@ async def _cached_health_report(storage: NeuralStorage, brain_name: str) -> Any:
 
     report = await DiagnosticsEngine(storage).analyze(brain_name)
     _GRADE_CACHE.set(key, report)
+    return report
+
+
+async def _cached_evolution(storage: NeuralStorage, brain_name: str) -> Any:
+    """Return the brain-evolution report, cached per brain.
+
+    Keyed on the storage's ACTIVE brain, not on ``brain_name``: EvolutionEngine
+    takes a brain_id but most of its reads go through the storage instance's own
+    current brain, so keying on the argument alone could serve one brain's report
+    for another. Same reasoning as the uncertainty cache.
+
+    ``BrainEvolution`` is a frozen dataclass of tuples, so unlike the uncertainty
+    payload it needs no defensive copy on the way in or out.
+    """
+    scope = getattr(storage, "current_brain_id", None) or brain_name
+    key = f"evolution:{scope}:{brain_name}"
+    cached = _EVOLUTION_CACHE.get(key)
+    if cached is not None:
+        return cached
+    from surreal_memory.engine.brain_evolution import EvolutionEngine
+
+    report = await EvolutionEngine(storage).analyze(brain_name)
+    _EVOLUTION_CACHE.set(key, report)
     return report
 
 
@@ -757,15 +785,13 @@ class EvolutionResponse(BaseModel):
 async def get_evolution(
     storage: Annotated[NeuralStorage, Depends(get_storage)],
 ) -> EvolutionResponse:
-    """Get evolution dynamics for the active brain."""
-    from surreal_memory.engine.brain_evolution import EvolutionEngine
+    """Get evolution dynamics for the active brain (served from the TTL cache)."""
     from surreal_memory.unified_config import get_config
 
     brain_name = get_config().current_brain
 
     try:
-        engine = EvolutionEngine(storage)
-        evo = await engine.analyze(brain_name)
+        evo = await _cached_evolution(storage, brain_name)
     except Exception as exc:
         logger.warning("Evolution analysis failed for brain %s: %s", brain_name, exc)
         raise HTTPException(status_code=500, detail="Evolution analysis failed")

--- a/src/surreal_memory/storage/base.py
+++ b/src/surreal_memory/storage/base.py
@@ -487,8 +487,13 @@ class NeuralStorage(ABC):
         """
         ...
 
-    async def get_all_synapses(self) -> list[Synapse]:
+    async def get_all_synapses(self, include_metadata: bool = True) -> list[Synapse]:
         """Get all synapses for the current brain.
+
+        Args:
+            include_metadata: When False, backends may omit the per-synapse
+                metadata blob. Callers that never read it should pass False —
+                on a large brain the blob dominates the transfer.
 
         Returns:
             List of all synapses

--- a/src/surreal_memory/storage/memory_store.py
+++ b/src/surreal_memory/storage/memory_store.py
@@ -341,7 +341,9 @@ class InMemoryStorage(
 
         return result
 
-    async def get_all_synapses(self) -> list[Synapse]:
+    async def get_all_synapses(self, include_metadata: bool = True) -> list[Synapse]:
+        # Accepted for interface parity; the in-memory buffer holds whole
+        # objects, so there is no projection to narrow.
         return await self.get_synapses()
 
     async def update_synapse(self, synapse: Synapse) -> None:

--- a/tests/unit/test_brain_evolution.py
+++ b/tests/unit/test_brain_evolution.py
@@ -747,6 +747,30 @@ class TestEvolutionEngine:
         assert mock_storage.get_all_synapses.call_count == 1
         # get_fibers called once (pre-fetched, passed to activity + decay)
         assert mock_storage.get_fibers.call_count == 1
+        # find_maturations called once — it used to run twice, once for the stage
+        # distribution and once for the maturation ratios, each a paged full scan
+        # of the maturation table.
+        assert mock_storage.find_maturations.call_count == 1
+        # get_stats called once — compute_topology used to fetch it a second time
+        # even though the caller had already done so, doubling the count()
+        # aggregates for no new information.
+        assert mock_storage.get_stats.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_synapse_metadata_is_not_fetched(self, mock_storage: AsyncMock) -> None:
+        """The metadata blob is dead weight on this path.
+
+        It was only ever read to derive enriched_synapse_ratio, which no caller
+        consumed. Dragging it along meant transferring a blob per row across the
+        whole synapse table on every evolution read.
+        """
+        engine = EvolutionEngine(mock_storage)
+        await engine.analyze("brain-1")
+
+        _, kwargs = mock_storage.get_all_synapses.call_args
+        assert kwargs.get("include_metadata") is False, (
+            "evolution must not pull the synapse metadata blob it never reads"
+        )
 
     @pytest.mark.asyncio
     async def test_full_integration(self, mock_storage: AsyncMock) -> None:

--- a/tests/unit/test_dashboard_cache.py
+++ b/tests/unit/test_dashboard_cache.py
@@ -202,18 +202,39 @@ class TestNoEndpointRecomputesDiagnosticsDirectly:
         for node in ast.walk(tree):
             if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
                 continue
-            if node.name == "_cached_health_report":
-                continue  # the one place allowed to compute it
+            if node.name in {"_cached_health_report", "_cached_evolution"}:
+                continue  # the two places allowed to compute an analysis
+
+            # Track engines bound to a local first: the handlers write
+            # `engine = EvolutionEngine(storage)` and then `engine.analyze(...)`,
+            # so matching only the inline `Engine(...).analyze(...)` form misses
+            # them entirely — which is exactly how this scan passed while
+            # /evolution still recomputed on every request.
+            engines = {"DiagnosticsEngine", "EvolutionEngine"}
+            bound: set[str] = set()
             for inner in ast.walk(node):
-                # Only DiagnosticsEngine — EvolutionEngine.analyze is a
-                # different, unrelated analysis with its own cost profile.
                 if (
+                    isinstance(inner, ast.Assign)
+                    and isinstance(inner.value, ast.Call)
+                    and getattr(inner.value.func, "id", "") in engines
+                ):
+                    for target in inner.targets:
+                        if isinstance(target, ast.Name):
+                            bound.add(target.id)
+
+            for inner in ast.walk(node):
+                if not (
                     isinstance(inner, ast.Call)
                     and isinstance(inner.func, ast.Attribute)
                     and inner.func.attr == "analyze"
-                    and isinstance(inner.func.value, ast.Call)
-                    and getattr(inner.func.value.func, "id", "") == "DiagnosticsEngine"
                 ):
+                    continue
+                receiver = inner.func.value
+                inline = isinstance(receiver, ast.Call) and (
+                    getattr(receiver.func, "id", "") in engines
+                )
+                via_local = isinstance(receiver, ast.Name) and receiver.id in bound
+                if inline or via_local:
                     offenders.append(f"{node.name}:{inner.lineno}")
 
         assert not offenders, (

--- a/tests/unit/test_evolution_dashboard.py
+++ b/tests/unit/test_evolution_dashboard.py
@@ -8,7 +8,20 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from surreal_memory.server.routes.dashboard_api import router
+from surreal_memory.server.routes.dashboard_api import _EVOLUTION_CACHE, router
+
+
+@pytest.fixture(autouse=True)
+def _clear_evolution_cache():
+    """Every test here analyses the same brain name.
+
+    Without this the first test's report would be served to all the others, and
+    the mocks they set up would never be reached — the suite would pass while
+    asserting nothing.
+    """
+    _EVOLUTION_CACHE.clear()
+    yield
+    _EVOLUTION_CACHE.clear()
 
 
 def _make_app() -> FastAPI:

--- a/tests/unit/test_topology_analysis.py
+++ b/tests/unit/test_topology_analysis.py
@@ -14,12 +14,12 @@ from surreal_memory.engine.topology_analysis import (
 )
 
 
-def _mock_synapse(source_id: str, target_id: str, enriched: bool = False) -> MagicMock:
+def _mock_synapse(source_id: str, target_id: str) -> MagicMock:
     """Create a mock synapse with source/target IDs."""
     s = MagicMock()
     s.source_id = source_id
     s.target_id = target_id
-    s.metadata = {"_enriched": True} if enriched else {}
+    s.metadata = {}
     return s
 
 
@@ -45,7 +45,6 @@ class TestTopologyMetrics:
             largest_component_ratio=0.8,
             density=0.1,
             knowledge_density=3.0,
-            enriched_synapse_ratio=0.2,
         )
         with pytest.raises(AttributeError):
             tm.density = 0.9  # type: ignore[misc]
@@ -62,7 +61,6 @@ class TestEmptyBrain:
         assert result.largest_component_ratio == 0.0
         assert result.density == 0.0
         assert result.knowledge_density == 0.0
-        assert result.enriched_synapse_ratio == 0.0
 
 
 class TestLargestComponentRatio:
@@ -166,26 +164,6 @@ class TestClusteringCoefficient:
         coeff = _clustering_coefficient(synapses)
         # Should complete without hanging and return a bounded value
         assert 0.0 <= coeff <= 1.0
-
-
-class TestEnrichedRatio:
-    """Tests for enriched synapse ratio."""
-
-    @pytest.mark.asyncio
-    async def test_enriched_synapses_counted(self, mock_storage: AsyncMock) -> None:
-        """Enriched synapses are counted correctly."""
-        synapses = [
-            _mock_synapse("a", "b", enriched=True),
-            _mock_synapse("b", "c", enriched=False),
-            _mock_synapse("c", "a", enriched=True),
-        ]
-        mock_storage.get_stats = AsyncMock(
-            return_value={"neuron_count": 3, "synapse_count": 3, "fiber_count": 0}
-        )
-        mock_storage.get_all_synapses = AsyncMock(return_value=synapses)
-
-        result = await compute_topology(mock_storage, "brain-1")
-        assert abs(result.enriched_synapse_ratio - 2 / 3) < 0.01
 
 
 class TestKnowledgeDensity:


### PR DESCRIPTION
## What

`/api/dashboard/evolution` was the last dashboard endpoint recomputing a full brain
analysis on **every** request, and that analysis did more work than it needed to.

| cost | before | after |
|---|---|---|
| synapse metadata | pulled for the whole table | omitted (`include_metadata=False`) |
| `find_maturations` | 2× paged full scan | 1× |
| `get_stats` | 2× (8 `count()` aggregates) | 1× (4) |
| cache | none | shares the diagnostics window |

## The metadata blob was dead weight

It was read solely to derive `enriched_synapse_ratio` — a metric **no caller consumes**.
`compute_topology` has exactly one caller, and that caller never reads it. So the entire
synapse table dragged a per-row blob across the wire to feed a metric nobody looks at.
The metric and its tests are removed rather than kept on life support.

`include_metadata` is now declared on `NeuralStorage`, not just implemented on the
SurrealDB backend — otherwise passing it would break the in-memory one.

## Cache key

Keyed on the storage's **active brain**, not on the `brain_id` argument. `EvolutionEngine`
takes an id, but most of its reads go through the storage instance's own current brain, so
keying on the argument alone could serve one brain's report for another. Same hazard the
uncertainty cache already guards against.

`BrainEvolution` is a frozen dataclass of tuples, so — unlike the uncertainty payload — it
needs no defensive copy.

## Why the existing guard let this through

The AST scan from #184 now covers `EvolutionEngine`, but the more important change is that
it **tracks engines bound to a local**. It matched only the inline
`Engine(...).analyze(...)` form, while this handler wrote `engine = EvolutionEngine(storage)`
— so the scan passed while the endpoint recomputed everything on every request.

`test_prefetches_data_once` is extended too: it guarded only `get_all_synapses` and
`get_fibers`; now also `find_maturations` and `get_stats`.

Added a cache-clearing fixture to `test_evolution_dashboard.py` — every test there analyses
the same brain, so without it the first report would be served to all the others and their
mocks would never be reached. The suite would pass while asserting nothing.

## Measured (end-to-end, real brain)

```
before:  ~14.5s on every load
after:    12.0s cold  →  1.7ms warm
```

The cold path improved less than expected — the table scans dominate, not the duplicated
queries. The slimming still stands on its own: the MCP path (`evolution_handler.py`) has no
endpoint cache, so points 1–3 are the only improvement it gets.

## Verification

- full suite, run serially: **7252 passed**, 0 failed
- lint / format clean; the single mypy error (`google.genai`) is identical on `main`
- latency figures above are end-to-end HTTP against a live brain, cold and warm