### PR TITLE
fix(activation): bound concurrent traversals in activate_from_multiple

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -460,7 +460,7 @@ con `RunnableWithMessageHistory`.
 git clone https://github.com/acidkill/surreal-memory
 cd surreal-memory && pip install -e ".[dev]"
 smem doctor --dev        # Verificar configuración de colaborador
-pytest tests/ -v          # 7200+ tests
+pytest tests/ -v          # 7300+ tests
 ruff check src/ tests/    # Lint
 make verify               # Full CI gate
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Forward-looking vision. What's next, what's possible, where we're going.
 > ZERO LLM dependency — pure algorithmic, regex, graph-based.
 
-**Current state**: v3.5.1 — 57 MCP tools, 7200+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
+**Current state**: v3.5.1 — 57 MCP tools, 7300+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
 
 **Storage**: SurrealDB is the only persistent backend — schema v10 — and `storage_backend`
 defaults to it. `#141` removed the SQLite backend entirely; selecting `storage_backend = "sqlite"`

--- a/src/surreal_memory/engine/activation.py
+++ b/src/surreal_memory/engine/activation.py
@@ -21,6 +21,13 @@ logger = logging.getLogger(__name__)
 # Safety cap: maximum queue entries to prevent memory exhaustion on dense graphs
 _MAX_QUEUE_SIZE = 50_000
 
+# Ceiling on activation traversals running at once in activate_from_multiple.
+# Each traversal walks the graph and hits storage, so an unbounded fan-out scales
+# concurrent load with caller input rather than with anything the system controls.
+# Matches _BATCH_FETCH_CONCURRENCY in the SurrealDB store, which bounds the same
+# class of fan-out one layer down.
+_MAX_CONCURRENT_ACTIVATIONS = 16
+
 
 @dataclass
 class ActivationTrace:
@@ -402,12 +409,24 @@ class SpreadingActivation:
         if not anchor_sets:
             return {}, []
 
-        # Activate from each set in parallel
-        tasks = [
-            self.activate(anchors, max_hops, anchor_activations=anchor_activations)
-            for anchors in anchor_sets
-            if anchors
-        ]
+        # Activate from each set in parallel, but BOUNDED. Gathering one
+        # traversal per anchor set meant simultaneous traversals — and pending
+        # asyncio tasks — grew directly with the number of inputs: 512 anchor
+        # sets produced 512 concurrent activations (#181). Each traversal walks
+        # the graph and hits storage, so the ceiling is what keeps a large
+        # multi-anchor recall from stampeding the backend.
+        #
+        # The bound throttles the work; it does not drop any of it. Every anchor
+        # set is still processed, just not all at the same instant.
+        semaphore = asyncio.Semaphore(_MAX_CONCURRENT_ACTIVATIONS)
+
+        async def _bounded(
+            anchors: list[str],
+        ) -> tuple[dict[str, ActivationResult], ActivationTrace]:
+            async with semaphore:
+                return await self.activate(anchors, max_hops, anchor_activations=anchor_activations)
+
+        tasks = [_bounded(anchors) for anchors in anchor_sets if anchors]
         raw_results = list(await asyncio.gather(*tasks)) if tasks else []
 
         if not raw_results:

--- a/tests/unit/test_activation_concurrency.py
+++ b/tests/unit/test_activation_concurrency.py
@@ -1,0 +1,74 @@
+"""Bound on concurrent activation traversals (#181).
+
+`activate_from_multiple` gathered one traversal per anchor set with no limit, so
+simultaneous traversals — and pending asyncio tasks — grew directly with the
+number of inputs. The reporter measured 512 anchor sets producing 512 concurrent
+activations.
+
+The test measures peak concurrency the same way rather than asserting on the
+call shape: a semaphore that is created but never awaited would pass a
+structural check and bound nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from surreal_memory.core.brain import BrainConfig
+from surreal_memory.engine.activation import SpreadingActivation
+from surreal_memory.storage.memory_store import InMemoryStorage
+
+ANCHOR_SETS = 128
+
+
+class _ConcurrencyProbe:
+    """Replaces a single activation with a coroutine that stays pending."""
+
+    def __init__(self) -> None:
+        self.active = 0
+        self.peak = 0
+        self._release = asyncio.Event()
+
+    async def __call__(self, anchors, max_hops=None, anchor_activations=None):
+        self.active += 1
+        self.peak = max(self.peak, self.active)
+        # Yield so every task that CAN start does start before any finishes —
+        # without this the loop could serialise them and hide the defect.
+        await asyncio.sleep(0)
+        self.active -= 1
+        return {}, []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_traversals_are_bounded() -> None:
+    engine = SpreadingActivation(InMemoryStorage(), BrainConfig())
+    probe = _ConcurrencyProbe()
+    engine.activate = probe  # type: ignore[method-assign]
+
+    anchor_sets = [[f"n-{i}"] for i in range(ANCHOR_SETS)]
+    await engine.activate_from_multiple(anchor_sets)
+
+    assert probe.peak < ANCHOR_SETS, (
+        f"all {ANCHOR_SETS} traversals ran at once — concurrency grows with the "
+        "number of anchor sets, which is the defect"
+    )
+
+
+@pytest.mark.asyncio
+async def test_every_anchor_set_is_still_processed() -> None:
+    """A bound must throttle the work, not drop it."""
+    engine = SpreadingActivation(InMemoryStorage(), BrainConfig())
+    seen: list[str] = []
+
+    async def _record(anchors, max_hops=None, anchor_activations=None):
+        seen.extend(anchors)
+        return {}, []
+
+    engine.activate = _record  # type: ignore[method-assign]
+
+    anchor_sets = [[f"n-{i}"] for i in range(ANCHOR_SETS)]
+    await engine.activate_from_multiple(anchor_sets)
+
+    assert len(seen) == ANCHOR_SETS


### PR DESCRIPTION
Closes #181.

## What

`activate_from_multiple` gathered one traversal per anchor set with **no limit**, so
simultaneous traversals — and pending asyncio tasks — grew directly with the number of
inputs. The reporter measured 512 anchor sets producing 512 concurrent activations.

Each traversal walks the graph and hits storage, so an unbounded fan-out scales concurrent
load with *caller input* rather than with anything the system controls.

## Fix

Bounded by a semaphore at the same ceiling the SurrealDB store already uses for this class
of fan-out one layer down (`_BATCH_FETCH_CONCURRENCY`). Reusing that number keeps one
answer for "how wide may we fan out" instead of two that can drift.

**The bound throttles the work; it does not drop any.** Every anchor set is still
processed, just not all at the same instant.

## Why the tests look like this

The concurrency test **measures peak simultaneous activations** rather than inspecting the
call shape. A semaphore that is constructed but never awaited would sail through a
structural check while bounding nothing — the probe replaces a single activation with a
coroutine that yields, so every task that *can* start does start before any finishes.

A second test asserts every anchor set is still processed, because a bound that quietly
discarded inputs would satisfy the first test perfectly.

## Verification

- full suite: **7273 passed**, 0 failed
- lint / format clean, mypy clean across `src/`
- all three docs gates green before pushing