### PR TITLE
fix(dashboard): serve-stale brains and diagnostics for remote databases (3.9.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "3.9.0"
+    "version": "3.9.1"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/.zcode/plans/plan-sess_f60973d5-1f9a-42f0-8e59-7808237ce200.md
+++ b/.zcode/plans/plan-sess_f60973d5-1f9a-42f0-8e59-7808237ce200.md
@@ -1,0 +1,38 @@
+## Finalne rozwiązanie: konsola → klaster (smem na Titanie)
+
+**Cel:** `smem <dowolne polecenie>` z interaktywnej konsoli Toniego łączy się z klastrem k3s (wss), nie z martwym `localhost:8001` — bez ręcznego source'owania `.env`, bez zmian w pakiecie.
+
+### Zmiana (jedna, operacyjna — zero kodu, zero release'a)
+
+Dodać do interaktywnego rc powłoki Toniego (wykryję przy wykonaniu: `~/.zshrc`, fallback `~/.bashrc`/`~/.profile` — prompt „~ ❯" sugeruje zsh+starship) blok:
+
+```zsh
+# smem → k3s cluster (run 010, 2026-09-03) — CLI czyta connection TYLKO z env
+if [ -f "$HOME/repos/surreal-memory/.env" ]; then
+  set -a; . "$HOME/repos/surreal-memory/.env"; set +a
+fi
+```
+
+Dlaczego to jest właściwe „finalne": `.env` pozostaje **jednym źródłem prawdy** (hooki już tak żyją przez `smem-hook-env`, bloki MCP klientów mają te same wartości) — konsola dołącza do tego samego mechanizmu zamiast powstawać czwarta kopia konfiguracji. Sekrety i tak krążą w env procesów MCP; na maszynie osobistej to akceptowalny poziom. Bez zmian w pakiecie = bez release'a 3.9.1.
+
+### Weryfikacja po zmianie (bramki)
+
+1. Świeża interaktywna powłoka: `echo $SURREALDB_URL` = `wss://surreal-memory.lab.nowak.sh/rpc`.
+2. `smem doctor` (z czystej powłoki, bez ręcznego source) → SurrealDB **3.2.4** (klaster), model `bge-m3`.
+3. `smem status` (nieinwazyjne) → liczniki z klastra (~50,6k neuronów).
+4. `smem consolidate` — już do Toniego (ciężka operacja na klastrze; zadziała — łączenie przez wss + embeddingi przez LiteLLM).
+
+### Zapis w ledgerze (REVISIT/kod-upstream)
+
+Do `~/repos/k3s-cluster/.goal/runs/010-surreal-memory-toni/STATE.md` dopiszę obserwację: CLI nie ma żadnej ścieżki konfiguracji connection poza env (brak dotenv, brak pola w config.toml) — kandydat na upstream PR (dotenv w CLI albo `[storage] url` w config.toml) jako **3.9.1+, osobna decyzja**, nie w tym runie.
+
+### Czego NIE robię
+
+- Nie zmieniam pakietu smem ani nie wydaję nowej wersji (osobny PR, jeśli zechcesz).
+- Nie przenoszę `.env` (hooki i MCP wskazują na obecne miejsce).
+- Nie ruszam klastra — zmiana dotyczy wyłącznie powłoki na Titanie.
+
+### Ryzyka
+
+- Jeśli repo `surreal-memory` zmieni kiedyś lokalizację, ścieżka w rc przestanie działać (guard `[ -f … ]` sprawia, że po prostu cicho nie załaduje — smem wróci do defaultu i objaw będzie czytelny).
+- Sekrety w env interaktywnej powłoki = ten sam poziom ekspozycji, który już istnieje (bloki env MCP).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.1] — 2026-09-03 — the dashboard answers before the diagnostics do
+
+### Fixed
+
+- The dashboard's Brains table and stats cards no longer block on full-brain
+  diagnostics. With the server running away from its database (a k3s pod
+  talking to SurrealDB over WebSocket), a cold
+  `DiagnosticsEngine.analyze` costs ~100 s and a warm one ~10 s — the browser
+  gives up long before either finishes, and the overview rendered "No brains
+  found" over zero counters although the data was fine. `/api/dashboard/brains`
+  now returns as soon as the per-brain counts are known (grade/purity render
+  at their defaults until computed), a previously computed table is served
+  instantly while a single background pass refreshes it, and an expired
+  diagnostics report is served stale and recomputed once in the background.
+  The cache TTL now paces the refresh instead of gating the caller.
+
 ## [3.9.0] — 2026-09-03 — reasoning endpoints may leave the machine, but only when told to
 
 ### Added

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",
@@ -1018,7 +1018,7 @@
         "istanbul-reports": "^3.1.7",
         "magic-string": "^0.30.17",
         "magicast": "^0.3.5",
-        "std-env": "^3.9.0",
+        "std-env": "^3.9.1",
         "test-exclude": "^7.0.1",
         "tinyrainbow": "^2.0.0"
       },
@@ -2263,7 +2263,7 @@
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "std-env": "^3.9.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^0.3.2",
         "tinyglobby": "^0.2.14",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.9.0"
+version = "3.9.1"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"
@@ -38,7 +38,7 @@ dependencies = [
     "networkx>=3.0",
 
     "typer>=0.9.0,<0.26",
-    "aiohttp>=3.9.0",
+    "aiohttp>=3.9.1",
     "rich>=13.0.0",
     "typing_extensions>=4.0",
 ]

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.9.0"
+__version__ = "3.9.1"
 
 __all__ = [
     "__version__",

--- a/src/surreal_memory/server/routes/dashboard_api.py
+++ b/src/surreal_memory/server/routes/dashboard_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Annotated, Any
@@ -25,6 +26,22 @@ logger = logging.getLogger(__name__)
 # A health grade does not meaningfully move within five minutes.
 _HEALTH_TTL_SECONDS = 300.0
 _GRADE_CACHE = TTLCache(ttl=_HEALTH_TTL_SECONDS)
+
+# Serve-stale-while-revalidate. Since smem 3.9.0 the server can run far away
+# from its database (k3s pod over WebSocket), where a cold
+# DiagnosticsEngine.analyze costs ~100 s and even a warm one ~10 s — far past
+# any browser's patience. The overview rendered "No brains found" and zero
+# counters because the frontend gives up before the endpoint answers. So: any
+# previously computed report is served AT ONCE from _GRADE_LAST_GOOD (which
+# survives the TTL, unlike the TTLCache) while a single background task
+# recomputes it; the TTL only decides how often that refresh happens, never
+# whether the caller blocks. _BRAINS_LAST_GOOD is the same idea for the whole
+# Brains table.
+_GRADE_LAST_GOOD: dict[str, Any] = {}
+_GRADE_REFRESH_KEYS: set[str] = set()
+_BRAINS_LAST_GOOD: list[BrainSummary] | None = None
+_BRAINS_REFRESHING = False
+_BRAINS_REFRESH_TASKS: set[asyncio.Task[None]] = set()
 
 # Brain-wide uncertainty overview is bounded/cheap, but cached per brain for a short
 # window anyway to keep the dashboard's polling off the storage hot path (same
@@ -52,11 +69,53 @@ async def _cached_health_report(storage: NeuralStorage, brain_name: str) -> Any:
     cached = _GRADE_CACHE.get(key)
     if cached is not None:
         return cached
+    stale = _GRADE_LAST_GOOD.get(key)
+    if stale is not None:
+        # Serve the last computed report at once and recompute in the
+        # background; on a remote database a cold analyze runs ~100 s — no
+        # browser waits that long, and serving nothing is what rendered the
+        # overview as "No brains found".
+        _schedule_grade_refresh(storage, brain_name, key)
+        return stale
     from surreal_memory.engine.diagnostics import DiagnosticsEngine
 
     report = await DiagnosticsEngine(storage).analyze(brain_name)
     _GRADE_CACHE.set(key, report)
+    _GRADE_LAST_GOOD[key] = report
     return report
+
+
+def _schedule_grade_refresh(storage: NeuralStorage, brain_name: str, key: str) -> None:
+    """Recompute one diagnostics report in the background, at most once per key.
+
+    A strong reference to the task is kept until it finishes (asyncio discards
+    tasks that only the event loop holds). A failure is logged, never raised —
+    the caller has already been served the stale report.
+    """
+
+    def _done(task: asyncio.Task[Any]) -> None:
+        _GRADE_REFRESH_KEYS.discard(key)
+        if not task.cancelled() and task.exception() is not None:
+            logger.warning(
+                "Background diagnostics refresh failed for brain %s",
+                brain_name,
+                exc_info=task.exception(),
+            )
+
+    if key in _GRADE_REFRESH_KEYS:
+        return
+    _GRADE_REFRESH_KEYS.add(key)
+
+    async def _refresh() -> Any:
+        from surreal_memory.engine.diagnostics import DiagnosticsEngine
+
+        report = await DiagnosticsEngine(storage).analyze(brain_name)
+        _GRADE_CACHE.set(key, report)
+        _GRADE_LAST_GOOD[key] = report
+        return report
+
+    task = asyncio.get_running_loop().create_task(_refresh())
+    task.add_done_callback(_done)
 
 
 async def _cached_evolution(storage: NeuralStorage, brain_name: str) -> Any:
@@ -324,6 +383,11 @@ async def list_brains_api(
     showed the real grade — the F-vs-D mismatch. Run diagnostics per brain here
     too, sequentially — one isolated connection at a time rather than a burst.
 
+    Serve-stale-while-revalidate (see ``_cached_health_report``): the response
+    returns as soon as the counts are known and diagnostics run in the
+    background. On a remote database the synchronous version cost ~100 s cold /
+    ~10 s warm per load, which the frontend answers with "No brains found".
+
     Per-brain diagnostics go through ``storage_for_scope``, never
     ``get_shared_storage(brain_name=...)``: on the SurrealDB backend the latter
     returns the process-wide singleton *after* repointing its brain, so this
@@ -338,20 +402,74 @@ async def list_brains_api(
     cfg = get_config()
     brain_names = await list_available_brains()
     active_name = cfg.current_brain
-    results: list[BrainSummary] = []
 
+    global _BRAINS_LAST_GOOD
+
+    def _refresh_in_background(names: list[str]) -> None:
+        """Compute diagnostics for every brain, updating _BRAINS_LAST_GOOD grades."""
+
+        async def _run() -> None:
+            global _BRAINS_LAST_GOOD
+            for name in names:
+                try:
+                    async with storage_for_scope(storage, name) as brain_storage:
+                        report = await _cached_health_report(brain_storage, name)
+                except Exception:
+                    logger.debug("Background diagnostics failed for brain %s", name, exc_info=True)
+                    continue
+                current = _BRAINS_LAST_GOOD
+                if current is None:
+                    continue
+                _BRAINS_LAST_GOOD = [
+                    (
+                        BrainSummary(
+                            id=b.id,
+                            name=b.name,
+                            neuron_count=b.neuron_count,
+                            synapse_count=b.synapse_count,
+                            fiber_count=b.fiber_count,
+                            grade=report.grade,
+                            purity_score=report.purity_score,
+                            is_active=b.is_active,
+                        )
+                        if b.name == name
+                        else b
+                    )
+                    for b in current
+                ]
+
+        global _BRAINS_REFRESHING
+        if _BRAINS_REFRESHING:
+            return
+        _BRAINS_REFRESHING = True
+
+        def _done(task: asyncio.Task[None]) -> None:
+            global _BRAINS_REFRESHING
+            _BRAINS_REFRESHING = False
+            if not task.cancelled() and task.exception() is not None:
+                logger.warning("Background brains refresh failed", exc_info=task.exception())
+
+        task = asyncio.get_running_loop().create_task(_run())
+        # Strong reference: the event loop discards tasks nobody holds.
+        _BRAINS_REFRESH_TASKS.add(task)
+        task.add_done_callback(_BRAINS_REFRESH_TASKS.discard)
+        task.add_done_callback(_done)
+
+    # Warm path: the whole table from the last successful pass, instantly —
+    # on a remote database a synchronous diagnostics pass costs ~100 s cold,
+    # which the browser answers with "No brains found".
+    if _BRAINS_LAST_GOOD is not None:
+        _refresh_in_background(brain_names)
+        return _BRAINS_LAST_GOOD
+
+    results: list[BrainSummary] = []
     for name in brain_names:
         try:
             async with storage_for_scope(storage, name) as brain_storage:
                 stats = await brain_storage.get_stats(name)
-                grade = "F"
-                purity = 0.0
-                try:
-                    report = await _cached_health_report(brain_storage, name)
-                    grade = report.grade
-                    purity = report.purity_score
-                except Exception:
-                    logger.debug("Diagnostics failed for brain %s", name, exc_info=True)
+            # Diagnostics is the expensive part (~100 s cold over a remote
+            # link): never in the request path. The background pass fills the
+            # grades in; until then the model defaults (F / 0.0) render.
             results.append(
                 BrainSummary(
                     id=name,
@@ -359,8 +477,8 @@ async def list_brains_api(
                     neuron_count=stats.get("neuron_count", 0),
                     synapse_count=stats.get("synapse_count", 0),
                     fiber_count=stats.get("fiber_count", 0),
-                    grade=grade,
-                    purity_score=purity,
+                    grade="F",
+                    purity_score=0.0,
                     is_active=name == active_name,
                 )
             )
@@ -368,6 +486,8 @@ async def list_brains_api(
             logger.warning("Brain summary failed for %s", name, exc_info=True)
             results.append(BrainSummary(id=name, name=name, is_active=name == active_name))
 
+    _BRAINS_LAST_GOOD = results
+    _refresh_in_background(brain_names)
     return results
 
 

--- a/tests/unit/test_dashboard_api.py
+++ b/tests/unit/test_dashboard_api.py
@@ -412,3 +412,183 @@ class TestBrainListingUsesActiveBackend:
         entry = next(b for b in resp.json()["brains"] if b["name"] == "legacy-brain")
         assert entry["path"] == str(real_path)
         assert entry["size_bytes"] == 10
+
+
+class _FakeAsyncCtx:
+    """async-with target returning a fixed storage object."""
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    async def __aenter__(self) -> Any:
+        return self._inner
+
+    async def __aexit__(self, *exc: Any) -> None:
+        return None
+
+
+class TestBrainsServeStale:
+    """The Brains table must answer immediately, always.
+
+    With the server remote from its database (k3s pod over WebSocket) a cold
+    DiagnosticsEngine.analyze costs ~100 s. The synchronous endpoint made the
+    overview render "No brains found" with zero counters, because the browser
+    gives up long before the endpoint answers. Contract now:
+
+    * the response returns as soon as per-brain counts are known — never waits
+      for diagnostics (grade/purity stay at the model defaults on a cold pod);
+    * diagnostics always run in the BACKGROUND and upgrade the last-good table
+      in place;
+    * once a table exists, later requests are served from it instantly while a
+      background pass refreshes it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_state(self) -> None:
+        from surreal_memory.server.routes import dashboard_api
+
+        dashboard_api._BRAINS_LAST_GOOD = None
+        dashboard_api._BRAINS_REFRESHING = False
+        dashboard_api._GRADE_CACHE.clear()
+        dashboard_api._GRADE_LAST_GOOD.clear()
+        dashboard_api._GRADE_REFRESH_KEYS.clear()
+        yield
+        # background tasks from the TestClient's portal may still be pending
+        dashboard_api._BRAINS_REFRESHING = False
+
+    @pytest.fixture()
+    def remote_brain_env(
+        self, monkeypatch: pytest.MonkeyPatch, mock_storage: AsyncMock
+    ) -> AsyncMock:
+        """One brain 'default', stats served from a fast aggregate, no DB."""
+        from surreal_memory.server.routes import dashboard_api
+
+        cfg = MagicMock()
+        cfg.current_brain = "default"
+        monkeypatch.setattr("surreal_memory.unified_config.get_config", lambda: cfg)
+        monkeypatch.setattr(
+            "surreal_memory.unified_config.list_available_brains",
+            AsyncMock(return_value=["default"]),
+        )
+        scope = AsyncMock()
+        scope.get_stats = AsyncMock(
+            return_value={
+                "neuron_count": 10,
+                "synapse_count": 20,
+                "fiber_count": 3,
+                "structural_neuron_count": 0,
+            }
+        )
+        monkeypatch.setattr(
+            dashboard_api, "storage_for_scope", lambda *a, **k: _FakeAsyncCtx(scope)
+        )
+        return mock_storage
+
+    def test_cold_response_never_runs_diagnostics(
+        self,
+        client: TestClient,
+        remote_brain_env: AsyncMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Cold pod: counts only — diagnostics deferred out of the request path.
+
+        The background pass DOES start an analyze (sleeping 30 s here); the
+        assertion is that the request still answers immediately with the
+        counts instead of waiting for it.
+        """
+        import asyncio
+        import time
+
+        calls = {"analyze": 0}
+
+        class _SlowDiagnostics:
+            def __init__(self, *_a: Any, **_k: Any) -> None:
+                pass
+
+            async def analyze(self, *_a: Any, **_k: Any) -> Any:
+                calls["analyze"] += 1
+                await asyncio.sleep(30)  # request must not wait for this
+
+        monkeypatch.setattr("surreal_memory.engine.diagnostics.DiagnosticsEngine", _SlowDiagnostics)
+        t0 = time.monotonic()
+        r = client.get("/api/dashboard/brains")
+        elapsed = time.monotonic() - t0
+        assert r.status_code == 200
+        assert elapsed < 5, f"request blocked {elapsed:.1f}s on background diagnostics"
+        body = r.json()
+        assert body[0]["name"] == "default"
+        assert body[0]["neuron_count"] == 10
+
+    def test_second_request_serves_last_good(
+        self,
+        client: TestClient,
+        remote_brain_env: AsyncMock,
+    ) -> None:
+        from surreal_memory.server.routes import dashboard_api
+
+        with patch("surreal_memory.engine.diagnostics.DiagnosticsEngine"):
+            first = client.get("/api/dashboard/brains")
+            assert first.status_code == 200
+            # Simulate the completed background pass upgrading the grades.
+            from surreal_memory.server.routes.dashboard_api import BrainSummary
+
+            dashboard_api._BRAINS_LAST_GOOD = [
+                BrainSummary(
+                    id="default",
+                    name="default",
+                    neuron_count=10,
+                    synapse_count=20,
+                    fiber_count=3,
+                    grade="D",
+                    purity_score=44.1,
+                    is_active=True,
+                )
+            ]
+            second = client.get("/api/dashboard/brains")
+            assert second.status_code == 200
+            assert second.json()[0]["grade"] == "D"
+
+    def test_last_good_survives_expired_diagnostics_cache(
+        self,
+        client: TestClient,
+        remote_brain_env: AsyncMock,
+    ) -> None:
+        """Serve-stale: an expired diagnostics cache still returns the table."""
+        from surreal_memory.server.routes import dashboard_api
+
+        with patch("surreal_memory.engine.diagnostics.DiagnosticsEngine"):
+            client.get("/api/dashboard/brains")
+            dashboard_api._GRADE_CACHE.clear()  # TTL gone
+            r = client.get("/api/dashboard/brains")
+            assert r.status_code == 200
+            assert r.json()[0]["name"] == "default"
+
+    def test_cached_health_report_serves_stale_and_schedules_refresh(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Expired-but-present report: stale returned, refresh happens once."""
+        import asyncio
+
+        from surreal_memory.engine.diagnostics import DiagnosticsEngine
+        from surreal_memory.server.routes import dashboard_api
+
+        async def _analyze(brain_name: str) -> object:
+            return {"grade": "C"}
+
+        monkeypatch.setattr(DiagnosticsEngine, "analyze", staticmethod(_analyze))
+        key = "health:default"
+        dashboard_api._GRADE_LAST_GOOD[key] = {"grade": "F"}
+
+        async def _scenario() -> tuple[object, int, object]:
+            storage = AsyncMock()
+            first = await dashboard_api._cached_health_report(storage, "default")
+            pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+            await asyncio.gather(*pending, return_exceptions=True)
+            second = await dashboard_api._cached_health_report(storage, "default")
+            return first, len(pending), second
+
+        first, pending_count, second = asyncio.run(_scenario())
+        assert first == {"grade": "F"}  # stale served instantly
+        assert pending_count == 1  # exactly one background refresh
+        assert second == {"grade": "C"}  # refreshed value served after the pass
+        assert dashboard_api._GRADE_LAST_GOOD[key] == {"grade": "C"}  # upgraded

--- a/tests/unit/test_dashboard_brains_scope.py
+++ b/tests/unit/test_dashboard_brains_scope.py
@@ -67,6 +67,18 @@ def _make_client(storage: Any) -> httpx.AsyncClient:
 
 
 class TestListBrainsDoesNotLeakBrainState:
+    @pytest.fixture(autouse=True)
+    def _reset_brains_module_state(self) -> Any:
+        """Each test starts with a cold serve-stale state (isolated contract)."""
+        from surreal_memory.server.routes import dashboard_api
+
+        dashboard_api._BRAINS_LAST_GOOD = None
+        dashboard_api._BRAINS_REFRESHING = False
+        dashboard_api._GRADE_LAST_GOOD.clear()
+        dashboard_api._GRADE_CACHE.clear()
+        yield
+        dashboard_api._BRAINS_REFRESHING = False
+
     """The read-only listing must never mutate the shared storage's brain."""
 
     @pytest.fixture(autouse=True)
@@ -165,10 +177,16 @@ class TestListBrainsDoesNotLeakBrainState:
             resp = await client.get("/api/dashboard/brains")
 
         assert resp.status_code == 200, resp.text
+        # Diagnostics now run in the background; let the scheduled pass finish.
+        import asyncio
+
+        from surreal_memory.server.routes import dashboard_api
+
+        await asyncio.gather(*dashboard_api._BRAINS_REFRESH_TASKS, return_exceptions=True)
         # The bound brain reuses the shared instance; the other one does not.
-        shared_storage.get_stats.assert_awaited_once_with(BOUND_BRAIN)
-        scoped_storage.get_stats.assert_awaited_once_with(OTHER_BRAIN)
-        scoped_storage.close.assert_awaited_once()
+        shared_storage.get_stats.assert_awaited_with(BOUND_BRAIN)
+        scoped_storage.get_stats.assert_awaited_with(OTHER_BRAIN)
+        scoped_storage.close.assert_awaited()
 
     async def test_summaries_carry_per_brain_stats_and_grade(
         self, shared_storage: AsyncMock, scoped_storage: AsyncMock
@@ -178,14 +196,36 @@ class TestListBrainsDoesNotLeakBrainState:
             resp = await client.get("/api/dashboard/brains")
 
         by_name = {row["name"]: row for row in resp.json()}
+        # Counts are live in the response; the grade arrives via the
+        # background diagnostics pass.
         assert by_name[BOUND_BRAIN]["neuron_count"] == 1
         assert by_name[BOUND_BRAIN]["is_active"] is True
         assert by_name[OTHER_BRAIN]["neuron_count"] == 10
         assert by_name[OTHER_BRAIN]["is_active"] is False
-        assert by_name[OTHER_BRAIN]["grade"] == "B"
+
+        import asyncio
+
+        from surreal_memory.server.routes import dashboard_api
+
+        await asyncio.gather(*dashboard_api._BRAINS_REFRESH_TASKS, return_exceptions=True)
+        rows = dashboard_api._BRAINS_LAST_GOOD or []
+        refreshed = {b.name: b.grade for b in rows}
+        assert refreshed[OTHER_BRAIN] == "B"
 
 
 class TestGetStatsDoesNotLeakBrainState:
+    @pytest.fixture(autouse=True)
+    def _reset_brains_module_state(self) -> Any:
+        """Each test starts with a cold serve-stale state (isolated contract)."""
+        from surreal_memory.server.routes import dashboard_api
+
+        dashboard_api._BRAINS_LAST_GOOD = None
+        dashboard_api._BRAINS_REFRESHING = False
+        dashboard_api._GRADE_LAST_GOOD.clear()
+        dashboard_api._GRADE_CACHE.clear()
+        yield
+        dashboard_api._BRAINS_REFRESHING = False
+
     """The overview endpoint's read-only GET must never mutate the shared storage."""
 
     @pytest.fixture(autouse=True)
@@ -304,6 +344,18 @@ class TestGetStatsDoesNotLeakBrainState:
     reason="requires SURREALDB_URL env var pointing to a running SurrealDB",
 )
 class TestListBrainsScopeLive:
+    @pytest.fixture(autouse=True)
+    def _reset_brains_module_state(self) -> Any:
+        """Each test starts with a cold serve-stale state (isolated contract)."""
+        from surreal_memory.server.routes import dashboard_api
+
+        dashboard_api._BRAINS_LAST_GOOD = None
+        dashboard_api._BRAINS_REFRESHING = False
+        dashboard_api._GRADE_LAST_GOOD.clear()
+        dashboard_api._GRADE_CACHE.clear()
+        yield
+        dashboard_api._BRAINS_REFRESHING = False
+
     """The singleton pointer must survive a real request against a real store."""
 
     async def test_request_leaves_the_shared_singleton_on_the_active_brain(self) -> None:
@@ -351,6 +403,18 @@ class TestListBrainsScopeLive:
     reason="requires SURREALDB_URL env var pointing to a running SurrealDB",
 )
 class TestGetStatsScopeLive:
+    @pytest.fixture(autouse=True)
+    def _reset_brains_module_state(self) -> Any:
+        """Each test starts with a cold serve-stale state (isolated contract)."""
+        from surreal_memory.server.routes import dashboard_api
+
+        dashboard_api._BRAINS_LAST_GOOD = None
+        dashboard_api._BRAINS_REFRESHING = False
+        dashboard_api._GRADE_LAST_GOOD.clear()
+        dashboard_api._GRADE_CACHE.clear()
+        yield
+        dashboard_api._BRAINS_REFRESHING = False
+
     """The singleton pointer must survive a real overview request against a
     real store — this is the endpoint that was found still leaking after
     /brains had already been fixed, so it gets the same live proof.

--- a/tests/unit/test_dashboard_cache.py
+++ b/tests/unit/test_dashboard_cache.py
@@ -9,7 +9,24 @@ from __future__ import annotations
 
 import importlib
 
+import pytest
+
 from surreal_memory.server.dashboard_cache import TTLCache
+
+
+@pytest.fixture(autouse=True)
+def _reset_dashboard_module_state():
+    """Keep the module-level serve-stale state from leaking between tests."""
+    from surreal_memory.server.routes import dashboard_api
+
+    dashboard_api._BRAINS_LAST_GOOD = None
+    dashboard_api._BRAINS_REFRESHING = False
+    dashboard_api._GRADE_CACHE.clear()
+    dashboard_api._GRADE_LAST_GOOD.clear()
+    dashboard_api._GRADE_REFRESH_KEYS.clear()
+    yield
+    dashboard_api._GRADE_LAST_GOOD.clear()
+    dashboard_api._GRADE_CACHE.clear()
 
 
 class _Clock:
@@ -202,8 +219,13 @@ class TestNoEndpointRecomputesDiagnosticsDirectly:
         for node in ast.walk(tree):
             if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
                 continue
-            if node.name in {"_cached_health_report", "_cached_evolution"}:
-                continue  # the two places allowed to compute an analysis
+            if node.name in {
+                "_cached_health_report",
+                "_cached_evolution",
+                "_refresh",
+                "_schedule_grade_refresh",
+            }:
+                continue  # cache entry points + the background refresh task
 
             # Track engines bound to a local first: the handlers write
             # `engine = EvolutionEngine(storage)` and then `engine.analyze(...)`,

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.9.0"
+        assert surreal_memory.__version__ == "3.9.1"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

- `/api/dashboard/brains` no longer blocks on full-brain diagnostics: it returns as soon as per-brain counts are known (grade/purity render at defaults until computed) and serves the last computed table instantly on later loads, while a single background pass per cycle recomputes diagnostics and upgrades the grades in place.
- `_cached_health_report` gained serve-stale-while-revalidate: an expired report is answered from the last-good cache and recomputed once in the background, so `/stats` and `/health` never re-block either. The TTL now paces the refresh instead of gating the caller.
- Contract tests updated: counts stay live in the response, grades arrive via the background pass, and the brain-scope leak guards await the scheduled refresh before asserting isolation.
- Version bump 3.9.0 → 3.9.1 everywhere.

## Why

With the server running away from its database (k3s pod talking to SurrealDB over WebSocket), a cold `DiagnosticsEngine.analyze` costs ~100 s and a warm one ~10 s per `/api/dashboard/brains` load. The browser gives up long before either finishes, and the overview rendered "No brains found" over zero counters although the data was fine (measured live on the run-010 cluster: brains 200 in 99.8 s cold / 9.9 s warm, TTL 300 s). Serving stale values and moving the recompute to the background removes the stall for remote deployments without changing anything for local ones.

## Test plan

- [x] `env -u SURREALDB_URL … pytest tests/ -m "not stress" -q` — 7238 passed, 108 skipped (live DB tests), 1 xfailed
- [x] New tests: cold response never waits for diagnostics; second request served from last-good; last-good survives an expired diagnostics cache; `_cached_health_report` serves stale and schedules exactly one refresh; the AST guard allowlist extended to the background refresh functions
- [x] `ruff check src/ tests/` clean; `ruff format` clean; `mypy src/ --ignore-missing-imports` clean
- [x] `python scripts/pre_ship.py --only versions` — every file at 3.9.1

## Verified by

@acidkill 
