### PR TITLE
fix(consolidation): a dry run must not advance the dedup census window

### DIFF
--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -2454,7 +2454,12 @@ class ConsolidationEngine:
             anchors = window
             report.extra["dedup_anchors_truncated"] = True
             report.extra["dedup_window_start"] = cursor
-            await self._advance_dedup_cursor(cursor, cap, anchors_total)
+            # The cursor is the one piece of state this census keeps between
+            # runs, and moving it is a write. A dry run that advanced it would
+            # make the next real run start a window later, so the slice the dry
+            # run only *looked at* is never compared at all.
+            if not dry_run:
+                await self._advance_dedup_cursor(cursor, cap, anchors_total)
             # INFO, not WARNING: on a brain that has simply outgrown the cap this
             # is a steady state, and every run would raise the same alarm until
             # operators learned to ignore dedup warnings — burying the real

--- a/tests/unit/test_dedup_alias_edges.py
+++ b/tests/unit/test_dedup_alias_edges.py
@@ -815,3 +815,54 @@ class TestAliasLinkSummaryLine:
         report = ConsolidationReport(duplicates_found=12, dry_run=True)
 
         assert report._alias_link_line() == ("12 pairs (census only; links not checked in dry run)")
+
+
+class FakeBrainCursorStorage(FakeAnchorStorage):
+    """FakeAnchorStorage plus the Brain row the dedup cursor lives in."""
+
+    def __init__(self, neurons: list[Neuron], cursor: int = 0) -> None:
+        super().__init__(neurons)
+        from surreal_memory.core.brain import Brain
+
+        self.brain = Brain.create(name="cursor-brain")
+        self.brain.metadata[ConsolidationEngine._DEDUP_CURSOR_KEY] = cursor
+        self.saved_brains: list[object] = []
+
+    async def get_brain(self, brain_id: str) -> object:
+        return self.brain
+
+    async def save_brain(self, brain: object) -> None:
+        self.saved_brains.append(brain)
+
+
+class TestDedupCursorRespectsDryRun:
+    @pytest.mark.asyncio
+    async def test_dry_run_does_not_advance_the_window(self) -> None:
+        """A dry run must leave the census window where it found it.
+
+        The cursor is the only piece of state the census keeps between runs,
+        and advancing it is a write: the next real run starts one window
+        later and the slice this dry run merely *looked at* is skipped, not
+        compared. ``--dry-run`` promised to touch nothing.
+        """
+        storage = FakeBrainCursorStorage([_anchor(f"note {i}") for i in range(7)], cursor=2)
+        engine = ConsolidationEngine(storage, config=ConsolidationConfig(dedup_max_anchors=5))
+        report = ConsolidationReport(dry_run=True)
+
+        await engine._dedup(report, dry_run=True)
+
+        assert report.extra["dedup_anchors_truncated"] is True
+        assert report.extra["dedup_window_start"] == 2, "the census still reads the cursor"
+        assert storage.saved_brains == [], "a dry run wrote the cursor back"
+        assert storage.brain.metadata[ConsolidationEngine._DEDUP_CURSOR_KEY] == 2
+
+    @pytest.mark.asyncio
+    async def test_a_real_run_still_advances_the_window(self) -> None:
+        """Positive control: the rotation itself is not what the dry-run guard removes."""
+        storage = FakeBrainCursorStorage([_anchor(f"note {i}") for i in range(7)], cursor=2)
+        engine = ConsolidationEngine(storage, config=ConsolidationConfig(dedup_max_anchors=5))
+
+        await engine._dedup(ConsolidationReport(), dry_run=False)
+
+        assert len(storage.saved_brains) == 1
+        assert storage.brain.metadata[ConsolidationEngine._DEDUP_CURSOR_KEY] == (2 + 5) % 7


### PR DESCRIPTION
## Summary

- `smem consolidate --dry-run` no longer writes to the brain: the dedup census advances its window cursor only when the run is real.
- Adds two tests — one that a dry run leaves the stored cursor exactly where it found it, and a positive control that a real run still rotates it.

## Why

`_dedup` caps the anchors it compares and rotates the window between runs by keeping a cursor in `Brain.metadata`. That rotation is a good idea, and it is the reason a brain that has outgrown the cap still gets a full census over several passes instead of comparing the same prefix forever. The cursor was advanced unconditionally, outside the `if not dry_run` guard that protects everything else in the pass, so a dry run persisted the next window before returning. The following real run then started one window later, and the slice the dry run had merely *looked at* was skipped rather than compared. The blind spot grew in proportion to how often anyone inspected the brain, which is an unkind way to treat the cautious. The cursor is the one piece of state this census keeps between runs, and moving it is a write; `--dry-run` undertakes not to make any.

## Changes

- `engine/consolidation.py`: `_advance_dedup_cursor` is called only when `not dry_run`. Nothing else moves. `dedup_window_start` is still reported, so a dry run's summary still says which window it inspected, and a real run rotates exactly as before.
- `tests/unit/test_dedup_alias_edges.py`: two tests over a truncated census. The dry-run test asserts the stored cursor is unchanged and that `save_brain` was never called; the real-run test asserts the cursor still advances by the window size. The second one is a positive control — it passes both before and after the fix, which is how you can tell the guard removed the write and not the rotation.

## Test plan

- [x] `pytest tests/unit/test_dedup_alias_edges.py` — 48 passed, against 46 on `main`; the delta is exactly the two tests added here.
- [x] `test_dry_run_does_not_advance_the_window` fails on `main` with `AssertionError: a dry run wrote the cursor back`. It fails again if `engine/consolidation.py` alone is reverted whilst the new tests are kept, so it measures this hunk rather than itself.
- [x] `pytest tests/ -m "not stress" -n 4` — 7285 passed, 48 skipped, 1 xfailed. Two tests in `tests/unit/test_dashboard_brains_scope.py` fail here and fail identically, by name, on `main` (7283 passed): they want a live SurrealDB and collide with one another under `-n`. Both pass when that file is run on its own.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 739 files already formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 354 source files.
- [x] Coverage under the CI gate: 72.41%, against 72.36% on `main`.
- [ ] `CHANGELOG.md` untouched — left to the release entry, as with #191–#193.

## Related issues

None filed. It is a one-line guard, so a PR seemed kinder than a ticket.

## Verified by

@RobertSigmundsson
