### PR TITLE
fix(mcp): refresh derived structure on edit, and expose min_salience

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -460,7 +460,7 @@ con `RunnableWithMessageHistory`.
 git clone https://github.com/acidkill/surreal-memory
 cd surreal-memory && pip install -e ".[dev]"
 smem doctor --dev        # Verificar configuración de colaborador
-pytest tests/ -v          # 7200+ tests
+pytest tests/ -v          # 7300+ tests
 ruff check src/ tests/    # Lint
 make verify               # Full CI gate
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Forward-looking vision. What's next, what's possible, where we're going.
 > ZERO LLM dependency — pure algorithmic, regex, graph-based.
 
-**Current state**: v3.5.1 — 57 MCP tools, 7200+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
+**Current state**: v3.5.1 — 57 MCP tools, 7300+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
 
 **Storage**: SurrealDB is the only persistent backend — schema v10 — and `storage_backend`
 defaults to it. `#141` removed the SQLite backend entirely; selecting `storage_backend = "sqlite"`

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -675,6 +675,7 @@ Transplant memories between brains by tags/types.
 | `source_brain` | string | Yes | — | Name of the source brain to extract from |
 | `tags` | array[string] | No | — | Tags to filter — fibers matching ANY tag will be included |
 | `memory_types` | array[string] | No | — | Memory types to filter (fact, decision, etc.) |
+| `min_salience` | number | No | — | Minimum salience a fiber must have to be transplanted (0.0-1.0, default 0.0 = unfiltered) |
 | `strategy` | string (`prefer_local`, `prefer_remote`, `prefer_recent`, `prefer_stronger`) | No | default: prefer_local | Conflict resolution strategy (default: prefer_local) |
 | `compact` | boolean | No | — | Return compact response (strip metadata hints, truncate lists). Saves 60-80% tokens. |
 | `token_budget` | integer | No | — | Max tokens for response. Progressively strips content to fit budget. |

--- a/src/surreal_memory/mcp/evolution_handler.py
+++ b/src/surreal_memory/mcp/evolution_handler.py
@@ -387,10 +387,16 @@ class EvolutionHandler:
         except ValueError:
             return {"error": f"Invalid strategy: {strategy_str}"}
 
-        filt = TransplantFilter(
-            tags=frozenset(tags) if tags else None,
-            memory_types=frozenset(memory_types) if memory_types else None,
-        )
+        try:
+            filt = TransplantFilter(
+                tags=frozenset(tags) if tags else None,
+                memory_types=frozenset(memory_types) if memory_types else None,
+                min_salience=float(args.get("min_salience", 0.0)),
+            )
+        except (TypeError, ValueError) as exc:
+            # TransplantFilter validates the range itself; surface that as an
+            # answer rather than letting it escape as a tool crash.
+            return {"error": f"Invalid min_salience: {exc}"}
 
         try:
             result = await transplant(

--- a/src/surreal_memory/mcp/lifecycle_handler.py
+++ b/src/surreal_memory/mcp/lifecycle_handler.py
@@ -41,9 +41,30 @@ async def _content_refreshed(storage: NeuralStorage, neuron: Neuron, new_content
     """
     from dataclasses import replace as dc_replace
 
+    from surreal_memory.extraction.structure_detector import detect_structure
     from surreal_memory.utils.simhash import simhash
 
     meta = dict(neuron.metadata)
+
+    # _structure is derived from the content exactly like content_hash is, and
+    # recall reads it back to answer with the memory's fields. Leaving it behind
+    # meant an edited memory kept describing text that no longer exists.
+    #
+    # Removed, not merely overwritten: when the new content has no structure at
+    # all, an overwrite-on-hit would preserve the previous fields — the worst
+    # case, because recall would then surface fields present nowhere.
+    structure = detect_structure(new_content)
+    if structure.is_structured:
+        meta["_structure"] = {
+            "format": structure.format.value,
+            "fields": [
+                {"name": f.name, "value": f.value, "type": f.field_type} for f in structure.fields
+            ],
+            "confidence": structure.confidence,
+        }
+    else:
+        meta.pop("_structure", None)
+
     updated = dc_replace(
         neuron, content=new_content, content_hash=simhash(new_content), metadata=meta
     )

--- a/src/surreal_memory/mcp/tool_schemas.py
+++ b/src/surreal_memory/mcp/tool_schemas.py
@@ -965,6 +965,15 @@ _ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
                     "items": {"type": "string"},
                     "description": "Memory types to filter (fact, decision, etc.)",
                 },
+                "min_salience": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 1.0,
+                    "description": (
+                        "Minimum salience a fiber must have to be transplanted "
+                        "(0.0-1.0, default 0.0 = unfiltered)"
+                    ),
+                },
                 "strategy": {
                     "type": "string",
                     "enum": [

--- a/tests/unit/test_mcp_edit_and_transplant.py
+++ b/tests/unit/test_mcp_edit_and_transplant.py
@@ -1,0 +1,141 @@
+"""Two MCP surfaces that quietly did less than they promised.
+
+* `smem_edit` refreshes `content_hash` and the embedding when content changes
+  (#166), but left `metadata["_structure"]` describing the OLD text. Recall
+  reads that field back, so an edited structured memory kept answering with
+  fields it no longer contains (#176).
+* `TransplantFilter.min_salience` is validated, documented and applied — but no
+  MCP caller ever set it, so `smem_transplant` always ran unfiltered with no way
+  to ask otherwise (#175).
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+
+from surreal_memory.mcp.tool_schemas import get_tool_schemas
+
+SRC_ROOT = pathlib.Path(__file__).resolve().parents[2] / "src" / "surreal_memory"
+
+
+def _function(source: str, name: str) -> ast.AST:
+    """The named function's AST node, sync or async."""
+    return next(
+        n
+        for n in ast.walk(ast.parse(source))
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == name
+    )
+
+
+def _schema(name: str) -> dict:
+    return next(s for s in get_tool_schemas() if s["name"] == name)
+
+
+class TestEditRefreshesStructure:
+    """Every field derived from content must be refreshed together."""
+
+    def test_content_refresh_recomputes_structure(self) -> None:
+        source = inspect.getsource(
+            __import__(
+                "surreal_memory.mcp.lifecycle_handler", fromlist=["_content_refreshed"]
+            )._content_refreshed
+        )
+        assert "detect_structure" in source, (
+            "_content_refreshed updates content_hash and the embedding but not "
+            "metadata['_structure'], which recall reads back — an edited memory "
+            "keeps answering with fields the new text no longer has"
+        )
+
+    def test_stale_structure_is_removed_not_just_overwritten(self) -> None:
+        """Editing structured text into prose must drop the old fields.
+
+        Overwriting only on a hit would leave the previous structure in place
+        when the new content has none — the worst case, because recall would
+        surface fields that no longer exist anywhere.
+        """
+        source = (SRC_ROOT / "mcp" / "lifecycle_handler.py").read_text(encoding="utf-8")
+        func = _function(source, "_content_refreshed")
+        pops = [
+            n
+            for n in ast.walk(func)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "pop"
+            and n.args
+            and isinstance(n.args[0], ast.Constant)
+            and n.args[0].value == "_structure"
+        ]
+        assert pops, "no branch removes a stale _structure when the new content has none"
+
+
+class TestTransplantExposesMinSalience:
+    def test_the_tool_schema_advertises_it(self) -> None:
+        props = _schema("smem_transplant")["inputSchema"]["properties"]
+        assert "min_salience" in props, (
+            "min_salience is validated and applied by the engine but unreachable "
+            "through MCP — callers always transplant unfiltered"
+        )
+
+    def test_the_schema_states_the_valid_range(self) -> None:
+        """An out-of-range value raises from the engine; say so up front."""
+        prop = _schema("smem_transplant")["inputSchema"]["properties"]["min_salience"]
+        assert prop.get("minimum") == 0.0
+        assert prop.get("maximum") == 1.0
+
+    def test_the_handler_passes_it_through(self) -> None:
+        source = (SRC_ROOT / "mcp" / "evolution_handler.py").read_text(encoding="utf-8")
+        calls = [
+            n
+            for n in ast.walk(ast.parse(source))
+            if isinstance(n, ast.Call) and getattr(n.func, "id", "") == "TransplantFilter"
+        ]
+        assert calls, "no TransplantFilter construction found"
+        passed = {kw.arg for call in calls for kw in call.keywords}
+        assert "min_salience" in passed, (
+            "the handler builds TransplantFilter without min_salience, so the "
+            "schema would advertise an argument that is silently dropped"
+        )
+
+
+class TestEditStructureBehaviour:
+    """The structural tests above pin the shape; these pin the outcome."""
+
+    async def test_editing_into_new_structure_replaces_the_old_fields(self) -> None:
+        from surreal_memory.core.neuron import Neuron, NeuronType
+        from surreal_memory.mcp.lifecycle_handler import _content_refreshed
+        from surreal_memory.storage.memory_store import InMemoryStorage
+
+        neuron = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="name: old\nrole: tester",
+            metadata={"_structure": {"format": "yaml", "fields": [{"name": "name"}]}},
+        )
+
+        updated = await _content_refreshed(
+            InMemoryStorage(), neuron, "name: new\nrole: reviewer\nteam: platform"
+        )
+
+        fields = {f["name"] for f in updated.metadata["_structure"]["fields"]}
+        assert "team" in fields, "structure was not recomputed from the new content"
+
+    async def test_editing_structure_away_drops_it_entirely(self) -> None:
+        """Recall reads _structure back; a leftover would surface dead fields."""
+        from surreal_memory.core.neuron import Neuron, NeuronType
+        from surreal_memory.mcp.lifecycle_handler import _content_refreshed
+        from surreal_memory.storage.memory_store import InMemoryStorage
+
+        neuron = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="name: old\nrole: tester",
+            metadata={"_structure": {"format": "yaml", "fields": [{"name": "name"}]}},
+        )
+
+        updated = await _content_refreshed(
+            InMemoryStorage(), neuron, "just some prose with no fields at all"
+        )
+
+        assert "_structure" not in updated.metadata, (
+            "stale structure survived an edit into unstructured text"
+        )


### PR DESCRIPTION
Closes #176. Closes #175.

Two MCP surfaces that quietly did less than they promised. Different symptoms, same
shape: a capability that exists everywhere except where a caller could reach it.

## #176 — `smem_edit` left `_structure` describing the old text

Since #166 a content edit refreshes `content_hash` and the embedding. It still did not
touch `metadata["_structure"]`, which is derived from the content the same way — and which
recall reads back to answer with a memory's fields.

So an edited structured memory kept reporting fields the new content no longer had.

Recomputed alongside the other derived fields. Importantly it is **removed, not merely
overwritten**, when the new content has no structure at all: overwrite-on-hit would
preserve the previous fields in exactly the worst case, leaving recall surfacing fields
that exist nowhere.

## #175 — `min_salience` was unreachable

`TransplantFilter.min_salience` is validated, documented and applied by the engine, but
nothing in `mcp/` ever set it. Every `smem_transplant` call therefore ran at the default
`0.0` — unfiltered, with no way to ask for anything else.

Now advertised in the tool schema with its `0.0–1.0` range stated up front, and forwarded
by the handler. The engine already validates the range; the handler turns that into a
returned error rather than letting it escape as a tool crash.

## Tests assert reachability, not just correctness

Both defects were invisible to correctness tests — the engine code was right the whole
time. So the tests check the path a caller actually travels: the schema advertises the
argument, the handler forwards it, and the edit path genuinely recomputes.

For the edit, structural tests are backed by behavioural ones: editing into new structure
replaces the fields, and editing structure *away* drops `_structure` entirely.

## Verification

- full suite: **7278 passed**, 0 failed
- lint / format clean
- all three docs gates regenerated and green before pushing