### PR TITLE
fix(memory): refresh content-derived fields on compress, restore, and refine

### DIFF
--- a/src/surreal_memory/engine/compression.py
+++ b/src/surreal_memory/engine/compression.py
@@ -26,10 +26,13 @@ from datetime import datetime
 from enum import IntEnum, StrEnum
 from typing import TYPE_CHECKING, Any
 
+from surreal_memory.utils.content_refresh import content_refreshed, contents_refreshed
 from surreal_memory.utils.timeutils import ensure_naive_utc, utcnow
 
 if TYPE_CHECKING:
+    from surreal_memory.core.brain import Brain
     from surreal_memory.core.fiber import Fiber
+    from surreal_memory.core.neuron import Neuron
     from surreal_memory.storage.base import NeuralStorage
 
 logger = logging.getLogger(__name__)
@@ -552,6 +555,7 @@ class CompressionEngine:
         target_tier: CompressionTier,
         *,
         dry_run: bool = False,
+        brain: Brain | None = None,
     ) -> CompressionResult:
         """Compress a single fiber to *target_tier*.
 
@@ -741,16 +745,41 @@ class CompressionEngine:
         # Apply compression: update each neuron's content if tier < GRAPH_ONLY,
         # or clear all content for GRAPH_ONLY.
         if target_tier == CompressionTier.GRAPH_ONLY:
-            for neuron in neurons.values():
-                from dataclasses import replace as dc_replace
+            from dataclasses import replace as dc_replace
 
-                cleared = dc_replace(neuron, content="[graph-only]")
+            # Neurons already carrying the placeholder with the sentinel hash
+            # are done - re-deriving their fields would only spend a provider
+            # call on a known result.
+            pending_clear = [n for n in neurons.values() if n.content != "[graph-only]"]
+            # The placeholder is a tombstone, not content, so it gets the
+            # codebase's "no meaningful fingerprint" sentinel rather than
+            # simhash("[graph-only]"). That SimHash is one constant for every
+            # graph-only anchor, and the consolidation census compares anchors
+            # by Hamming distance - identical fingerprints would read as a
+            # near-duplicate pair and persist a false "duplicate of" edge
+            # between unrelated memories. Both census and dedup skip 0.
+            refreshed = [
+                dc_replace(n, content_hash=0)
+                for n in await contents_refreshed(
+                    self._storage, [(n, "[graph-only]") for n in pending_clear], brain=brain
+                )
+            ]
+            # Tombstones written before this change carry the SimHash of their
+            # deleted original text, which keeps feeding the census fingerprints
+            # of content that no longer exists. Stamp the sentinel on those too;
+            # no re-embed - a repeat pass stays provider-free.
+            refreshed.extend(
+                dc_replace(n, content_hash=0)
+                for n in neurons.values()
+                if n.content == "[graph-only]" and n.content_hash != 0
+            )
+            for cleared in refreshed:
                 try:
                     await self._storage.update_neuron(cleared)
                 except Exception:
                     logger.error(
                         "Failed to clear neuron %s content for fiber %s",
-                        neuron.id,
+                        cleared.id,
                         fiber.id,
                         exc_info=True,
                     )
@@ -764,9 +793,9 @@ class CompressionEngine:
             anchor_id = fiber.anchor_neuron_id
             anchor_neuron = neurons.get(anchor_id)
             if anchor_neuron is not None:
-                from dataclasses import replace as dc_replace
-
-                updated_anchor = dc_replace(anchor_neuron, content=compressed_content)
+                updated_anchor = await content_refreshed(
+                    self._storage, anchor_neuron, compressed_content, brain=brain
+                )
                 try:
                     await self._storage.update_neuron(updated_anchor)
                 except Exception:
@@ -830,9 +859,7 @@ class CompressionEngine:
             logger.error("Anchor neuron %s missing for fiber %s", anchor_id, fiber_id)
             return False
 
-        from dataclasses import replace as dc_replace
-
-        restored_neuron = dc_replace(anchor_neuron, content=original_content)
+        restored_neuron = await content_refreshed(self._storage, anchor_neuron, original_content)
         try:
             await self._storage.update_neuron(restored_neuron)
         except Exception:
@@ -840,6 +867,8 @@ class CompressionEngine:
             return False
 
         # Reset fiber compression tier to 0 (FULL).
+        from dataclasses import replace as dc_replace
+
         updated_fiber = dc_replace(fiber, compression_tier=int(CompressionTier.FULL))
         try:
             await self._storage.update_fiber(updated_fiber)
@@ -881,6 +910,9 @@ class CompressionEngine:
         if current_tier in (CompressionTier.TEMPLATE, CompressionTier.GRAPH_ONLY):
             neurons = await self._storage.get_neurons_batch(list(fiber.neuron_ids))
             restored_count = 0
+            # Collect first, then refresh as one batch: re-deriving each neuron's
+            # embedding separately would cost a provider round-trip per neuron.
+            pending: list[tuple[Neuron, str]] = []
             for neuron in neurons.values():
                 snapshot: dict[str, Any] | None = await self._storage.get_neuron_snapshot(neuron.id)
                 if snapshot is None:
@@ -888,16 +920,18 @@ class CompressionEngine:
                 original_content: str = snapshot.get("original_content", "")
                 if not original_content:
                     continue
-                from dataclasses import replace as dc_replace
+                pending.append((neuron, original_content))
 
-                restored_neuron = dc_replace(neuron, content=original_content)
+            for restored_neuron in await contents_refreshed(self._storage, pending):
                 try:
                     await self._storage.update_neuron(restored_neuron)
-                    await self._storage.delete_neuron_snapshot(neuron.id)
+                    await self._storage.delete_neuron_snapshot(restored_neuron.id)
                     restored_count += 1
                 except Exception:
                     logger.error(
-                        "Failed to restore neuron %s from snapshot", neuron.id, exc_info=True
+                        "Failed to restore neuron %s from snapshot",
+                        restored_neuron.id,
+                        exc_info=True,
                     )
 
             if restored_count > 0:
@@ -966,6 +1000,14 @@ class CompressionEngine:
 
         fibers = await self._storage.get_fibers(limit=10000)
 
+        # One brain lookup for the whole pass: the derived-field refresh needs
+        # the brain's embedding config, which cannot change mid-run, and paying
+        # a per-fiber lookup would contradict this path's own round-trip budget.
+        try:
+            brain = await self._storage.get_brain(self._storage.current_brain_id or "")
+        except Exception:
+            brain = None
+
         for idx, fiber in enumerate(fibers):
             # Pinned (KB) fibers stay at tier 0 forever
             if fiber.pinned:
@@ -1004,7 +1046,7 @@ class CompressionEngine:
                 break
 
             try:
-                result = await self.compress_fiber(fiber, target_tier, dry_run=dry_run)
+                result = await self.compress_fiber(fiber, target_tier, dry_run=dry_run, brain=brain)
             except Exception:
                 logger.error("Compression failed for fiber %s", fiber.id, exc_info=True)
                 report.fibers_skipped += 1

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -2511,11 +2511,21 @@ class ConsolidationEngine:
                 await asyncio.sleep(0)
             if anchor_a.content_hash is None or anchor_a.content_hash == 0:
                 continue
+            # GRAPH_ONLY tombstones written before the hash sentinel existed
+            # still carry the SimHash of their deleted original text - a
+            # fingerprint of content that is no longer there, which can
+            # near-duplicate-match a genuine memory and persist a false ALIAS
+            # edge. Guard on content like every other fingerprint consumer;
+            # tombstones stamped with the sentinel are already skipped above.
+            if anchor_a.content == "[graph-only]":
+                continue
 
             for anchor_b in anchors[i + 1 :]:
                 if anchor_b.id in seen:
                     continue
                 if anchor_b.content_hash is None or anchor_b.content_hash == 0:
+                    continue
+                if anchor_b.content == "[graph-only]":
                     continue
 
                 if is_near_duplicate(

--- a/src/surreal_memory/engine/dedup/pipeline.py
+++ b/src/surreal_memory/engine/dedup/pipeline.py
@@ -128,11 +128,19 @@ class DedupPipeline:
             limit=max_candidates,
         )
 
-        # Filter to anchor neurons only
+        # Filter to anchor neurons only. GRAPH_ONLY tombstones are excluded
+        # here, ahead of every tier: legacy ones still carry the SimHash of
+        # their DELETED text, so tier 1 could canonicalise a brand-new memory
+        # onto a tombstone - the new fiber would anchor to "[graph-only]" and
+        # its text survive only as an alias neuron. (The FTS analyzer happily
+        # tokenises the placeholder into "graph"/"only", so tombstones do turn
+        # up in this candidate search.) Same guard the census uses.
         return [
             n
             for n in candidates
-            if n.metadata.get("is_anchor", False) and n.type == NeuronType.CONCEPT
+            if n.metadata.get("is_anchor", False)
+            and n.type == NeuronType.CONCEPT
+            and n.content != "[graph-only]"
         ]
 
     def _tier1_simhash(

--- a/src/surreal_memory/engine/interference.py
+++ b/src/surreal_memory/engine/interference.py
@@ -113,6 +113,15 @@ async def detect_interference(
         if candidate.id == new_neuron.id:
             continue
 
+        # GRAPH_ONLY tombstones carry the no-fingerprint sentinel (hash 0),
+        # and the recompute fallback below would resurrect exactly the shared
+        # constant that sentinel suppresses - every tombstone would then sit
+        # the same Hamming distance from the new memory, and one save could
+        # persist a CONTRADICTS edge to all of them at once. The fallback is
+        # for real content that merely lost its hash; a placeholder is not that.
+        if candidate.content == "[graph-only]":
+            continue
+
         cand_hash = candidate.content_hash or simhash(candidate.content)
         dist = hamming_distance(new_hash, cand_hash)
 

--- a/src/surreal_memory/engine/pipeline_steps.py
+++ b/src/surreal_memory/engine/pipeline_steps.py
@@ -255,6 +255,12 @@ async def _find_similar_entity(storage: NeuralStorage, text: str) -> Neuron | No
         if len(first_word) >= 3:
             nearby = await storage.find_neurons(content_contains=first_word, limit=10)
             for candidate in nearby:
+                # A GRAPH_ONLY tombstone written before the hash sentinel still
+                # carries the SimHash of its deleted text; reusing it here would
+                # bind the new entity reference to a placeholder. Same guard as
+                # the census and the dedup pipeline.
+                if candidate.content == "[graph-only]":
+                    continue
                 if candidate.content_hash and is_near_duplicate(text_hash, candidate.content_hash):
                     return candidate
     return None

--- a/src/surreal_memory/engine/prediction_error.py
+++ b/src/surreal_memory/engine/prediction_error.py
@@ -136,6 +136,12 @@ async def compute_surprise_bonus(
     min_hamming = 64  # worst case
 
     for neuron in unique[:20]:  # cap to avoid perf issues
+        # A GRAPH_ONLY tombstone has no content to be surprised by - and a
+        # legacy one still carries the SimHash of its deleted text, which would
+        # deflate the novelty of a new memory resembling content that is gone.
+        if neuron.content == "[graph-only]":
+            continue
+
         # Contradiction check
         if _detects_reversal(content, neuron.content):
             max_reversal_score = 2.5

--- a/src/surreal_memory/engine/retrieval.py
+++ b/src/surreal_memory/engine/retrieval.py
@@ -1468,6 +1468,12 @@ class ReflexPipeline:
         # Collect candidates with embeddings, compute similarity in parallel
         embed_pairs: list[tuple[str, list[float]]] = []
         for neuron in candidates:
+            # GRAPH_ONLY tombstones share one placeholder text, so their
+            # vectors are identical brain-wide - for a query anywhere near that
+            # region they would tie with each other and crowd genuine memories
+            # out of the top-k anchor slots. Same skip as semantic discovery.
+            if neuron.content == "[graph-only]":
+                continue
             stored_embedding = neuron.metadata.get("_embedding")
             if stored_embedding and isinstance(stored_embedding, list):
                 embed_pairs.append((neuron.id, stored_embedding))

--- a/src/surreal_memory/engine/semantic_discovery.py
+++ b/src/surreal_memory/engine/semantic_discovery.py
@@ -386,6 +386,14 @@ async def discover_semantic_synapses(
             for n in batch:
                 if not n.content.strip():
                     continue
+                # GRAPH_ONLY tombstones all share the literal placeholder as
+                # content, so their stored vectors are identical brain-wide -
+                # cosine 1.0 between memories that have nothing in common.
+                # Linking them would persist a false SIMILAR_TO edge on every
+                # consolidation pass; the dedup census skips these anchors for
+                # the same reason (their content_hash carries the 0 sentinel).
+                if n.content == "[graph-only]":
+                    continue
                 emb = n.metadata.get("_embedding")
                 if emb:
                     type_neurons.append(n)

--- a/src/surreal_memory/mcp/instruction_handler.py
+++ b/src/surreal_memory/mcp/instruction_handler.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from surreal_memory.mcp.constants import MAX_CONTENT_LENGTH
 from surreal_memory.mcp.tool_handler_utils import _require_brain_id
+from surreal_memory.utils.content_refresh import content_refreshed
 from surreal_memory.utils.timeutils import utcnow
 
 if TYPE_CHECKING:
@@ -121,9 +122,7 @@ class InstructionHandler:
 
             # Update anchor neuron content
             if anchor:
-                from dataclasses import replace as dc_replace
-
-                updated_neuron = dc_replace(anchor, content=new_content)
+                updated_neuron = await content_refreshed(storage, anchor, new_content)
                 await storage.update_neuron(updated_neuron)
                 changes.append(f"content updated (v{old_version}→v{new_version})")
 

--- a/src/surreal_memory/mcp/lifecycle_handler.py
+++ b/src/surreal_memory/mcp/lifecycle_handler.py
@@ -12,95 +12,14 @@ from surreal_memory.core.memory_types import (
 )
 from surreal_memory.mcp.constants import MAX_CONTENT_LENGTH
 from surreal_memory.mcp.tool_handler_utils import _get_brain_or_error, _require_brain_id
+from surreal_memory.utils.content_refresh import content_refreshed
 from surreal_memory.utils.timeutils import utcnow
 
 if TYPE_CHECKING:
-    from surreal_memory.core.neuron import Neuron
     from surreal_memory.storage.base import NeuralStorage
     from surreal_memory.unified_config import UnifiedConfig
 
 logger = logging.getLogger(__name__)
-
-
-async def _content_refreshed(storage: NeuralStorage, neuron: Neuron, new_content: str) -> Neuron:
-    """Return *neuron* with its content replaced and the derived fields refreshed.
-
-    ``content_hash`` is a pure function of the content, so it is recomputed
-    unconditionally — keeping the old fingerprint would feed near-duplicate
-    detection the SimHash of text that no longer exists.
-
-    The embedding is recomputed only when the neuron already carries one
-    (``metadata["_embedding"]``, surfaced by the storage read). ``update_neuron``
-    writes whatever vector that key holds, so without a refresh a content edit
-    actively re-saves the OLD vector against the NEW text: the memory stays
-    retrievable by what it used to say, and ``reindex --missing-only`` cannot
-    repair it because the field is never empty. Re-embedding goes through the
-    same provider path and bounded wait the write path uses; if the provider is
-    unavailable the edit still succeeds, but the stale vector is reported with a
-    warning instead of being rewritten silently.
-    """
-    from dataclasses import replace as dc_replace
-
-    from surreal_memory.extraction.structure_detector import detect_structure
-    from surreal_memory.utils.simhash import simhash
-
-    meta = dict(neuron.metadata)
-
-    # _structure is derived from the content exactly like content_hash is, and
-    # recall reads it back to answer with the memory's fields. Leaving it behind
-    # meant an edited memory kept describing text that no longer exists.
-    #
-    # Removed, not merely overwritten: when the new content has no structure at
-    # all, an overwrite-on-hit would preserve the previous fields — the worst
-    # case, because recall would then surface fields present nowhere.
-    structure = detect_structure(new_content)
-    if structure.is_structured:
-        meta["_structure"] = {
-            "format": structure.format.value,
-            "fields": [
-                {"name": f.name, "value": f.value, "type": f.field_type} for f in structure.fields
-            ],
-            "confidence": structure.confidence,
-        }
-    else:
-        meta.pop("_structure", None)
-
-    updated = dc_replace(
-        neuron, content=new_content, content_hash=simhash(new_content), metadata=meta
-    )
-    if "_embedding" not in meta:
-        return updated
-    try:
-        import asyncio
-
-        from surreal_memory.core.brain import BrainConfig
-        from surreal_memory.engine.encoder import _inline_embed_timeout
-        from surreal_memory.engine.semantic_discovery import _create_provider
-
-        brain = await storage.get_brain(storage.brain_id or "")
-        provider = _create_provider(
-            brain.config if brain else BrainConfig(), task_type="RETRIEVAL_DOCUMENT"
-        )
-        embed = provider.embed_batch([updated.embedding_text()])
-        budget = _inline_embed_timeout()
-        vectors = await (asyncio.wait_for(embed, timeout=budget) if budget else embed)
-        meta["_embedding"] = list(vectors[0])
-    except TimeoutError:
-        logger.warning(
-            "smem_edit changed the content of neuron %s but re-embedding exceeded "
-            "its time budget — the stored vector still describes the old content; "
-            "run `smem reindex --all` to repair it.",
-            neuron.id,
-        )
-    except Exception:
-        logger.warning(
-            "smem_edit changed the content of neuron %s but could not recompute its "
-            "embedding — the stored vector still describes the old content; "
-            "run `smem reindex --all` to repair it.",
-            neuron.id,
-            exc_info=True,
-        )
-    return updated
 
 
 class LifecycleHandler:
@@ -194,7 +113,7 @@ class LifecycleHandler:
             if new_content is not None:
                 anchor = await storage.get_neuron(fiber.anchor_neuron_id)
                 if anchor:
-                    updated_neuron = await _content_refreshed(storage, anchor, new_content)
+                    updated_neuron = await content_refreshed(storage, anchor, new_content)
                     await storage.update_neuron(updated_neuron)
                     changes.append(f"content updated ({len(new_content)} chars)")
 
@@ -211,7 +130,7 @@ class LifecycleHandler:
 
             changes = []
             if new_content is not None:
-                neuron = await _content_refreshed(storage, neuron, new_content)
+                neuron = await content_refreshed(storage, neuron, new_content)
                 changes.append(f"content updated ({len(new_content)} chars)")
             if new_type is not None:
                 from surreal_memory.core.neuron import NeuronType

--- a/src/surreal_memory/utils/content_refresh.py
+++ b/src/surreal_memory/utils/content_refresh.py
@@ -1,0 +1,170 @@
+"""Shared helper for keeping content-derived fields in sync with a content change.
+
+Lives in ``utils/`` (not ``engine/`` or ``mcp/``) because every layer that changes
+a neuron's content - the MCP edit tool, instruction refinement, and the
+compression engine - needs it, and ``utils/`` is the one layer none of them
+import back from (see ``simhash``, which sits here for the same reason).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from surreal_memory.core.brain import Brain
+    from surreal_memory.core.neuron import Neuron
+    from surreal_memory.storage.base import NeuralStorage
+
+logger = logging.getLogger(__name__)
+
+
+async def contents_refreshed(
+    storage: NeuralStorage,
+    changes: list[tuple[Neuron, str]],
+    *,
+    brain: Brain | None = None,
+) -> list[Neuron]:
+    """Refresh many neurons' content-derived fields in ONE provider round-trip.
+
+    ``content_hash`` is a pure function of the content, so it is recomputed for
+    every neuron unconditionally - keeping the old fingerprint would feed
+    near-duplicate detection the SimHash of text that no longer exists. So is
+    ``metadata["_structure"]``, which recall reads back to answer with the
+    memory's fields; it is re-derived, and *removed* when the new content has no
+    structure, so recall can never surface fields that exist nowhere.
+
+    The embedding is recomputed only for neurons that already carry one
+    (``metadata["_embedding"]``, surfaced by the storage read). ``update_neuron``
+    writes whatever vector that key holds, so without a refresh a content change
+    actively re-saves the OLD vector against the NEW text: the memory stays
+    retrievable by what it used to say, and ``reindex --missing-only`` cannot
+    repair it because the field is never empty.
+
+    Batching matters because the compression engine calls this from loops over
+    every neuron of a fiber, under a time budget, in a path that already counts
+    database round-trips as its dominant cost. One brain lookup and one
+    ``embed_batch`` cover the whole batch, mirroring how the write path embeds on
+    create (``encoder.py``) rather than paying a round-trip per neuron.
+
+    Re-embedding goes through the same provider path and bounded wait the write
+    path uses. If the provider is unavailable the change still succeeds, but the
+    stale vectors are reported with a warning naming the repair command instead
+    of being rewritten silently.
+
+    ``brain`` lets a caller that loops over many fibers (``compress_all``) fetch
+    the brain once and reuse it, instead of paying one lookup per fiber for a
+    value that cannot change mid-pass. When omitted, it is fetched here.
+    """
+    from dataclasses import replace as dc_replace
+
+    from surreal_memory.extraction.structure_detector import detect_structure
+    from surreal_memory.utils.simhash import simhash
+
+    updated: list[Neuron] = []
+    metas: list[dict[str, object]] = []
+    for neuron, new_content in changes:
+        # dc_replace keeps this exact dict object, so mutating it below also
+        # updates the returned neuron's metadata.
+        meta = dict(neuron.metadata)
+
+        # _structure is derived from the content exactly like content_hash is,
+        # and recall reads it back to answer with the memory's fields. Leaving
+        # it behind meant an edited memory kept describing text that no longer
+        # exists.
+        #
+        # Removed, not merely overwritten: when the new content has no structure
+        # at all, an overwrite-on-hit would preserve the previous fields - the
+        # worst case, because recall would then surface fields present nowhere.
+        structure = detect_structure(new_content)
+        if structure.is_structured:
+            meta["_structure"] = {
+                "format": structure.format.value,
+                "fields": [
+                    {"name": f.name, "value": f.value, "type": f.field_type}
+                    for f in structure.fields
+                ],
+                "confidence": structure.confidence,
+            }
+        else:
+            meta.pop("_structure", None)
+
+        metas.append(meta)
+        updated.append(
+            dc_replace(
+                neuron, content=new_content, content_hash=simhash(new_content), metadata=meta
+            )
+        )
+
+    targets = [i for i, meta in enumerate(metas) if "_embedding" in meta]
+    if not targets:
+        return updated
+
+    scope = f"neuron {updated[targets[0]].id}" if len(targets) == 1 else f"{len(targets)} neurons"
+    try:
+        import asyncio
+
+        from surreal_memory.core.brain import BrainConfig
+        from surreal_memory.engine.encoder import _inline_embed_timeout
+        from surreal_memory.engine.semantic_discovery import _create_provider
+
+        if brain is None:
+            brain = await storage.get_brain(storage.brain_id or "")
+        provider = _create_provider(
+            brain.config if brain else BrainConfig(), task_type="RETRIEVAL_DOCUMENT"
+        )
+        # Embed each DISTINCT text once and fan its vector out. Identical text
+        # must map to the identical vector anyway, and a GRAPH_ONLY pass hands
+        # this helper one placeholder string per neuron - without the dedup
+        # that is N copies of the same text in one provider payload.
+        texts = [updated[i].embedding_text() for i in targets]
+        unique_index: dict[str, int] = {}
+        unique_texts: list[str] = []
+        for text in texts:
+            if text not in unique_index:
+                unique_index[text] = len(unique_texts)
+                unique_texts.append(text)
+        embed = provider.embed_batch(unique_texts)
+        budget = _inline_embed_timeout()
+        vectors = await (asyncio.wait_for(embed, timeout=budget) if budget else embed)
+        # Check the count before assigning any of it. A provider that returns a
+        # short list would otherwise leave the tail neurons holding their OLD
+        # vectors with no error and no warning - a silent stale write, which is
+        # the exact failure this helper exists to remove.
+        if len(vectors) != len(unique_texts):
+            raise ValueError(
+                f"embedding provider returned {len(vectors)} vectors for {len(unique_texts)} texts"
+            )
+        for i, text in zip(targets, texts, strict=True):
+            metas[i]["_embedding"] = list(vectors[unique_index[text]])
+    except TimeoutError:
+        logger.warning(
+            "Content of %s changed but re-embedding exceeded its time budget - "
+            "the stored vectors still describe the old content; "
+            "run `smem reindex --all` to repair them.",
+            scope,
+        )
+    except Exception:
+        logger.warning(
+            "Content of %s changed but the embeddings could not be recomputed - "
+            "the stored vectors still describe the old content; "
+            "run `smem reindex --all` to repair them.",
+            scope,
+            exc_info=True,
+        )
+    return updated
+
+
+async def content_refreshed(
+    storage: NeuralStorage,
+    neuron: Neuron,
+    new_content: str,
+    *,
+    brain: Brain | None = None,
+) -> Neuron:
+    """Return *neuron* with its content replaced and the derived fields refreshed.
+
+    Single-neuron form of :func:`contents_refreshed` - see there for why the hash
+    is always recomputed and the vector only when one already exists.
+    """
+    return (await contents_refreshed(storage, [(neuron, new_content)], brain=brain))[0]

--- a/tests/unit/test_adaptive_instructions.py
+++ b/tests/unit/test_adaptive_instructions.py
@@ -12,15 +12,19 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from dataclasses import replace as dc_replace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from surreal_memory.core.brain import Brain
 from surreal_memory.engine.encoder import (
     _extract_trigger_patterns,
     _inject_instruction_metadata,
 )
 from surreal_memory.mcp.server import MCPServer
+from surreal_memory.storage.memory_store import InMemoryStorage
+from surreal_memory.utils.simhash import simhash
 
 # ──────────────────── Shared helpers ────────────────────
 
@@ -845,3 +849,121 @@ class TestBackwardCompatibility:
 
         assert "error" not in result
         assert result["status"] == "refined"
+
+
+# ──────────────────── smem_refine: content-derived field refresh ────────────────────
+
+
+async def _refine_test_store() -> InMemoryStorage:
+    """Real (non-mock) InMemoryStorage with a brain activated."""
+    store = InMemoryStorage()
+    brain = Brain.create(name="test-refine-refresh-brain")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+    return store
+
+
+async def _seeded_instruction(store: InMemoryStorage, content: str, vector: list[float]):
+    from surreal_memory.core.fiber import Fiber
+    from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
+    from surreal_memory.core.neuron import Neuron, NeuronType
+
+    anchor = Neuron.create(
+        type=NeuronType.CONCEPT, content=content, metadata={"_embedding": list(vector)}
+    )
+    anchor = dc_replace(anchor, content_hash=simhash(content))
+    await store.add_neuron(anchor)
+    fiber = Fiber.create(
+        neuron_ids={anchor.id},
+        synapse_ids=set(),
+        anchor_neuron_id=anchor.id,
+        fiber_id="fiber-instr-refresh",
+    )
+    await store.add_fiber(fiber)
+    typed_mem = TypedMemory.create(
+        fiber_id=fiber.id,
+        memory_type=MemoryType.INSTRUCTION,
+        priority=Priority.NORMAL,
+        source="test",
+    )
+    await store.add_typed_memory(typed_mem)
+    return anchor, fiber
+
+
+class TestRefineRefreshesDerivedFields:
+    """A content refine (``smem_refine``) must refresh content-derived fields.
+
+    ``_refine`` did ``dc_replace(anchor, content=new_content)`` straight into
+    ``update_neuron`` - re-saving the OLD ``content_hash`` and the OLD embedding
+    vector next to the NEW content, the same pattern #166 fixed for ``smem_edit``
+    but left standing on the instruction-refinement path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_refine_recomputes_content_hash_and_vector(self) -> None:
+        server = _make_server()
+        store = await _refine_test_store()
+        old_vec = [0.1, 0.2, 0.3]
+        orig = "always double-check totals before reporting them"
+        anchor, fiber = await _seeded_instruction(store, orig, old_vec)
+        server.get_storage = AsyncMock(return_value=store)
+
+        fresh_vec = [5.0, 5.0, 5.0]
+        provider = MagicMock()
+        provider.embed_batch = AsyncMock(return_value=[list(fresh_vec)])
+        new_content = "always double-check totals AND currency before reporting them"
+        with patch(
+            "surreal_memory.engine.semantic_discovery._create_provider", return_value=provider
+        ):
+            result = await server.call_tool(
+                "smem_refine", {"neuron_id": fiber.id, "new_content": new_content}
+            )
+
+        assert result["status"] == "refined"
+        saved = await store.get_neuron(anchor.id)
+        assert saved.content == new_content
+        assert saved.content_hash == simhash(new_content), (
+            "content_hash must be the fingerprint of the NEW content - keeping the old "
+            "one feeds near-duplicate detection the SimHash of text that no longer exists"
+        )
+        assert saved.metadata["_embedding"] == fresh_vec, (
+            "the vector saved with the new content must describe the new content - "
+            "re-saving the old one keeps the memory retrievable by what it used to say"
+        )
+        provider.embed_batch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_refine_survives_provider_unavailable_but_warns(self, caplog) -> None:
+        import logging
+
+        server = _make_server()
+        store = await _refine_test_store()
+        old_vec = [0.1, 0.2]
+        orig = "always double-check totals before reporting them"
+        anchor, fiber = await _seeded_instruction(store, orig, old_vec)
+        server.get_storage = AsyncMock(return_value=store)
+
+        with (
+            patch(
+                "surreal_memory.engine.semantic_discovery._create_provider",
+                side_effect=RuntimeError("no provider"),
+            ),
+            caplog.at_level(logging.WARNING, logger="surreal_memory.utils.content_refresh"),
+        ):
+            result = await server.call_tool(
+                "smem_refine", {"neuron_id": fiber.id, "new_content": "new content here"}
+            )
+
+        assert result["status"] == "refined", "refine must not depend on embedder availability"
+        saved = await store.get_neuron(anchor.id)
+        assert saved.content == "new content here"
+        assert saved.content_hash == simhash("new content here"), (
+            "content_hash has no provider dependency and must still be refreshed"
+        )
+        assert saved.metadata["_embedding"] == old_vec, (
+            "with no provider available the old vector must be kept, not dropped or guessed"
+        )
+        assert any("reindex" in r.message for r in caplog.records), (
+            "a stale vector left behind must be reported loudly, with the remediation "
+            "command - silence here is indistinguishable from a successful refresh"
+        )

--- a/tests/unit/test_compression.py
+++ b/tests/unit/test_compression.py
@@ -16,14 +16,17 @@ Covers:
 
 from __future__ import annotations
 
+from dataclasses import replace as dc_replace
 from datetime import timedelta
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
 
 from surreal_memory.core.brain import Brain
 from surreal_memory.core.fiber import Fiber
+from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.engine.compression import (
     CompressionConfig,
     CompressionEngine,
@@ -36,6 +39,7 @@ from surreal_memory.engine.compression import (
 )
 from surreal_memory.engine.consolidation import ConsolidationReport, ConsolidationStrategy
 from surreal_memory.storage.memory_store import InMemoryStorage
+from surreal_memory.utils.simhash import simhash
 from surreal_memory.utils.timeutils import utcnow
 
 # ---------------------------------------------------------------------------
@@ -718,3 +722,677 @@ class TestConsolidationIntegration:
         report.tokens_saved = 200
         assert report.fibers_compressed == 5
         assert report.tokens_saved == 200
+
+
+# ---------------------------------------------------------------------------
+# Content-derived field refresh on compress / decompress / recover
+# ---------------------------------------------------------------------------
+
+
+async def _refresh_test_store() -> InMemoryStorage:
+    """Real (non-mock) InMemoryStorage with a brain activated."""
+    store = InMemoryStorage()
+    brain = Brain.create(name="test-refresh-brain")
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+    return store
+
+
+def _seeded_neuron(content: str, vector: list[float]) -> Neuron:
+    neuron = Neuron.create(
+        type=NeuronType.CONCEPT, content=content, metadata={"_embedding": list(vector)}
+    )
+    return dc_replace(neuron, content_hash=simhash(content))
+
+
+class TestCompressionRefreshesDerivedFields:
+    """Compress, decompress, and recover must not leave derived fields stale.
+
+    Each path did ``dc_replace(neuron, content=new)`` and handed the result
+    straight to ``update_neuron`` - re-saving the OLD ``content_hash`` and the
+    OLD embedding vector next to the NEW content, the pattern #166 fixed for
+    ``smem_edit`` but left standing here.
+
+    The vector cannot simply be cleared: ``embedding_vec`` carries an HNSW index
+    with a fixed dimension, so writing an empty array is rejected outright
+    ("Incorrect vector dimension (0)") and takes the whole update with it. So
+    these paths re-embed, like the edit tool - but batched, one provider call per
+    compression step rather than one per neuron.
+    """
+
+    @staticmethod
+    def _assert_refreshed(saved: Neuron, expected_content: str, expected_vec: list[float]) -> None:
+        """The saved neuron must carry the new content's hash and its new vector."""
+        assert saved.content == expected_content
+        assert saved.content_hash == simhash(expected_content), (
+            "content_hash must describe the content actually stored - keeping the old "
+            "fingerprint feeds near-duplicate detection the SimHash of text that is gone"
+        )
+        assert saved.metadata["_embedding"] == expected_vec, (
+            "the vector stored with the new content must describe the new content - "
+            "re-saving the old one keeps the memory retrievable by what it used to say"
+        )
+
+    @pytest.mark.asyncio
+    async def test_compress_graph_only_refreshes_hash_and_vector(self) -> None:
+        store = await _refresh_test_store()
+        orig = "the office is closed on fridays for maintenance this quarter"
+        neuron = _seeded_neuron(orig, [0.1, 0.2, 0.3])
+        await store.add_neuron(neuron)
+        fiber = Fiber(
+            id="f-graph",
+            neuron_ids={neuron.id},
+            synapse_ids=set(),
+            anchor_neuron_id=neuron.id,
+            compression_tier=0,
+            created_at=utcnow() - timedelta(days=200.0),
+        )
+        await store.add_fiber(fiber)
+
+        fresh_vec = [9.0, 8.0, 7.0]
+        provider = MagicMock()
+        provider.embed_batch = AsyncMock(return_value=[list(fresh_vec)])
+        with patch(
+            "surreal_memory.engine.semantic_discovery._create_provider", return_value=provider
+        ):
+            engine = CompressionEngine(store)
+            await engine.compress_fiber(fiber, CompressionTier.GRAPH_ONLY)
+
+        saved = await store.get_neuron(neuron.id)
+        assert saved.content == "[graph-only]"
+        assert saved.content_hash == 0, (
+            "the placeholder is a tombstone, not content - it must carry the "
+            "no-fingerprint sentinel, not one constant SimHash shared by every "
+            "graph-only anchor"
+        )
+        assert saved.metadata["_embedding"] == fresh_vec
+
+    @pytest.mark.asyncio
+    async def test_compress_extractive_refreshes_hash_and_vector(self) -> None:
+        store = await _refresh_test_store()
+        orig = (
+            "Widget shipments doubled in March. The warehouse team hired five new staff. "
+            "Revenue from the north region grew by twelve percent this quarter."
+        )
+        neuron = _seeded_neuron(orig, [0.1, 0.2, 0.3])
+        await store.add_neuron(neuron)
+        fiber = Fiber(
+            id="f-extractive",
+            neuron_ids={neuron.id},
+            synapse_ids=set(),
+            anchor_neuron_id=neuron.id,
+            compression_tier=0,
+            created_at=utcnow() - timedelta(days=15.0),
+        )
+        await store.add_fiber(fiber)
+
+        fresh_vec = [1.0, 1.0, 1.0]
+        provider = MagicMock()
+        provider.embed_batch = AsyncMock(return_value=[list(fresh_vec)])
+        with patch(
+            "surreal_memory.engine.semantic_discovery._create_provider", return_value=provider
+        ):
+            engine = CompressionEngine(store)
+            result = await engine.compress_fiber(fiber, CompressionTier.EXTRACTIVE)
+
+        saved = await store.get_neuron(neuron.id)
+        assert saved.content != orig, "the tier must actually have compressed the content"
+        assert result.compressed_token_count < result.original_token_count
+        self._assert_refreshed(saved, saved.content, fresh_vec)
+
+    @pytest.mark.asyncio
+    async def test_decompress_refreshes_hash_and_vector(self) -> None:
+        store = await _refresh_test_store()
+        orig = "the meeting moved to thursday at ten"
+        neuron = _seeded_neuron(orig, [0.1, 0.2, 0.3])
+        await store.add_neuron(neuron)
+        fiber = Fiber(
+            id="f-decompress",
+            neuron_ids={neuron.id},
+            synapse_ids=set(),
+            anchor_neuron_id=neuron.id,
+            compression_tier=1,
+            created_at=utcnow(),
+        )
+        await store.add_fiber(fiber)
+        await store.save_compression_backup(
+            fiber_id=fiber.id,
+            original_content=orig,
+            compression_tier=1,
+            original_token_count=10,
+            compressed_token_count=5,
+        )
+        # Seed realistic drift: the neuron currently sits compressed, and its
+        # derived fields were refreshed AGAINST THE COMPRESSED TEXT in the interim
+        # (a reindex ran while the fiber was compressed). Without this the hash
+        # would already equal simhash(orig) by coincidence - the field was never
+        # touched since creation - and the assertion would pass on unfixed code.
+        compressed = dc_replace(
+            neuron,
+            content="the meeting moved",
+            content_hash=simhash("the meeting moved"),
+            metadata={"_embedding": [4.0, 5.0, 6.0]},
+        )
+        await store.update_neuron(compressed)
+
+        fresh_vec = [2.0, 2.0, 2.0]
+        provider = MagicMock()
+        provider.embed_batch = AsyncMock(return_value=[list(fresh_vec)])
+        with patch(
+            "surreal_memory.engine.semantic_discovery._create_provider", return_value=provider
+        ):
+            engine = CompressionEngine(store)
+            ok = await engine.decompress_fiber(fiber.id)
+
+        assert ok is True
+        saved = await store.get_neuron(neuron.id)
+        self._assert_refreshed(saved, orig, fresh_vec)
+
+    @pytest.mark.asyncio
+    async def test_recover_refreshes_hash_and_vector(self) -> None:
+        store = await _refresh_test_store()
+        orig = "quarterly numbers are final and archived"
+        neuron = _seeded_neuron(orig, [0.1, 0.2, 0.3])
+        await store.add_neuron(neuron)
+        fiber = Fiber(
+            id="f-recover",
+            neuron_ids={neuron.id},
+            synapse_ids=set(),
+            anchor_neuron_id=neuron.id,
+            compression_tier=int(CompressionTier.GRAPH_ONLY),
+            created_at=utcnow(),
+        )
+        await store.add_fiber(fiber)
+        await store.save_neuron_snapshot(
+            neuron_id=neuron.id,
+            brain_id=store.current_brain_id or "",
+            original_content=orig,
+            compressed_at=utcnow().isoformat(),
+            tier=int(CompressionTier.GRAPH_ONLY),
+        )
+        # Same seeding rationale as the decompress test: the neuron is mid
+        # GRAPH_ONLY, carrying the placeholder's hash and a vector from that phase.
+        graph_only = dc_replace(
+            neuron,
+            content="[graph-only]",
+            content_hash=simhash("[graph-only]"),
+            metadata={"_embedding": [7.0, 8.0, 9.0]},
+        )
+        await store.update_neuron(graph_only)
+
+        fresh_vec = [3.0, 3.0, 3.0]
+        provider = MagicMock()
+        provider.embed_batch = AsyncMock(return_value=[list(fresh_vec)])
+        with patch(
+            "surreal_memory.engine.semantic_discovery._create_provider", return_value=provider
+        ):
+            engine = CompressionEngine(store)
+            ok = await engine.recover_fiber(fiber.id)
+
+        assert ok is True
+        saved = await store.get_neuron(neuron.id)
+        self._assert_refreshed(saved, orig, fresh_vec)
+
+    @pytest.mark.asyncio
+    async def test_multi_neuron_compression_embeds_once_per_distinct_text(self) -> None:
+        """A fiber's neurons must cost ONE provider round-trip - and a GRAPH_ONLY
+        fiber only ONE embedding, since every neuron ends up with the same text.
+
+        Compression runs unattended over every neuron of a fiber, under a time
+        budget, in a path that already counts database round-trips as its
+        dominant cost - so embedding per neuron is the thing to prevent, and
+        sending N copies of the identical placeholder in the one batch is the
+        residual waste after that. Identical text must map to the identical
+        vector anyway, so each distinct text is embedded once and fanned out.
+        (Text-to-neuron pairing for DISTINCT texts is pinned by the echo-provider
+        recovery test.)
+        """
+        store = await _refresh_test_store()
+        neurons = [
+            _seeded_neuron(f"sentence number {i} about widgets", [0.1, 0.2]) for i in range(3)
+        ]
+        for n in neurons:
+            await store.add_neuron(n)
+        fiber = Fiber(
+            id="f-batched",
+            neuron_ids={n.id for n in neurons},
+            synapse_ids=set(),
+            anchor_neuron_id=neurons[0].id,
+            compression_tier=0,
+            created_at=utcnow() - timedelta(days=200.0),
+        )
+        await store.add_fiber(fiber)
+
+        fresh_vec = [5.0, 5.0]
+        provider = MagicMock()
+        provider.embed_batch = AsyncMock(return_value=[list(fresh_vec)])
+        create_provider = MagicMock(return_value=provider)
+        with patch("surreal_memory.engine.semantic_discovery._create_provider", create_provider):
+            engine = CompressionEngine(store)
+            await engine.compress_fiber(fiber, CompressionTier.GRAPH_ONLY)
+
+        assert create_provider.call_count == 1, (
+            f"the provider must be resolved once per compression step, not per neuron "
+            f"(got {create_provider.call_count} for {len(neurons)} neurons)"
+        )
+        provider.embed_batch.assert_awaited_once()
+        assert provider.embed_batch.await_args.args[0] == ["[graph-only]"], (
+            "three tombstoned neurons share one text - the batch must carry it once"
+        )
+        for n in neurons:
+            saved = await store.get_neuron(n.id)
+            assert saved.metadata["_embedding"] == fresh_vec, (
+                "every neuron sharing the text must receive the vector embedded for it"
+            )
+
+    @pytest.mark.asyncio
+    async def test_compress_leaves_a_vectorless_neuron_alone(self) -> None:
+        """No vector means nothing to go stale - and no reason to reach a provider."""
+        store = await _refresh_test_store()
+        orig = "a plain note with no embedding at all"
+        neuron = Neuron.create(type=NeuronType.CONCEPT, content=orig)
+        neuron = dc_replace(neuron, content_hash=simhash(orig))
+        await store.add_neuron(neuron)
+        fiber = Fiber(
+            id="f-no-vector",
+            neuron_ids={neuron.id},
+            synapse_ids=set(),
+            anchor_neuron_id=neuron.id,
+            compression_tier=0,
+            created_at=utcnow() - timedelta(days=200.0),
+        )
+        await store.add_fiber(fiber)
+
+        create_provider = MagicMock()
+        with patch("surreal_memory.engine.semantic_discovery._create_provider", create_provider):
+            engine = CompressionEngine(store)
+            await engine.compress_fiber(fiber, CompressionTier.GRAPH_ONLY)
+
+        saved = await store.get_neuron(neuron.id)
+        assert saved.content == "[graph-only]"
+        assert saved.content_hash == 0
+        assert "_embedding" not in saved.metadata
+        # An install with no vectors to refresh must not reach for an embedder.
+        create_provider.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_batched_recover_pairs_each_neuron_with_its_own_text_vector(self) -> None:
+        """Every neuron must receive the vector of ITS OWN restored text.
+
+        The batch helper embeds a list and assigns positionally, so the failure
+        to guard against is a swapped assignment - distinct vectors alone would
+        not catch it. The provider here derives each vector from the text it was
+        given, making any misalignment visible as the wrong vector on a neuron.
+        """
+        store = await _refresh_test_store()
+        texts = {
+            "n-alpha": "alpha original text",
+            "n-beta": "beta original text is deliberately longer",
+            "n-gamma": "gamma",
+        }
+        neurons = []
+        for nid in texts:
+            neuron = Neuron.create(
+                type=NeuronType.CONCEPT,
+                content="[graph-only]",
+                neuron_id=nid,
+                metadata={"_embedding": [0.1, 0.1]},
+            )
+            neuron = dc_replace(neuron, content_hash=0)
+            await store.add_neuron(neuron)
+            neurons.append(neuron)
+        fiber = Fiber(
+            id="f-pairing",
+            neuron_ids=set(texts),
+            synapse_ids=set(),
+            anchor_neuron_id="n-alpha",
+            compression_tier=int(CompressionTier.GRAPH_ONLY),
+            created_at=utcnow(),
+        )
+        await store.add_fiber(fiber)
+        for nid, orig in texts.items():
+            await store.save_neuron_snapshot(
+                neuron_id=nid,
+                brain_id=store.current_brain_id or "",
+                original_content=orig,
+                compressed_at=utcnow().isoformat(),
+                tier=int(CompressionTier.GRAPH_ONLY),
+            )
+
+        provider = MagicMock()
+        # Echo provider: the vector encodes the text it was derived from.
+        provider.embed_batch = AsyncMock(
+            side_effect=lambda batch: [[float(len(t)), 1.0] for t in batch]
+        )
+        with patch(
+            "surreal_memory.engine.semantic_discovery._create_provider", return_value=provider
+        ):
+            ok = await CompressionEngine(store).recover_fiber(fiber.id)
+
+        assert ok is True
+        for nid, orig in texts.items():
+            saved = await store.get_neuron(nid)
+            assert saved.content == orig
+            assert saved.metadata["_embedding"] == [float(len(orig)), 1.0], (
+                f"neuron {nid} must carry the vector derived from its own text - "
+                "anything else means the batch assignment is misaligned"
+            )
+
+    @pytest.mark.asyncio
+    async def test_recompression_stamps_the_sentinel_on_legacy_tombstones(self) -> None:
+        """When a legacy tombstone DOES meet the compression path, it gets the sentinel.
+
+        Tombstones written by older versions carry the SimHash of their deleted
+        original text. A fiber parked at GRAPH_ONLY never re-enters compression
+        (their protection is the census's content guard, not this path), but a
+        PARTIALLY recovered fiber does: ``recover_fiber`` resets it to FULL while
+        neurons without a snapshot keep the placeholder - the tier-0 fiber here
+        models exactly that shape. Re-compression must normalise the stale hash
+        to the sentinel, and must not spend a provider call doing it.
+        """
+        store = await _refresh_test_store()
+        legacy = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="[graph-only]",
+            metadata={"_embedding": [0.3, 0.4]},
+        )
+        legacy = dc_replace(legacy, content_hash=simhash("the deleted original text"))
+        await store.add_neuron(legacy)
+        fiber = Fiber(
+            id="f-legacy",
+            neuron_ids={legacy.id},
+            synapse_ids=set(),
+            anchor_neuron_id=legacy.id,
+            compression_tier=0,
+            created_at=utcnow() - timedelta(days=200.0),
+        )
+        await store.add_fiber(fiber)
+
+        create_provider = MagicMock()
+        with patch("surreal_memory.engine.semantic_discovery._create_provider", create_provider):
+            await CompressionEngine(store).compress_fiber(fiber, CompressionTier.GRAPH_ONLY)
+
+        create_provider.assert_not_called()
+        saved = await store.get_neuron(legacy.id)
+        assert saved.content == "[graph-only]"
+        assert saved.content_hash == 0, (
+            "a legacy tombstone must not keep the fingerprint of its deleted text"
+        )
+        assert saved.metadata["_embedding"] == [0.3, 0.4], (
+            "stamping the sentinel must not touch the vector - no re-embed on a repeat pass"
+        )
+
+    @pytest.mark.asyncio
+    async def test_graph_only_anchors_are_not_paired_as_near_duplicates(self) -> None:
+        """Two unrelated fibers compressed to GRAPH_ONLY must not look like duplicates.
+
+        Every graph-only neuron ends up with the same placeholder text, so a
+        SimHash of it would be one constant shared brain-wide. The consolidation
+        census compares anchors by Hamming distance, so identical fingerprints
+        would read as distance 0 and persist a false "duplicate of" edge between
+        memories that have nothing to do with each other.
+        """
+        from surreal_memory.utils.simhash import is_near_duplicate
+
+        store = await _refresh_test_store()
+        saved = []
+        for idx, text in enumerate(
+            ["the north warehouse lease renewal terms", "a totally unrelated travel itinerary"]
+        ):
+            neuron = _seeded_neuron(text, [0.1, 0.2])
+            await store.add_neuron(neuron)
+            fiber = Fiber(
+                id=f"f-dup-{idx}",
+                neuron_ids={neuron.id},
+                synapse_ids=set(),
+                anchor_neuron_id=neuron.id,
+                compression_tier=0,
+                created_at=utcnow() - timedelta(days=200.0),
+            )
+            await store.add_fiber(fiber)
+            provider = MagicMock()
+            provider.embed_batch = AsyncMock(return_value=[[1.0, 1.0]])
+            with patch(
+                "surreal_memory.engine.semantic_discovery._create_provider", return_value=provider
+            ):
+                await CompressionEngine(store).compress_fiber(fiber, CompressionTier.GRAPH_ONLY)
+            saved.append(await store.get_neuron(neuron.id))
+
+        a, b = saved
+        assert a.content_hash == 0 and b.content_hash == 0, (
+            "placeholder content must carry the no-fingerprint sentinel that the "
+            "census and the dedup pipeline both skip"
+        )
+        assert not is_near_duplicate(simhash("unrelated one"), 0), (
+            "sanity: the sentinel must not be treated as a comparable fingerprint"
+        )
+
+    @pytest.mark.asyncio
+    async def test_recompression_after_partial_recovery_does_not_re_embed_the_placeholder(
+        self,
+    ) -> None:
+        """A re-entered GRAPH_ONLY pass must not pay for neurons already cleared.
+
+        A fiber sitting at GRAPH_ONLY never re-enters compression (the tier
+        early-return), so the realistic way already-tombstoned neurons meet
+        this branch again is a PARTIAL recovery: ``recover_fiber`` resets the
+        fiber to FULL when it restores at least one neuron, while neurons that
+        had no snapshot keep the placeholder. When the fiber later ages back
+        into GRAPH_ONLY, those neurons are already correct - re-deriving their
+        fields would spend a provider call on a known result.
+        """
+        store = await _refresh_test_store()
+        neuron = _seeded_neuron("something that will be compressed away", [0.1, 0.2])
+        await store.add_neuron(neuron)
+        fiber = Fiber(
+            id="f-repeat",
+            neuron_ids={neuron.id},
+            synapse_ids=set(),
+            anchor_neuron_id=neuron.id,
+            compression_tier=0,
+            created_at=utcnow() - timedelta(days=200.0),
+        )
+        await store.add_fiber(fiber)
+
+        provider = MagicMock()
+        provider.embed_batch = AsyncMock(return_value=[[2.0, 2.0]])
+        with patch(
+            "surreal_memory.engine.semantic_discovery._create_provider", return_value=provider
+        ):
+            await CompressionEngine(store).compress_fiber(fiber, CompressionTier.GRAPH_ONLY)
+
+        # The partial-recovery shape: fiber back at FULL, neuron still a
+        # tombstone. (recover_fiber resets the tier whenever it restores any
+        # neuron; this one had no snapshot, so its placeholder survived.)
+        recovered_fiber = dc_replace(fiber, compression_tier=int(CompressionTier.FULL))
+        await store.update_fiber(recovered_fiber)
+
+        second = MagicMock()
+        with patch("surreal_memory.engine.semantic_discovery._create_provider", second):
+            result = await CompressionEngine(store).compress_fiber(
+                recovered_fiber, CompressionTier.GRAPH_ONLY
+            )
+
+        assert result.skipped is False, (
+            "the pass must actually run - an early-returned pass proves nothing "
+            "about what a re-entered one would cost"
+        )
+        second.assert_not_called()
+        saved = await store.get_neuron(neuron.id)
+        assert saved.content == "[graph-only]"
+        assert saved.content_hash == 0
+
+    @pytest.mark.asyncio
+    async def test_only_the_vectored_neuron_is_embedded_and_gets_its_own_vector(self) -> None:
+        """A fiber may mix neurons with and without vectors - each must be handled."""
+        store = await _refresh_test_store()
+        plain_a = Neuron.create(type=NeuronType.CONCEPT, content="first plain note")
+        vectored = _seeded_neuron("the middle note that carries a vector", [0.1, 0.2])
+        plain_b = Neuron.create(type=NeuronType.CONCEPT, content="third plain note")
+        for n in (plain_a, vectored, plain_b):
+            await store.add_neuron(n)
+        fiber = Fiber(
+            id="f-mixed",
+            neuron_ids={plain_a.id, vectored.id, plain_b.id},
+            synapse_ids=set(),
+            anchor_neuron_id=vectored.id,
+            compression_tier=0,
+            created_at=utcnow() - timedelta(days=200.0),
+        )
+        await store.add_fiber(fiber)
+
+        fresh_vec = [4.0, 4.0]
+        provider = MagicMock()
+        provider.embed_batch = AsyncMock(return_value=[list(fresh_vec)])
+        with patch(
+            "surreal_memory.engine.semantic_discovery._create_provider", return_value=provider
+        ):
+            engine = CompressionEngine(store)
+            await engine.compress_fiber(fiber, CompressionTier.GRAPH_ONLY)
+
+        assert len(provider.embed_batch.await_args.args[0]) == 1, (
+            "only the neuron that actually carries a vector belongs in the batch"
+        )
+        assert (await store.get_neuron(vectored.id)).metadata["_embedding"] == fresh_vec
+        for plain in (plain_a, plain_b):
+            saved = await store.get_neuron(plain.id)
+            assert saved.content == "[graph-only]"
+            assert saved.content_hash == 0
+            assert "_embedding" not in saved.metadata
+
+    @pytest.mark.asyncio
+    async def test_short_provider_output_warns_instead_of_silently_keeping_old_vectors(
+        self, caplog
+    ) -> None:
+        """A provider returning fewer vectors than texts must not pass silently.
+
+        Assigning positionally over a short list would leave the tail neurons
+        holding their OLD vectors with no error and no warning - a silent stale
+        write, which is the failure this whole change exists to remove.
+        """
+        import logging
+
+        store = await _refresh_test_store()
+        old_vec = [0.1, 0.2]
+        neurons = [_seeded_neuron(f"note number {i} with content", old_vec) for i in range(3)]
+        for n in neurons:
+            await store.add_neuron(n)
+        fiber = Fiber(
+            id="f-short-output",
+            neuron_ids={n.id for n in neurons},
+            synapse_ids=set(),
+            anchor_neuron_id=neurons[0].id,
+            compression_tier=0,
+            created_at=utcnow() - timedelta(days=200.0),
+        )
+        await store.add_fiber(fiber)
+
+        provider = MagicMock()
+        provider.embed_batch = AsyncMock(return_value=[[9.0, 9.0], [8.0, 8.0]])  # 2 for 3 texts
+        with (
+            patch(
+                "surreal_memory.engine.semantic_discovery._create_provider", return_value=provider
+            ),
+            caplog.at_level(logging.WARNING, logger="surreal_memory.utils.content_refresh"),
+        ):
+            engine = CompressionEngine(store)
+            await engine.compress_fiber(fiber, CompressionTier.GRAPH_ONLY)
+
+        assert any("reindex" in r.message for r in caplog.records), (
+            "a truncated provider response must be reported, not absorbed"
+        )
+        for n in neurons:
+            assert (await store.get_neuron(n.id)).metadata["_embedding"] == old_vec, (
+                "on a count mismatch no vector may be assigned - a partial write would "
+                "leave some neurons silently stale and indistinguishable from success"
+            )
+
+    @pytest.mark.asyncio
+    async def test_compress_warns_when_re_embedding_exceeds_its_time_budget(self, caplog) -> None:
+        """The bounded-wait branch must report, not swallow."""
+        import asyncio
+        import logging
+
+        store = await _refresh_test_store()
+        old_vec = [0.1, 0.2]
+        neuron = _seeded_neuron("a note whose re-embed will outlast the budget", old_vec)
+        await store.add_neuron(neuron)
+        fiber = Fiber(
+            id="f-timeout",
+            neuron_ids={neuron.id},
+            synapse_ids=set(),
+            anchor_neuron_id=neuron.id,
+            compression_tier=0,
+            created_at=utcnow() - timedelta(days=200.0),
+        )
+        await store.add_fiber(fiber)
+
+        async def _too_slow(_texts: list[str]) -> list[list[float]]:
+            await asyncio.sleep(5)
+            return [[1.0, 1.0]]
+
+        provider = MagicMock()
+        provider.embed_batch = _too_slow
+        with (
+            patch(
+                "surreal_memory.engine.semantic_discovery._create_provider", return_value=provider
+            ),
+            patch("surreal_memory.engine.encoder._inline_embed_timeout", return_value=0.01),
+            caplog.at_level(logging.WARNING, logger="surreal_memory.utils.content_refresh"),
+        ):
+            engine = CompressionEngine(store)
+            await engine.compress_fiber(fiber, CompressionTier.GRAPH_ONLY)
+
+        saved = await store.get_neuron(neuron.id)
+        assert saved.content == "[graph-only]", "a slow embedder must not block the compression"
+        assert saved.content_hash == 0
+        assert saved.metadata["_embedding"] == old_vec
+        assert any("time budget" in r.message for r in caplog.records), (
+            "exceeding the embed budget must be named as such, not folded into a generic failure"
+        )
+
+    @pytest.mark.asyncio
+    async def test_compress_survives_provider_unavailable_but_warns(self, caplog) -> None:
+        import logging
+
+        store = await _refresh_test_store()
+        old_vec = [0.1, 0.2, 0.3]
+        orig = (
+            "Widget shipments doubled in March. The warehouse team hired five new staff. "
+            "Revenue from the north region grew by twelve percent this quarter."
+        )
+        neuron = _seeded_neuron(orig, old_vec)
+        await store.add_neuron(neuron)
+        fiber = Fiber(
+            id="f-provider-down",
+            neuron_ids={neuron.id},
+            synapse_ids=set(),
+            anchor_neuron_id=neuron.id,
+            compression_tier=0,
+            created_at=utcnow() - timedelta(days=15.0),
+        )
+        await store.add_fiber(fiber)
+
+        with (
+            patch(
+                "surreal_memory.engine.semantic_discovery._create_provider",
+                side_effect=RuntimeError("no provider"),
+            ),
+            caplog.at_level(logging.WARNING, logger="surreal_memory.utils.content_refresh"),
+        ):
+            engine = CompressionEngine(store)
+            await engine.compress_fiber(fiber, CompressionTier.EXTRACTIVE)
+
+        saved = await store.get_neuron(neuron.id)
+        assert saved.content != orig, "compression must not depend on embedder availability"
+        assert saved.content_hash == simhash(saved.content), (
+            "content_hash has no provider dependency and must still be refreshed"
+        )
+        assert saved.metadata["_embedding"] == old_vec, (
+            "with no provider available the old vector must be kept, not dropped or guessed - "
+            "an empty vector is rejected outright by the HNSW index on embedding_vec"
+        )
+        assert any("reindex" in r.message for r in caplog.records), (
+            "a stale vector left behind must be reported loudly, with the remediation "
+            "command - silence here is indistinguishable from a successful refresh"
+        )

--- a/tests/unit/test_dedup_alias_edges.py
+++ b/tests/unit/test_dedup_alias_edges.py
@@ -420,6 +420,51 @@ class FakeEncodeStorage(FakeStorage):
 
 class TestConsolidationDedupCallSite:
     @pytest.mark.asyncio
+    async def test_legacy_stale_hash_tombstone_is_never_aliased(self) -> None:
+        # A tombstone written before the sentinel existed carries the SimHash
+        # of its DELETED original text. A genuine memory whose content
+        # near-duplicates that deleted text would hash within threshold - and
+        # without a content guard the census would persist an ALIAS edge from a
+        # real memory to a tombstone, "deduplicating" it against content that
+        # no longer exists. Fibers already at GRAPH_ONLY never re-enter the
+        # compression path, so no stamping can repair these rows: the census
+        # itself must refuse to fingerprint a placeholder.
+        from surreal_memory.utils.simhash import simhash
+
+        deleted_text = "deployment notes for the old cluster"
+        legacy = _anchor("[graph-only]", content_hash=simhash(deleted_text))
+        genuine = _anchor(deleted_text, content_hash=simhash(deleted_text))
+        storage = FakeAnchorStorage([legacy, genuine])
+        engine = ConsolidationEngine(storage)
+
+        report = ConsolidationReport()
+        await engine._dedup(report, dry_run=False)
+
+        assert [s for s in storage.synapses if s.type is SynapseType.ALIAS] == [], (
+            "a genuine memory must never be aliased to a tombstone - the "
+            "tombstone's fingerprint describes text that was deleted"
+        )
+        assert report.duplicates_found == 0
+
+    @pytest.mark.asyncio
+    async def test_graph_only_tombstone_anchors_are_never_aliased(self) -> None:
+        # GRAPH_ONLY compression writes the placeholder with the no-fingerprint
+        # sentinel (content_hash = 0) precisely so this census cannot pair two
+        # unrelated tombstones - hamming(h, h) is 0 for any shared constant, so
+        # without the sentinel skip every tombstone pair would read as an exact
+        # duplicate and persist a false ALIAS edge. Pin that skip.
+        a = _anchor("[graph-only]", content_hash=0)
+        b = _anchor("[graph-only]", content_hash=0)
+        storage = FakeAnchorStorage([a, b])
+        engine = ConsolidationEngine(storage)
+
+        report = ConsolidationReport()
+        await engine._dedup(report, dry_run=False)
+
+        assert [s for s in storage.synapses if s.type is SynapseType.ALIAS] == []
+        assert report.duplicates_found == 0
+
+    @pytest.mark.asyncio
     async def test_repeated_runs_leave_one_row_per_pair(self) -> None:
         # The production shape exactly: consolidation re-derives the same
         # duplicate pair on every run. Three runs, one row.

--- a/tests/unit/test_dedup_pipeline.py
+++ b/tests/unit/test_dedup_pipeline.py
@@ -58,6 +58,39 @@ class TestTier1SimHash:
         assert result.similarity_score > 0.8
 
     @pytest.mark.asyncio
+    async def test_legacy_tombstone_never_canonicalises_a_new_save(self) -> None:
+        """A new memory must not be deduplicated onto a GRAPH_ONLY tombstone.
+
+        A tombstone written before the hash sentinel existed carries the
+        SimHash of its DELETED original text. A new save whose content
+        near-duplicates that deleted text lands within threshold - and the
+        pipeline would make the tombstone the canonical anchor, so the new
+        fiber anchors to "[graph-only]" and the new text survives only as an
+        alias neuron. Candidate search genuinely reaches tombstones (the FTS
+        analyzer tokenises the placeholder into "graph"/"only"), so the
+        candidate filter itself must refuse them, ahead of every tier.
+        """
+        deleted_text = "Only use the staging cluster for load tests"
+        legacy = Neuron(
+            id="tombstone-1",
+            type=NeuronType.CONCEPT,
+            content="[graph-only]",
+            metadata={"is_anchor": True},
+            content_hash=simhash(deleted_text),
+        )
+        cfg = DedupConfig(enabled=True, simhash_threshold=10)
+        storage = _make_storage([legacy])
+
+        pipeline = DedupPipeline(config=cfg, storage=storage)
+        result = await pipeline.check_duplicate("Only use the staging cluster for load testing")
+
+        assert result.is_duplicate is False, (
+            "the tombstone's fingerprint describes deleted text - treating the new "
+            "memory as its duplicate buries the new content under a placeholder anchor"
+        )
+        assert result.existing_neuron_id != "tombstone-1"
+
+    @pytest.mark.asyncio
     async def test_near_duplicate_detected(self) -> None:
         original = "We decided to use PostgreSQL for the database"
         similar = "We decided to use PostgreSQL for the databases"

--- a/tests/unit/test_edit_forget.py
+++ b/tests/unit/test_edit_forget.py
@@ -358,7 +358,7 @@ class TestEditRefreshesDerivedFields:
                 "surreal_memory.engine.semantic_discovery._create_provider",
                 side_effect=RuntimeError("no provider"),
             ),
-            caplog.at_level(logging.WARNING, logger="surreal_memory.mcp.lifecycle_handler"),
+            caplog.at_level(logging.WARNING, logger="surreal_memory.utils.content_refresh"),
         ):
             result = await server.call_tool(
                 "smem_edit", {"memory_id": neuron.id, "content": "new content"}

--- a/tests/unit/test_interference.py
+++ b/tests/unit/test_interference.py
@@ -57,6 +57,45 @@ class TestDetectInterference:
         assert results == []
 
     @pytest.mark.asyncio
+    async def test_graph_only_tombstones_never_interfere(self) -> None:
+        """A tombstone's sentinel hash must not be recomputed around.
+
+        GRAPH_ONLY tombstones carry content_hash 0 precisely so hash consumers
+        skip them; the recompute fallback would resurrect the shared constant
+        simhash of the placeholder, and any new memory whose fingerprint lands
+        in the interference window would then CONTRADICTS-link to every
+        tag-overlapping tombstone in the brain at once.
+        """
+        from dataclasses import replace
+
+        from surreal_memory.utils.simhash import hamming_distance, simhash
+
+        config = MagicMock()
+        config.interference_detection_enabled = True
+        config.fan_effect_threshold = 15
+
+        # Precondition, asserted so the test cannot rot silently: this content's
+        # fingerprint sits inside the 8..18 interference window relative to the
+        # placeholder's - i.e. WITHOUT the skip it would register interference.
+        content = "graph-only compression tier notes"
+        dist = hamming_distance(simhash(content), simhash("[graph-only]"))
+        assert 8 <= dist <= 18, f"precondition drifted: distance {dist} not in window"
+
+        new_neuron = _make_neuron(content, ["memory"])
+        tombstone = _make_neuron("[graph-only]", ["memory"], created_offset_hours=24)
+        tombstone = replace(tombstone, content_hash=0)
+
+        storage = AsyncMock()
+        storage.find_neurons = AsyncMock(return_value=[tombstone])
+
+        results = await detect_interference(new_neuron, storage, config)
+        non_fan = [r for r in results if r.interference_type != InterferenceType.FAN_EFFECT]
+        assert non_fan == [], (
+            "a tombstone has no fingerprint to interfere with - recomputing one "
+            "from the placeholder pairs the new memory with every tombstone at once"
+        )
+
+    @pytest.mark.asyncio
     async def test_similar_retroactive(self) -> None:
         config = MagicMock()
         config.interference_detection_enabled = True

--- a/tests/unit/test_lazy_entity.py
+++ b/tests/unit/test_lazy_entity.py
@@ -273,3 +273,35 @@ def test_brain_config_lazy_entity_defaults():
     assert config.lazy_entity_enabled is True
     assert config.lazy_entity_promotion_threshold == 2
     assert config.lazy_entity_prune_days == 90
+
+
+# ── Entity reuse must never bind to a GRAPH_ONLY tombstone ──
+
+
+async def test_similar_entity_lookup_skips_legacy_tombstones():
+    """A tombstone with a stale hash must not become an entity's neuron.
+
+    Tombstones written before the hash sentinel carry the SimHash of their
+    DELETED text. The near-duplicate fallback in entity reuse would match a
+    new entity against that fingerprint and bind the entity reference to a
+    "[graph-only]" placeholder - a persisted wrong link. Same guard as the
+    census and the dedup pipeline.
+    """
+    from surreal_memory.engine.pipeline_steps import _find_similar_entity
+    from surreal_memory.utils.simhash import simhash
+
+    entity_text = "Staging Cluster"
+    tombstone = Neuron.create(type=NeuronType.CONCEPT, content="[graph-only]")
+    from dataclasses import replace as dc_replace
+
+    tombstone = dc_replace(tombstone, content_hash=simhash(entity_text))
+
+    storage = AsyncMock()
+    # Exact and normalised lookups miss; the hash fallback sees the tombstone.
+    storage.find_neurons = AsyncMock(side_effect=[[], [], [tombstone]])
+
+    result = await _find_similar_entity(storage, entity_text)
+    assert result is None, (
+        "the tombstone's fingerprint describes deleted text - binding a live "
+        "entity reference to a placeholder neuron is a persisted wrong link"
+    )

--- a/tests/unit/test_mcp_edit_and_transplant.py
+++ b/tests/unit/test_mcp_edit_and_transplant.py
@@ -39,11 +39,11 @@ class TestEditRefreshesStructure:
     def test_content_refresh_recomputes_structure(self) -> None:
         source = inspect.getsource(
             __import__(
-                "surreal_memory.mcp.lifecycle_handler", fromlist=["_content_refreshed"]
-            )._content_refreshed
+                "surreal_memory.utils.content_refresh", fromlist=["contents_refreshed"]
+            ).contents_refreshed
         )
         assert "detect_structure" in source, (
-            "_content_refreshed updates content_hash and the embedding but not "
+            "contents_refreshed updates content_hash and the embedding but not "
             "metadata['_structure'], which recall reads back — an edited memory "
             "keeps answering with fields the new text no longer has"
         )
@@ -55,8 +55,8 @@ class TestEditRefreshesStructure:
         when the new content has none — the worst case, because recall would
         surface fields that no longer exist anywhere.
         """
-        source = (SRC_ROOT / "mcp" / "lifecycle_handler.py").read_text(encoding="utf-8")
-        func = _function(source, "_content_refreshed")
+        source = (SRC_ROOT / "utils" / "content_refresh.py").read_text(encoding="utf-8")
+        func = _function(source, "contents_refreshed")
         pops = [
             n
             for n in ast.walk(func)
@@ -104,8 +104,8 @@ class TestEditStructureBehaviour:
 
     async def test_editing_into_new_structure_replaces_the_old_fields(self) -> None:
         from surreal_memory.core.neuron import Neuron, NeuronType
-        from surreal_memory.mcp.lifecycle_handler import _content_refreshed
         from surreal_memory.storage.memory_store import InMemoryStorage
+        from surreal_memory.utils.content_refresh import content_refreshed
 
         neuron = Neuron.create(
             type=NeuronType.CONCEPT,
@@ -113,7 +113,7 @@ class TestEditStructureBehaviour:
             metadata={"_structure": {"format": "yaml", "fields": [{"name": "name"}]}},
         )
 
-        updated = await _content_refreshed(
+        updated = await content_refreshed(
             InMemoryStorage(), neuron, "name: new\nrole: reviewer\nteam: platform"
         )
 
@@ -123,8 +123,8 @@ class TestEditStructureBehaviour:
     async def test_editing_structure_away_drops_it_entirely(self) -> None:
         """Recall reads _structure back; a leftover would surface dead fields."""
         from surreal_memory.core.neuron import Neuron, NeuronType
-        from surreal_memory.mcp.lifecycle_handler import _content_refreshed
         from surreal_memory.storage.memory_store import InMemoryStorage
+        from surreal_memory.utils.content_refresh import content_refreshed
 
         neuron = Neuron.create(
             type=NeuronType.CONCEPT,
@@ -132,7 +132,7 @@ class TestEditStructureBehaviour:
             metadata={"_structure": {"format": "yaml", "fields": [{"name": "name"}]}},
         )
 
-        updated = await _content_refreshed(
+        updated = await content_refreshed(
             InMemoryStorage(), neuron, "just some prose with no fields at all"
         )
 

--- a/tests/unit/test_performance_fixes.py
+++ b/tests/unit/test_performance_fixes.py
@@ -185,6 +185,51 @@ class TestEmbeddingFallback:
         result = await pipeline._find_embedding_anchors("test query")
         assert result == []
 
+    @pytest.mark.asyncio
+    async def test_graph_only_tombstones_never_enter_the_anchor_set(
+        self, mock_storage, mock_config
+    ):
+        """Tombstones share one placeholder vector, so for any query near that
+        region they tie with each other and would crowd genuine memories out of
+        the top-k anchor slots. They must be excluded before scoring."""
+        mock_provider = AsyncMock()
+        mock_provider.embed = AsyncMock(return_value=[0.5, 0.5, 0.0])
+        # Every candidate scores above threshold - ordering alone decides.
+        mock_provider.similarity = AsyncMock(return_value=0.9)
+
+        tombstones = [
+            Neuron.create(
+                type=NeuronType.CONCEPT,
+                content="[graph-only]",
+                neuron_id=f"tomb-{i}",
+                metadata={"_embedding": [0.5, 0.5, 0.0]},
+            )
+            for i in range(12)
+        ]
+        genuine = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="the genuine memory about the same topic",
+            neuron_id="genuine-1",
+            metadata={"_embedding": [0.5, 0.49, 0.01]},
+        )
+        mock_storage.find_neurons = AsyncMock(return_value=[*tombstones, genuine])
+
+        pipeline = ReflexPipeline(
+            storage=mock_storage,
+            config=mock_config,
+            embedding_provider=mock_provider,
+        )
+
+        anchors = await pipeline._find_embedding_anchors("that topic", top_k=10)
+
+        assert "genuine-1" in anchors, (
+            "the genuine memory must not be displaced from the anchor set"
+        )
+        assert not any(a.startswith("tomb-") for a in anchors), (
+            "a tombstone's vector describes a placeholder, not a memory - it must "
+            "never occupy an anchor slot"
+        )
+
 
 # -- Retrieval: Query Expansion ----------------------------------------------
 

--- a/tests/unit/test_prediction_error.py
+++ b/tests/unit/test_prediction_error.py
@@ -81,6 +81,37 @@ class TestComputeSurpriseBonus:
         assert result == 1.0
 
     @pytest.mark.asyncio
+    async def test_legacy_tombstone_does_not_deflate_novelty(
+        self, mock_storage: AsyncMock, mock_config: MagicMock
+    ) -> None:
+        """A tombstone must not make a new memory look familiar.
+
+        A GRAPH_ONLY tombstone written before the hash sentinel carries the
+        SimHash of its DELETED text. A new memory resembling that deleted text
+        would score hamming ~0 against it and be stored with zero surprise -
+        low arousal for content the brain no longer actually holds.
+        """
+        content = "PostgreSQL is fast for OLTP workloads"
+        tombstone = MagicMock()
+        tombstone.id = "tombstone-1"
+        tombstone.content = "[graph-only]"
+        tombstone.content_hash = simhash(content)  # stale hash of the deleted text
+
+        mock_storage.find_neurons = AsyncMock(return_value=[tombstone])
+
+        result = await compute_surprise_bonus(
+            content=content,
+            tags={"postgres"},
+            content_hash=simhash(content),
+            storage=mock_storage,
+            config=mock_config,
+        )
+        assert result >= 2.0, (
+            "with only a tombstone as 'evidence' the content is effectively novel - "
+            "a fingerprint of deleted text must not count as familiarity"
+        )
+
+    @pytest.mark.asyncio
     async def test_redundant_content(self, mock_storage: AsyncMock, mock_config: MagicMock) -> None:
         """Near-duplicate content → surprise ~0."""
         content = "PostgreSQL is fast for OLTP workloads"

--- a/tests/unit/test_semantic_discovery.py
+++ b/tests/unit/test_semantic_discovery.py
@@ -190,6 +190,60 @@ class TestDiscoverSemanticSynapses:
                 assert syn.weight <= 0.6
         assert found_similar
 
+    async def test_graph_only_tombstones_are_never_linked(
+        self, storage: InMemoryStorage, brain_config: BrainConfig
+    ) -> None:
+        """Tombstones share one placeholder text, so their stored vectors are
+        identical brain-wide - cosine 1.0 between memories with nothing in
+        common. Discovery must skip them, or every consolidation pass persists
+        false SIMILAR_TO edges between unrelated memories; genuine neurons in
+        the same brain must still link so the skip cannot over-filter.
+        """
+        t1 = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="[graph-only]",
+            neuron_id="t1",
+            metadata={"_embedding": [0.7, 0.7, 0.0]},
+        )
+        t2 = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="[graph-only]",
+            neuron_id="t2",
+            metadata={"_embedding": [0.7, 0.7, 0.0]},  # identical - placeholder embed
+        )
+        real1 = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="machine learning",
+            neuron_id="real1",
+            metadata={"_embedding": [0.9, 0.1, 0.0]},
+        )
+        real2 = Neuron.create(
+            type=NeuronType.CONCEPT,
+            content="deep learning",
+            neuron_id="real2",
+            metadata={"_embedding": [0.85, 0.15, 0.0]},
+        )
+        for n in (t1, t2, real1, real2):
+            await storage.add_neuron(n)
+
+        result = await discover_semantic_synapses(storage, brain_config)
+
+        tombstone_ids = {"t1", "t2"}
+        tombstone_edges = [
+            s
+            for s in result.synapses
+            if s.source_id in tombstone_ids or s.target_id in tombstone_ids
+        ]
+        assert tombstone_edges == [], (
+            "identical placeholder vectors must not become SIMILAR_TO edges - "
+            "a tombstone pair at cosine 1.0 is an artefact of compression, not "
+            "a semantic relationship"
+        )
+        assert result.neurons_embedded == 2, "only the two genuine neurons are eligible"
+        assert any({s.source_id, s.target_id} == {"real1", "real2"} for s in result.synapses), (
+            "the skip must not stop genuine neurons from linking"
+        )
+
     async def test_skips_existing_synapse_pairs(
         self, storage: InMemoryStorage, brain_config: BrainConfig
     ) -> None:


### PR DESCRIPTION
## Summary

- The compression engine's compress/decompress/recover paths and instruction refinement now refresh `content_hash` and the embedding when they replace a neuron's content, instead of re-saving the old ones next to the new text - the same class #166 fixed for `smem_edit`, on five of the six call sites it left standing (the sixth is a server route, noted below).
- Refreshing is **batched**: one brain lookup and one `embed_batch` per compression step, not one per neuron. Compression walks every neuron of a fiber under a time budget, so a per-neuron round-trip was not an acceptable way to fix this.
- The shared helper moves to `utils/content_refresh.py` so both layers can use it without a new cross-layer import.
- Adds twenty-four behavioural tests, including one that fails if the per-neuron round-trip ever comes back, one for a provider that returns fewer vectors than it was given, and ones proving graph-only tombstones are paired by none of the consumers of content-derived fields - not the dedup census, not the save-time dedup pipeline, not semantic discovery, not interference detection, and never as recall anchors.

## Rebased onto v3.8.0, and what that changed

This branch was rebuilt on `ae8e8743` (v3.8.0). One file conflicted, and the resolution is worth
describing because taking either side wholesale would have been wrong.

`#188` landed after this work was written. It kept `_content_refreshed` local to
`mcp/lifecycle_handler.py` and taught it a third derived field: `metadata["_structure"]`, which
recall reads back to answer with the memory's fields. This branch does the opposite - it *removes*
that local function and moves it to `utils/content_refresh.py`, so the nine other call sites can
share it.

Resolving in this branch's favour alone would have silently dropped `#188`: the handler would
delegate to a helper that knew nothing about `_structure`, and an edited memory would keep
describing text that no longer exists - the exact defect `#188` fixed. Nothing would have failed
loudly; `detect_structure` would simply have stopped being called on the edit path.

So the shared helper absorbs it. `contents_refreshed` now re-derives `_structure` for every
neuron whose content changes, and **removes** the key when the new content has no structure at
all - preserving `#188`'s deliberate choice of removal over overwrite, because an overwrite-on-hit
would leave recall surfacing fields that exist nowhere.

`#188`'s own regression tests are kept and repointed at the new location (two direct imports and
two AST probes). They pass unchanged in substance, including
`test_editing_structure_away_drops_it_entirely` - which is the proof that the move did not cost
the fix.

## Why

#166 fixed `smem_edit`'s content-update paths but left the same pattern everywhere else that overwrites a neuron's `content`: `engine/compression.py`'s compress/decompress/recover, and `mcp/instruction_handler.py`'s refine handler. Each did `dc_replace(neuron, content=new)` straight into `update_neuron`, which writes `content_hash` from the object and the vector from `metadata["_embedding"]` - so the old fingerprint and the old vector were re-saved against the new content.

Compression makes the effect automatic rather than opt-in. A neuron reaching the GRAPH_ONLY tier has its content replaced with the placeholder `"[graph-only]"` while its vector and hash keep describing the full text that was there before - the memory stays retrievable by content that has since been deleted. Tier 1-3 compression has the same problem against the compressed excerpt. Decompression and snapshot recovery restore the original text without checking the derived fields match it, so drift from an intervening compress cycle survives the restore silently.

Worth flagging for anyone testing this: for the restore paths the obvious test - restore the original, assert the hash matches - **passes on the unfixed code**. The field was never touched since creation and you are restoring exactly the text it was derived from, so it agrees by coincidence. Two of the tests below seed a drifted hash and vector first, so a post-restore match can only come from an actual refresh.

## Batching, and why the vector is refreshed rather than cleared

The obvious cheap fix - clear `embedding_vec` and let `reindex --missing-only` repair it - **does not work**, and fails in a way worth recording. `embedding_vec` carries an HNSW index with a fixed dimension (`ensure_schema` defines it on every connect, defaulting the dimension when unset, so any schema-initialised deployment has it), and under that index writing an empty array is rejected:

```
UPDATE neuron:a MERGE { content: "[graph-only]", embedding_vec: [] };
-- Incorrect vector dimension (0). Expected a vector of 4 dimension.
```

The error takes the whole statement with it: the row keeps its old content as well as its old vector, so the compression step silently does nothing. (`embedding_vec: NONE` is accepted, but `update_neuron` cannot express it - a `None` in `metadata["_embedding"]` means "leave alone", so clearing would need a storage-layer change.) Refreshing the vector is therefore the only in-scope fix.

That makes the cost question real, because compression is not an interactive edit: it runs from a background consolidation pass, in loops over every neuron of a fiber, and `compress_fiber` already treats database round-trips as its dominant cost while `compress_all` defers fibers when it exhausts its time budget. Embedding one neuron at a time would have added a provider round-trip per neuron to a path that makes none today.

So the helper takes a batch: hashes are recomputed locally for everything, and the neurons that actually carry a vector are embedded together in a single `embed_batch` behind a single brain lookup - the same shape `encoder.py` already uses when embedding on create. Each *distinct* text is embedded once and its vector fanned out, so a GRAPH_ONLY fiber costs one embedding rather than one per neuron of the identical placeholder; `compress_all` fetches the brain once for the whole pass rather than once per fiber. A fiber of any size costs two round-trips, not two per neuron.

The single-neuron entry point is a thin wrapper over the batch one, so the edit and refine paths keep #166's functional behaviour: the edit succeeds without a provider, the old vector is kept and a warning names `smem reindex --all` on provider failure, and the timeout branch stays separate. Two cosmetic deltas from #166, called out for anyone filtering logs: the warning now comes from the `surreal_memory.utils.content_refresh` logger rather than `surreal_memory.mcp.lifecycle_handler`, and its text no longer begins with "smem_edit" (the helper serves several tools now).

## A tombstone must carry no fingerprint on *any* axis

One class of consequence only shows up once the derived fields are actually correct: every neuron compressed to GRAPH_ONLY ends up with the same content, `"[graph-only]"`, so anything derived from that content is a single constant shared brain-wide. Each downstream consumer that compares derived fields then pairs unrelated tombstones with each other:

- **Hash axis.** The consolidation census compares anchors by SimHash Hamming distance; identical fingerprints read as distance 0 and persist a false `duplicate of` edge. So the placeholder is written with `content_hash = 0` - the codebase's existing "no meaningful fingerprint" value, which the census, the dedup pipeline and the context optimizer already skip - and the census and the save-time dedup pipeline additionally refuse to fingerprint placeholder content at all. Those content guards are what cover *pre-existing* tombstones: rows written before this change carry the SimHash of their deleted original text, a fiber parked at GRAPH_ONLY never re-enters the compression path (the tier early-return), and `reindex` repairs vectors, not hashes. Without them, a genuine memory that near-duplicates the *deleted* text would be aliased to a tombstone by the census - or, worse, a brand-new save would be *canonicalised onto* one: the dedup candidate search reaches tombstones (the FTS analyzer tokenises the placeholder into `graph`/`only`), tier-1 would match the stale hash, and the new fiber would anchor to `"[graph-only]"` with its actual text surviving only as an alias neuron. Interference detection gets the same placeholder skip: its recompute-on-missing-hash fallback exists for real content that lost its hash, and would otherwise resurrect exactly the shared constant the sentinel suppresses - one save landing in the interference window would `CONTRADICTS`-link to every tag-overlapping tombstone at once.
- **Vector axis.** Two tombstones embed to the identical vector - cosine 1.0 between memories with nothing in common. Both consumers of stored vectors now skip placeholder-content neurons: semantic discovery (which runs inside automatic consolidation and would persist the pair as a `SIMILAR_TO` edge) and recall's embedding anchor selection (where a brain's worth of identical tombstone vectors would otherwise tie with each other and crowd genuine memories out of the top-k anchor slots for any query near that region). The stale fields were accidentally hiding all of these interactions, since they still described the different original texts.

The same reasoning covers two smaller hash consumers: entity reuse at encode time (its near-duplicate fallback could bind a brand-new entity reference to a placeholder neuron - a persisted wrong link) and novelty scoring (a tombstone's stale hash would make a new memory resembling the deleted text look familiar, storing it with deflated surprise). Both now skip placeholder content.

When a legacy tombstone *does* meet the compression path again - a partially recovered fiber, reset to FULL while its snapshot-less neurons kept the placeholder - the pass normalises its stale hash to the sentinel, without touching its vector and without a provider call. But that path is opportunistic, not a remediation: the guards above are what make legacy fingerprints inert. These seven guarded sites (census, save-time dedup, interference, discovery, recall anchors, entity reuse, novelty scoring) are, to the best of my enumeration, every consumer whose comparison against a tombstone fingerprint would persist a wrong outcome; the storage-level KNN search has no callers in the recall path. Two places still *see* legacy fingerprints, disclosed rather than stretched into this diff: sync's insert dedup compares exact hashes inside the storage query (a re-synced copy of text identical to a tombstone's deleted original is treated as already present - pre-existing behaviour, and arguably the intended dedup of the same aged-out memory; the sharp edge is a tombstone whose snapshot is missing, where the peer's copy is the only surviving full text and is still dropped), and the recall context optimizer's in-flight duplicate filter (no persisted state). A one-shot migration stamping the sentinel onto legacy rows (`content = '[graph-only]' AND content_hash != 0`) would retire both and is a natural follow-up.

## One instance deliberately left out

`server/routes/memory.py`'s neuron update route has the same bug: it builds `replace(neuron, **updates)` with a new `content` and hands it to `update_neuron`, so a content edit through the HTTP API re-saves the old hash and vector exactly as the paths here did. I have left it out rather than quietly widen the diff - it is a different surface with its own test story (routes, dashboard), and this PR is already the compression-and-refine change. It is the last instance I can find: I enumerated every `update_neuron` call in `src/`, and the rest are metadata-only stamps (`conflict_detection`, `supersession`, `reconsolidation`, `conflict_handler`, `integration/mapper.py`), vector writes already derived from current content (`encoder`, `doc_trainer`), or peer-state replication (`sync_engine`). Happy to follow up with the route in a separate PR if you would rather have it handled the same way.

## Where the helper lives

`mcp/` already imports `engine/` lazily at the call site, but `engine/` does not import `mcp/`; reusing the helper from `engine/compression.py` would have added a backwards `engine → mcp` edge. It is content-and-storage logic, not MCP-protocol logic, so it moved to `utils/content_refresh.py` - the home `simhash` already has, for the same reason. Its imports of the embedding provider stay function-local, exactly as before, so nothing changes about when that code runs.

## Test plan

- [x] `pytest -m "not stress" -n auto` passes locally - 7103 passed, 146 skipped, 1 xfailed (baseline on `main` is 7079 passed with the same skip/xfail counts; the delta is exactly this PR's twenty-four new tests).
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` clean.
- [x] `mypy src/ --ignore-missing-imports` clean - no issues in 354 source files.
- [x] The new tests were proven to fail against `main`: each compression site (GRAPH_ONLY compress, tier-1 compress, decompress, snapshot recovery) and the refine site saved a neuron carrying the old `content_hash` and vector next to the new content; the provider-unavailable tests saw no warning logged.
- [x] A three-neuron fiber is compressed with the provider factory patched, asserting it is constructed **once** and handed all three texts in one `embed_batch` - so a per-neuron round-trip cannot creep back in unnoticed. Separate tests cover a fiber mixing vectored and vectorless neurons, an install with no vectors never reaching for an embedder, and the bounded-wait branch.
- [x] A provider returning fewer vectors than texts is rejected before anything is assigned, and warns: assigning positionally over a short list would leave the tail neurons holding old vectors with no error and no warning - the same silent-stale failure this PR removes. A companion test restores a three-neuron fiber through an echo provider and asserts each neuron receives the vector derived from *its own* text, so a misaligned batch assignment cannot pass either.
- [x] Two graph-only tombstones go through the consolidation dedup census with no ALIAS edge and through semantic discovery with no SIMILAR_TO edge, while genuine similar neurons in the same brain still link. A legacy tombstone carrying the SimHash of its deleted text is neither aliased to a genuine memory whose content matches that deleted text nor allowed to canonicalise a new save in the dedup pipeline, and when a partially recovered fiber re-enters compression, the stale hash is normalised to the sentinel without a provider call.
- [x] The empty-vector rejection quoted above was reproduced against an ephemeral in-memory SurrealDB with the project's own schema and HNSW index definition.
- [x] Diff touches `engine/`, `mcp/`, `utils/` (the new shared helper) and `tests/` only; no server routes or dashboard assets.

## Verified by

@RobertSigmundsson

---

A note of thanks that is also context: #188 landed the day before this branch was rebuilt, and it
is a good fix - it is precisely why the conflict here had to be resolved as a *merge* rather than
a cherry-pick, and why the shared helper now carries the `_structure` handling instead of dropping
it. Your regression tests for it are kept and repointed at the new location; they pass unchanged
in substance.

Thanks as well for closing #174, #175 and #176. This PR is the remaining half of that same class -
the call sites outside the MCP layer that `_content_refreshed` never reached.
