### PR TITLE
chore(release): 3.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "3.7.0"
+    "version": "3.8.0"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.0] — 2026-08-27 — the dashboard answers, and what it reports stops lying
+
+Every dashboard endpoint that recomputed a multi-second analysis on each request now
+serves it from a shared cached report, and three defects that made stored state quietly
+disagree with reality are fixed.
+
+### Added
+
+- `smem prune-orphan-states` — reports, and on `--apply` removes, `neuron_state` rows whose
+  neuron is gone. Deliberately an explicit command rather than a consolidation stage: it
+  deletes on the strength of a neuron/state comparison, and normalising only one side of
+  that comparison empties the table. It defaults to reporting.
+- Per-pass decay telemetry (`[decay_telemetry]`, off by default). One aggregate row per
+  decay pass — never a row per edge, since the pass touches every synapse and per-edge rows
+  are the write pattern that grew the change log without bound. Records the weight
+  distribution either side of the pass, why each skipped synapse was skipped, and the knobs
+  the pass ran with, because a distribution is uninterpretable without them.
+- `smem_transplant` accepts `min_salience`. The engine validated and applied it all along;
+  no MCP caller could set it, so every transplant ran unfiltered.
+
+### Fixed
+
+- `/api/dashboard/health`, `/brains`, `/config-status` and `/storage/status` each called
+  the diagnostics engine directly, so one analysis ran once per endpoint per page load
+  instead of once per brain per window. They now share one cached report — which also
+  removes the possibility of two endpoints disagreeing about the same brain.
+- The diagnostics cache has its own TTL instead of the shared 60 s default. A report
+  costing tens of seconds cannot amortise inside a minute: anyone opening the dashboard
+  less often than that missed every time and paid full price.
+- `/api/dashboard/evolution` recomputed on every request, and its analysis fetched the
+  synapse metadata blob for a metric no caller reads, ran the maturation scan twice, and
+  re-fetched stats its caller had already retrieved.
+- `add_neuron` swallowed a failed `neuron_state` insert and still reported success. A
+  neuron without a state row looks permanently un-accessed: it never receives the
+  activation boost and is a standing candidate for dead-neuron pruning, for a reason
+  nothing logged.
+- `smem_edit` refreshed `content_hash` and the embedding on a content edit but left
+  `metadata["_structure"]` describing the previous text, which recall reads back. It is now
+  recomputed — and removed, not merely overwritten, when the new content has no structure.
+- `activate_from_multiple` started one traversal per anchor set with no bound, so
+  concurrent traversals grew with caller input rather than with anything the system
+  controls.
+
 ## [3.7.0] — 2026-08-26 — the change log stops growing, and the dashboard stops waiting on it
 
 The dashboard's sync card could take minutes to answer, and the health page paid a

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.7.0"
+version = "3.8.0"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.7.0"
+__version__ = "3.8.0"
 
 __all__ = [
     "__version__",

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.7.0"
+        assert surreal_memory.__version__ == "3.8.0"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
Release PR for **3.8.0**. Version bumped across all 16 version-bearing sites
(`collect_versions()` in `scripts/pre_ship.py` is the source of truth), plus the CHANGELOG
entry.

## Why MINOR, not PATCH

Six merged PRs since 3.7.0. Most are fixes, but three add capability that did not exist
before, all backward-compatible:

- `smem prune-orphan-states` — a new CLI command
- `[decay_telemetry]` — a new opt-in table with its own config section and storage methods
- `smem_transplant(min_salience=…)` — a new tool argument

Shipping those under a patch tag would misdescribe them.

## What is in it

| PR | |
|---|---|
| #184 | one cached diagnostics report shared by four dashboard endpoints |
| #185 | `/evolution` fetches once, caches, and stops pulling an unread blob |
| #186 | `add_neuron` stops swallowing the `neuron_state` write; orphans reclaimable explicitly |
| #187 | per-pass decay telemetry (#183) |
| #188 | `smem_edit` refreshes `_structure`; `min_salience` reachable over MCP |
| #189 | bounded concurrency in `activate_from_multiple` |

Closes #174, #175, #176, #181, #183 across those PRs.

## Verification

- **7280 passed**, 0 failed
- lint / format clean
- all seven Docs Freshness gates green locally before pushing: versions, dead modules,
  MCP reference, CLI reference, config reference, REST reference, scattered references