### PR TITLE
fix(reasoning): pin ReasoningBank pattern fibers so lifecycle cannot eat them

### DIFF
--- a/src/surreal_memory/engine/reasoning_distiller.py
+++ b/src/surreal_memory/engine/reasoning_distiller.py
@@ -25,7 +25,7 @@ import math
 import os
 import re
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from fnmatch import fnmatch
 from typing import TYPE_CHECKING, Any
 
@@ -408,6 +408,10 @@ async def _materialize_pattern(
             "_reasoning_signature": sig,
         },
     )
+    # Patterns are activated only by injection (which may be OFF); unpinned they
+    # are dead weight to decay/prune and vanish between sessions — pin them like
+    # trained KB (doc_trainer) so lifecycle skips their neurons and fibers.
+    fiber = replace(fiber, pinned=True)
     await storage.add_fiber(fiber)
     return True
 

--- a/tests/unit/test_reasoning_distiller.py
+++ b/tests/unit/test_reasoning_distiller.py
@@ -116,6 +116,7 @@ async def test_distill_creates_pattern_fiber(tmp_path: Path, no_embedder: None) 
 
     fibers = await storage.find_fibers(metadata_key="_reasoning_pattern", limit=100)
     assert len(fibers) == 1
+    assert fibers[0].pinned is True  # KB-grade: lifecycle must never decay/prune patterns
     md = fibers[0].metadata
     assert md["_reasoning_pattern"] is True
     assert md["_source_model"] == "claude-fable-5"


### PR DESCRIPTION
## Summary

- Pattern fibers minted by `distill_reasoning_patterns` are now pinned at materialization, so the lifecycle passes stop treating a distilled lesson as ordinary decayable weight.
- Adds one assertion to the existing `test_distill_creates_pattern_fiber`, which fails without the pin.

## Why

`_materialize_pattern` mints each mined pattern as a fiber tagged with `_reasoning_pattern` metadata, and leaves it unpinned. That marker is honoured in exactly one place — `_merge` refuses to absorb a fiber carrying `_habit_pattern` or `_reasoning_pattern` — and nowhere else. Every other lifecycle pass reads the pin and only the pin: `DecayManager.apply_decay` skips neurons belonging to pinned fibers, `ConsolidationEngine._prune` skips pinned neuron ids for synapse pruning and again for the orphan and dead-neuron sweep, and `CompressionEngine.run` keeps pinned fibers at tier 0. There is no metadata fallback in any of them, so a pattern that is only ever activated by injection — which may be off — ages exactly like a short-term fragment, and disappears without anything louder than the routine `INFO` lines those passes already emit.

This is the axis #168 left open. That PR observed that decay, dead-neuron pruning and orphan pruning all honour the pin, and closed the one lifecycle pass that did not. Reasoning patterns were never pinned to begin with, so being honoured everywhere did them no good.

## Changes

- `engine/reasoning_distiller.py`: import `replace` from `dataclasses`; `_materialize_pattern` sets `fiber = replace(fiber, pinned=True)` between the `Fiber.create(...)` block and `storage.add_fiber(fiber)`, with a comment naming the reason. Setting the flag before the insert rather than by a follow-up update means the pattern is never briefly unpinned and there is no second write — a small departure from how `doc_trainer` pins trained KB fibers, which updates after creating.
- `tests/unit/test_reasoning_distiller.py`: one added line, `assert fibers[0].pinned is True`, immediately after the existing `assert len(fibers) == 1`.

## Two options, and why this one

1. **Mint, then pin (this PR).** `Fiber.create(...)` is unchanged and `replace(fiber, pinned=True)` follows it. One hunk, no signature churn; `pinned` is already a field on the dataclass.
2. **Add `pinned=` to `Fiber.create()`.** Tidier read in isolation, but it changes a constructor used right across the storage layer, and the new parameter would default to `False` — which is what happens today anyway. Happy to switch if you would rather patterns were pinned that way, or if there is a reason they should not count as pinned at all.

## Not touched, on purpose

- `lifecycle.py`, `consolidation.py`, `compression.py`, `storage/surrealdb/pinning.py`. They already do the right thing once `fiber.pinned` is `True`; this PR only supplies the flag they were waiting for.
- The log level of the decay and prune passes. They are meant to be quiet, and making them loud to compensate for a fixed bug would be the worse trade.

## Test plan

- [x] `pytest tests/unit/test_reasoning_distiller.py` — 61 passed.
- [x] With `engine/reasoning_distiller.py` alone reverted to `main` and the test kept, `test_distill_creates_pattern_fiber` fails on `AssertionError: assert False is True` — so the assertion measures this hunk rather than itself.
- [x] `pytest tests/ -m "not stress" -n 4` — 7283 passed, 48 skipped, 1 xfailed, matching `main` exactly. Two tests in `tests/unit/test_dashboard_brains_scope.py` fail on this branch and on `main` alike: they want a live SurrealDB and collide with one another under `-n`. Both pass when that file is run on its own.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 739 files already formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 354 source files.
- [x] Coverage under the CI gate: 72.39%, against 72.36% on `main`.
- [ ] `CHANGELOG.md` untouched — left to the release entry, as with #191–#193.

The lifecycle passes that read `pinned` are not retested here. They have their own coverage, and this PR does not touch them.

## Related issues

None filed; this is the fix rather than the report. The near neighbour is #168, above.

## Verified by

@RobertSigmundsson
