### PR TITLE
fix(storage): persist the pre-compression neuron snapshot instead of dropping it

### DIFF
--- a/src/surreal_memory/storage/surrealdb/compression.py
+++ b/src/surreal_memory/storage/surrealdb/compression.py
@@ -174,7 +174,11 @@ class SurrealDBCompressionMixin:
             "neuron_id": neuron_id,
             "brain_id": brain_id,
             "original_content": original_content,
-            "compressed_at": _parse_datetime(compressed_at) or utcnow(),
+            # neuron_snapshots.compressed_at is declared TYPE string, so send a
+            # string: a datetime fails coercion on a SCHEMAFULL table and the
+            # caller's fail-soft except swallows it, leaving no snapshot to
+            # recover from. get_neuron_snapshot parses it back on read.
+            "compressed_at": (_parse_datetime(compressed_at) or utcnow()).isoformat(),
             "tier": int(tier),
         }
 

--- a/tests/unit/_surrealdb_live.py
+++ b/tests/unit/_surrealdb_live.py
@@ -44,6 +44,7 @@ LIVE_TEST_BRAIN_NAMES = frozenset(
         "parity-test-surreal",  # test_get_project_memories.py
         "snapshot-roundtrip-live",  # test_surrealdb_export_import_live.py
         "snapshot-roundtrip-live-target",  # test_surrealdb_export_import_live.py
+        "neuron-snapshot-live",  # test_surrealdb_neuron_snapshot_live.py
         "pinned-expiry-test-9f3a1c",  # test_surrealdb_expiry_respects_pinned_live.py
         "bug006-tm-delete-id-live",  # test_surrealdb_typed_memory_delete_id_live.py
         "kw-df-batch-live-4b8d2e",  # test_surrealdb_keyword_df_live.py

--- a/tests/unit/test_surrealdb_neuron_snapshot_live.py
+++ b/tests/unit/test_surrealdb_neuron_snapshot_live.py
@@ -1,0 +1,112 @@
+"""Regression: a pre-compression neuron snapshot must actually reach the database.
+
+``save_neuron_snapshot`` sent ``compressed_at`` as a ``datetime`` while the
+schema declares ``neuron_snapshots.compressed_at TYPE string``. On a SCHEMAFULL
+table the write is refused with a coercion error, and the only caller
+(``engine/compression.py``) wraps the call in a fail-soft ``except`` that logs
+and compresses anyway - so tier 3-4 compression destroyed the original content
+while its snapshot silently never existed, leaving ``recover_neuron_content``
+nothing to restore from.
+
+Only a live engine can catch this: the in-memory backend keeps a plain dict with
+no schema, so the type mismatch is invisible there. The test is skipped when
+SURREALDB_URL is unset so CI without docker still passes.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+import pytest
+
+from surreal_memory.core.brain import Brain
+from surreal_memory.utils.timeutils import utcnow
+from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
+
+SURREALDB_URL = os.getenv("SURREALDB_URL")
+
+pytestmark = pytest.mark.skipif(
+    not SURREALDB_URL,
+    reason="requires SURREALDB_URL env var pointing to a running SurrealDB",
+)
+
+
+@pytest.fixture
+async def surrealdb_storage():  # type: ignore[no-untyped-def]
+    ensure_real_surrealdb_sdk()
+    from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+    storage = SurrealDBStorage(url=SURREALDB_URL)
+    await storage.initialize()
+    brain = Brain.create(name="neuron-snapshot-live")
+    await storage.save_brain(brain)
+    storage.set_brain(brain.id)
+    yield storage
+    try:
+        await cleanup_live_brains(storage, own_brain_id=brain.id)
+    except Exception:
+        pass
+    try:
+        await storage.close()
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_save_neuron_snapshot_persists(surrealdb_storage) -> None:  # type: ignore[no-untyped-def]
+    """The snapshot is readable after the write, and its timestamp round-trips."""
+    brain_id = surrealdb_storage.current_brain_id
+    before = utcnow()
+
+    await surrealdb_storage.save_neuron_snapshot(
+        neuron_id="snap-1",
+        brain_id=brain_id,
+        original_content="content that destructive compression is about to replace",
+        compressed_at=before.isoformat(),
+        tier=3,
+    )
+
+    snapshot = await surrealdb_storage.get_neuron_snapshot("snap-1")
+    assert snapshot is not None, "the snapshot was refused by the schema and silently lost"
+    assert snapshot["original_content"] == (
+        "content that destructive compression is about to replace"
+    )
+    assert snapshot["tier"] == 3
+    assert isinstance(snapshot["compressed_at"], datetime)
+    assert snapshot["compressed_at"] == before.replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_save_neuron_snapshot_upserts(surrealdb_storage) -> None:  # type: ignore[no-untyped-def]
+    """A second write for the same neuron updates the row (the merge branch).
+
+    The merge path shares the record payload with the insert path, so it is
+    subject to the same coercion. Note this test can only demonstrate the merge
+    working: before the fix, the first write never lands, so there is no row to
+    merge onto and the failure surfaces on the insert.
+    """
+    brain_id = surrealdb_storage.current_brain_id
+
+    await surrealdb_storage.save_neuron_snapshot(
+        neuron_id="snap-2",
+        brain_id=brain_id,
+        original_content="first",
+        compressed_at=utcnow().isoformat(),
+        tier=3,
+    )
+    second_at = utcnow()
+    await surrealdb_storage.save_neuron_snapshot(
+        neuron_id="snap-2",
+        brain_id=brain_id,
+        original_content="second",
+        compressed_at=second_at.isoformat(),
+        tier=4,
+    )
+
+    snapshot = await surrealdb_storage.get_neuron_snapshot("snap-2")
+    assert snapshot is not None
+    assert snapshot["original_content"] == "second"
+    assert snapshot["tier"] == 4
+    # The merged row carries the second write's timestamp, not the first's.
+    assert snapshot["compressed_at"] == second_at.replace(tzinfo=None)


### PR DESCRIPTION
## Summary

- `save_neuron_snapshot` now sends `compressed_at` as the `string` the schema declares, so the pre-compression snapshot actually reaches the database instead of being refused.
- Adds a live regression test covering both write paths (first insert, and the merge used on a second write for the same neuron).

## Why

`neuron_snapshots.compressed_at` is defined `TYPE string`, but the storage layer wrote a `datetime` into it. On a SCHEMAFULL table SurrealDB refuses the write:

```
InternalError: Couldn't coerce value for field `compressed_at` of `neuron_snapshots:…`:
Expected `string` but found `d'2026-08-19T18:34:06.419075Z'`
```

The only caller - `CompressionEngine`, saving originals before the destructive tiers - wraps the call in a fail-soft `except` that logs and then compresses anyway. So the failure was invisible in normal operation: tier 3-4 compression replaced a neuron's content while the snapshot meant to protect it silently never existed, and `recover_neuron_content` had nothing to restore from. The counterpart table `compression_backups.compressed_at` is `TYPE datetime` and receives a `datetime`; only this one column disagreed with its writer.

Sending the declared type is the smaller of the two possible fixes and the one that works everywhere. The alternative - redefining the column as `datetime`, which would read more naturally and match `compression_backups` - cannot be delivered by editing the schema alone: `ensure_schema` swallows `already exists` on a re-`DEFINE`, so an existing database would keep the `string` column and stay broken. That route needs a numbered migration and a `SCHEMA_VERSION` bump, which is a larger change than this fix and touches every deployment; I have deliberately left it out rather than fold it in here. Happy to follow up with it if you would prefer the column normalised.

Two details worth noting for review:

- **No data migration is needed.** The field definition and its writer were introduced in the same commit (`1f6fe80d`, #28) and neither line has changed since, so no `neuron_snapshots` row has ever been written on a SurrealDB backend. There is no legacy value in the column to be compatible with.
- **The read path is untouched.** `get_neuron_snapshot` already parses through `_parse_datetime`, which accepts both a string and a `datetime`, so callers keep receiving a `datetime` exactly as before.
- **One inherited quirk, now observable.** `_parse_datetime` drops `tzinfo` without converting to UTC, so an offset-bearing input would be stored as local wall time labelled UTC. That is pre-existing behaviour and the only in-tree caller passes `utcnow().isoformat()`, which is already naive UTC - but this value reaches the database for the first time with this fix, so it is worth stating rather than leaving to be discovered.

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` passes locally: 7079 passed, 148 skipped, 1 xfailed. The skip count is +2 against the same run on `main` - precisely the two new tests, which skip when `SURREALDB_URL` is unset.
- [x] `ruff check src/ tests/` clean; `ruff format --check` clean.
- [x] `mypy src/ --ignore-missing-imports` - `Success: no issues found in 353 source files`.
- [x] The new tests were proven to fail without the fix: with the one-line change stashed, both fail against a live engine with the coercion error quoted above; with it applied, both pass.
- [x] Verified end to end against a real engine (`surrealdb:v3.2.4`, ephemeral instance, real `ensure_schema`): before the fix `get_neuron_snapshot` returned `None` and `SELECT count() FROM neuron_snapshots GROUP ALL` returned `0`; after it, the snapshot reads back with its content and tier intact and the count is `1`.
- [x] The test is placed with the other live-engine tests and gated on `SURREALDB_URL`, so it runs in the integration job and skips elsewhere; its throwaway brain name is registered with the shared cleanup helper so it does not accumulate rows.

A note on why the test needs a live engine: this failure is a schema coercion refusal, and the in-memory backend stores snapshots in a plain dict with no schema, so the mismatch cannot surface there. That is also why nothing caught it earlier - before this change, `save_neuron_snapshot` had no test coverage at all.

## Verified by

@RobertSigmundsson

---

Rebased onto v3.8.0 (`ae8e8743`) and re-tested there. #186 landed in the same area - the
`neuron_state` write - but the paths are disjoint: this one is the snapshot row in
`neuron_snapshots`, which #186 does not touch. Thanks for the quick turnaround on both
v3.7.0 and v3.8.0.
