### PR TITLE
chore(release): 3.8.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "3.8.0"
+    "version": "3.8.1"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.8.1] — 2026-08-30 — a memory stops being findable by text it no longer contains
+
+Compression is meant to be either reversible or honest. Two defects made it neither: the
+snapshot that destructive compression takes before overwriting content never reached the
+database, and every path that replaced a neuron's content re-saved the fingerprint and
+embedding of the text it had just deleted.
+
+### Fixed
+
+- `save_neuron_snapshot` wrote a `datetime` into a column the schema declares as a string,
+  so a SCHEMAFULL backend refused the write. The only caller wraps the save in a fail-soft
+  `except`, so nothing surfaced: destructive compression replaced a neuron's content while
+  the snapshot meant to protect it silently never existed, leaving content recovery with
+  nothing to restore from. The read path already parsed either representation, so callers
+  are unaffected.
+- The compression engine's compress, decompress and recover paths, and instruction
+  refinement, replaced a neuron's `content` without recomputing `content_hash`, the stored
+  embedding, or `metadata["_structure"]` — so a memory stayed retrievable by text that had
+  been deleted, and could not be repaired by a missing-only reindex, because the vector was
+  never empty. This is the same class fixed for `smem_edit` in 3.8.0, applied to the call
+  sites outside the MCP layer.
+- Refreshing is batched rather than per neuron: compression walks every neuron of a fiber
+  under a time budget, and identical text is embedded once and fanned out, so a fiber costs
+  one brain lookup and one embedding call rather than a provider round-trip per neuron. A
+  provider returning fewer vectors than it was given is rejected before any of them is
+  assigned, since a positional assignment over a short list would leave the tail neurons
+  holding stale vectors with neither an error nor a warning.
+- A neuron compressed to the graph-only tier carries a placeholder for content, so anything
+  derived from it is one constant shared across the store. Correct derived fields therefore
+  made a latent problem reachable: consumers comparing those fields would pair unrelated
+  tombstones with each other, or canonicalise a genuine new memory onto one. The placeholder
+  now carries the codebase's existing no-fingerprint sentinel, and the consumers of
+  content-derived fields — the deduplication census, the save-time deduplication pipeline,
+  interference detection, semantic discovery, recall anchor selection, entity reuse and
+  novelty scoring — skip placeholder content rather than fingerprinting it.
+
 ## [3.8.0] — 2026-08-27 — the dashboard answers, and what it reports stops lying
 
 Every dashboard endpoint that recomputed a multi-second analysis on each request now

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.8.0"
+version = "3.8.1"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.8.0"
+__version__ = "3.8.1"
 
 __all__ = [
     "__version__",

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.8.0"
+        assert surreal_memory.__version__ == "3.8.1"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Release 3.8.1. Version bumped across all 16 version-bearing locations, with a `CHANGELOG.md`
section for the two fixes that landed since 3.8.0.

PATCH rather than MINOR: both changes are bug fixes with no new surface. `smem_transplant`'s
`min_salience` and the decay telemetry that would have justified a MINOR shipped in 3.8.0.

## Contents

- #192 — `save_neuron_snapshot` sent a `datetime` into a column the schema declares as a
  string, so a SCHEMAFULL backend refused the write and the caller's fail-soft `except`
  hid it. Destructive compression therefore ran with no snapshot behind it.
- #193 — compress, decompress, recover and instruction refinement now recompute
  `content_hash`, the stored embedding and `metadata["_structure"]` when they replace a
  neuron's content, batched per fiber rather than per neuron. Consumers of content-derived
  fields skip graph-only placeholder content instead of fingerprinting a store-wide constant.

## Test plan

- [x] `python scripts/pre_ship.py` — all 10 sections pass, including version consistency
      (16/16 at 3.8.1), the CHANGELOG entry check, ruff, mypy, the fast unit suite, and both
      documentation-freshness gates.
- [x] Both merged PRs were green on all 9 CI checks before merge, including the live
      SurrealDB integration job.
- [ ] Post-publish: confirm the artefacts actually reached PyPI, npm (plugin and SDK),
      ClawHub and the VS Code Marketplace. The publish steps in `release.yml` are tolerant of
      failure, so a green job is not by itself evidence that anything was published.
