### PR TITLE
fix(storage): brain import surfaces per-loop drops instead of swallowing them

### DIFF
--- a/src/surreal_memory/cli/commands/brain.py
+++ b/src/surreal_memory/cli/commands/brain.py
@@ -345,17 +345,26 @@ def brain_import(
 
         # Load/create storage and import
         storage = await get_storage(config, brain_name=brain_name)
-        await storage.import_brain(snapshot, storage.brain_id)
-        await storage.close()
+        imported_bid = await storage.import_brain(snapshot, storage.brain_id)
+        # Report the counts the storage actually ended up with, not the counts
+        # the source file said were in the payload. `_to_surreal_id` folds
+        # neuron ids to `neuron:<id>` without a brain component, so importing
+        # under a fresh name can still collide with an existing brain's ids;
+        # `import_brain` now logs the shortfall, and this report tells the
+        # operator what actually landed instead of what the file claimed.
+        try:
+            stats = await storage.get_stats(imported_bid)
+        finally:
+            await storage.close()
 
         if use:
             config.current_brain = brain_name
             config.save()
 
         typer.secho(f"Imported brain: {brain_name}", fg=typer.colors.GREEN)
-        typer.echo(f"  Neurons: {len(data['neurons'])}")
-        typer.echo(f"  Synapses: {len(data['synapses'])}")
-        typer.echo(f"  Fibers: {len(data['fibers'])}")
+        typer.echo(f"  Neurons: {stats['neuron_count']}")
+        typer.echo(f"  Synapses: {stats['synapse_count']}")
+        typer.echo(f"  Fibers: {stats['fiber_count']}")
 
     run_async(_import())
 

--- a/src/surreal_memory/storage/surrealdb/store.py
+++ b/src/surreal_memory/storage/surrealdb/store.py
@@ -2529,6 +2529,14 @@ class SurrealDBStorage(
         )
         await self.save_brain(brain)
 
+        # Count successful writes per loop. Bare `except: pass` used to swallow
+        # duplicate-id collisions (trivially reachable — `_to_surreal_id` folds
+        # neuron ids to `neuron:<id>` without a brain component, so importing a
+        # snapshot under a fresh name while the original brain still holds those
+        # ids raises straight into these except blocks). The shortfall now
+        # surfaces as a warning; the return type stays `str` so the abstract
+        # method contract in NeuralStorage does not change.
+        neuron_ok = 0
         for nd in snapshot.neurons:
             try:
                 neuron = Neuron(
@@ -2539,9 +2547,19 @@ class SurrealDBStorage(
                     created_at=_parse_datetime(nd.get("created_at")) or utcnow(),
                 )
                 await self.add_neuron(neuron)
+                neuron_ok += 1
             except Exception:
-                pass
+                logger.debug("Skipped unimportable neuron record", exc_info=True)
+        if neuron_ok < len(snapshot.neurons):
+            logger.warning(
+                "Imported %d of %d neurons into brain %r; %d dropped",
+                neuron_ok,
+                len(snapshot.neurons),
+                bid,
+                len(snapshot.neurons) - neuron_ok,
+            )
 
+        synapse_ok = 0
         for sd in snapshot.synapses:
             try:
                 synapse = Synapse(
@@ -2555,9 +2573,19 @@ class SurrealDBStorage(
                     created_at=_parse_datetime(sd.get("created_at")) or utcnow(),
                 )
                 await self.add_synapse(synapse)
+                synapse_ok += 1
             except Exception:
-                pass
+                logger.debug("Skipped unimportable synapse record", exc_info=True)
+        if synapse_ok < len(snapshot.synapses):
+            logger.warning(
+                "Imported %d of %d synapses into brain %r; %d dropped",
+                synapse_ok,
+                len(snapshot.synapses),
+                bid,
+                len(snapshot.synapses) - synapse_ok,
+            )
 
+        fiber_ok = 0
         for fd in snapshot.fibers:
             try:
                 fiber = Fiber(
@@ -2570,8 +2598,17 @@ class SurrealDBStorage(
                     salience=float(fd.get("salience", 0.0)),
                 )
                 await self.add_fiber(fiber)
+                fiber_ok += 1
             except Exception:
-                pass
+                logger.debug("Skipped unimportable fiber record", exc_info=True)
+        if fiber_ok < len(snapshot.fibers):
+            logger.warning(
+                "Imported %d of %d fibers into brain %r; %d dropped",
+                fiber_ok,
+                len(snapshot.fibers),
+                bid,
+                len(snapshot.fibers) - fiber_ok,
+            )
 
         # Restore the side tables the graph does not carry. Snapshots written by
         # versions before these were exported simply have no such keys.

--- a/tests/unit/test_surrealdb_import_brain_reports_drops.py
+++ b/tests/unit/test_surrealdb_import_brain_reports_drops.py
@@ -1,0 +1,140 @@
+"""Regression: SurrealDB import_brain must not silently drop colliding records.
+
+Each neuron/synapse/fiber insert used to be wrapped in a bare `except: pass`,
+so a duplicate record id — trivially reachable by importing a snapshot into a
+newly-named brain while the original was still around, since `_to_surreal_id`
+folds neuron id to `neuron:<id>` without a brain component — vanished with no
+counter, no log line, and no signal to the caller.
+
+The fix keeps the return type stable (interface `NeuralStorage.import_brain`
+must stay `-> str`) and adds a `logger.warning` with the shortfall per loop
+when at least one record failed to land.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from surreal_memory.core.brain import BrainSnapshot
+from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+
+def _snapshot_with(neurons: int, synapses: int, fibers: int) -> BrainSnapshot:
+    """Minimal snapshot: unique ids so a bare add_* would happily accept them."""
+    now = datetime(2026, 9, 3, tzinfo=UTC)
+    return BrainSnapshot(
+        brain_id="src-brain",
+        brain_name="src",
+        exported_at=now,
+        version="1",
+        neurons=[
+            {
+                "id": f"n{i}",
+                "type": "concept",
+                "content": f"neuron {i}",
+                "metadata": {},
+                "created_at": now.isoformat(),
+            }
+            for i in range(neurons)
+        ],
+        synapses=[
+            {
+                "id": f"s{i}",
+                "source_id": "n0",
+                "target_id": "n0",
+                "type": "similar_to",
+                "weight": 1.0,
+                "direction": "forward",
+                "metadata": {},
+                "created_at": now.isoformat(),
+            }
+            for i in range(synapses)
+        ],
+        fibers=[
+            {
+                "id": f"f{i}",
+                "neuron_ids": [],
+                "synapse_ids": [],
+                "anchor_neuron_id": "",
+                "pathway": [],
+                "conductivity": 1.0,
+                "salience": 0.0,
+            }
+            for i in range(fibers)
+        ],
+        config={},
+        metadata={},
+    )
+
+
+def _bare_storage() -> SurrealDBStorage:
+    """Instance without connecting — __init__ needs env; tests only need methods."""
+    store: SurrealDBStorage = object.__new__(SurrealDBStorage)
+    store._current_brain_id = None  # type: ignore[attr-defined]
+    return store
+
+
+@pytest.mark.asyncio
+async def test_import_brain_warns_when_neurons_are_dropped(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _bare_storage()
+    store.set_brain = lambda bid: setattr(store, "_current_brain_id", bid)  # type: ignore[assignment,method-assign]
+    store.save_brain = AsyncMock()  # type: ignore[method-assign]
+
+    calls: dict[str, int] = {"neuron": 0, "synapse": 0, "fiber": 0}
+
+    async def _add_neuron(_neuron: Any) -> None:
+        calls["neuron"] += 1
+        if calls["neuron"] == 2:
+            raise RuntimeError("duplicate id n1")
+
+    async def _add_synapse(_synapse: Any) -> None:
+        calls["synapse"] += 1
+
+    async def _add_fiber(_fiber: Any) -> None:
+        calls["fiber"] += 1
+
+    store.add_neuron = _add_neuron  # type: ignore[method-assign]
+    store.add_synapse = _add_synapse  # type: ignore[method-assign]
+    store.add_fiber = _add_fiber  # type: ignore[method-assign]
+
+    snapshot = _snapshot_with(neurons=3, synapses=1, fibers=1)
+
+    with caplog.at_level(logging.WARNING, logger="surreal_memory.storage.surrealdb.store"):
+        bid = await store.import_brain(snapshot, "restore-test")
+
+    # Interface stays str — no breaking change.
+    assert bid == "restore-test"
+
+    # Fix: the shortfall MUST surface as a warning that names both counts.
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(
+        "neuron" in r.getMessage().lower() and "2" in r.getMessage() and "3" in r.getMessage()
+        for r in warnings
+    ), f"expected 'imported 2 of 3 neurons' warning; got: {[r.getMessage() for r in warnings]}"
+
+
+@pytest.mark.asyncio
+async def test_import_brain_silent_when_everything_lands(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _bare_storage()
+    store.set_brain = lambda bid: setattr(store, "_current_brain_id", bid)  # type: ignore[assignment,method-assign]
+    store.save_brain = AsyncMock()  # type: ignore[method-assign]
+    store.add_neuron = AsyncMock()  # type: ignore[method-assign]
+    store.add_synapse = AsyncMock()  # type: ignore[method-assign]
+    store.add_fiber = AsyncMock()  # type: ignore[method-assign]
+
+    snapshot = _snapshot_with(neurons=2, synapses=1, fibers=1)
+
+    with caplog.at_level(logging.WARNING, logger="surreal_memory.storage.surrealdb.store"):
+        await store.import_brain(snapshot, "clean-brain")
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings == [], f"no drops → no warning; got: {[r.getMessage() for r in warnings]}"


### PR DESCRIPTION
## Summary

- `SurrealDBStorage.import_brain` now counts what each of its three per-record loops actually wrote, and warns with both numbers when the totals disagree, instead of discarding failures silently.
- `smem brain import` reports the destination brain's own counts rather than the size of the file it was given.
- Adds a regression test covering both the shortfall warning and the silence of a clean import.

## Why

`import_brain` wraps each of its three per-record loops — neurons, synapses, fibers — in a bare `except Exception: pass`:

```python
# src/surreal_memory/storage/surrealdb/store.py, import_brain()
for nd in snapshot.neurons:
    try:
        neuron = Neuron(...)
        await self.add_neuron(neuron)
    except Exception:
        pass
```

Anything failing to write during an import therefore vanished: no counter, no log line, nothing in the return value. A duplicate record id is the trivial way in, since `_to_surreal_id` folds a neuron's own id into `neuron:<id>` with no brain component — so importing a snapshot under a fresh `--name` whilst the original brain still holds those ids raises straight into the except.

The two later loops in the *same function*, added for projects and typed memories by #134, already handle this properly with `logger.debug("Skipped unimportable project record", exc_info=True)`. The pattern simply never propagated up to the first three loops.

`smem brain import` compounded it by never asking the storage layer what landed:

```python
# src/surreal_memory/cli/commands/brain.py, brain_import()
await storage.import_brain(snapshot, storage.brain_id)   # return value discarded
...
typer.echo(f"  Neurons: {len(data['neurons'])}")          # the source file, not the destination
```

Exit code 0 and a confident count, even if the destination received nothing. The HTTP route already gets this right — `server/routes/brain.py` calls `storage.get_stats(imported_id)` and reports real numbers — so the CLI was the odd one out on a report the operator is more likely to be reading.

## Changes

- `storage/surrealdb/store.py::import_brain`: per-loop success counters; `logger.debug(..., exc_info=True)` on each swallow, so the exception is no longer thrown away either; and `logger.warning("Imported %d of %d neurons into brain %r; %d dropped", …)` after a loop whose shortfall is non-zero. The warning carries both counts and the target brain id, so the log can be read without the input file to hand.
- `cli/commands/brain.py::brain_import`: captures the returned brain id, calls `storage.get_stats(imported_bid)` in a `try` with `close()` in the `finally`, and prints `neuron_count`, `synapse_count` and `fiber_count` in place of `len(data[...])`.
- `tests/unit/test_surrealdb_import_brain_reports_drops.py` (new, 140 lines): `test_import_brain_warns_when_neurons_are_dropped` swaps `add_neuron` for a callable that raises on its second call and asserts a `WARNING` naming both counts, plus that `import_brain` still returns the target brain id; `test_import_brain_silent_when_everything_lands` asserts no warning when every write succeeds.

## A deliberate choice worth naming

`get_stats` sits in the `try`, not in a `except: pass` of its own. If the verification query fails, `close()` still runs and the command reports the failure rather than falling back to the file-derived numbers. Printing counts that might be wrong is the behaviour this PR exists to remove, so it seemed the wrong place to be forgiving. Say the word if you would rather it degraded to a warning and the old output.

The return type stays `str`. `NeuralStorage.import_brain -> str` in `storage/base.py`, the HTTP route, and `InMemoryBrainMixin.import_brain` (which never had this bug — it has no per-record `try/except` at all) are all untouched. This is a report-loudly change, not an interface change.

## Not touched, on purpose

- `_to_surreal_id`. The `neuron:<id>` folding is *why* collisions are easy, but re-scoping ids by brain reaches every read and write path, the snapshot format and the dashboard queries, and would invalidate every existing brain on disk. That is a separate conversation; this PR only stops the drops being silent.
- Raising on a shortfall. The storage layer now warns and the CLI now prints the true counts; whether a partial import should be a hard failure is a policy call for the caller.

## Test plan

- [x] `pytest tests/unit/test_surrealdb_import_brain_reports_drops.py` — 2 passed.
- [x] With both source files reverted to `main` and the new test kept, it fails on `AssertionError: expected 'imported 2 of 3 neurons' warning; got: []`, whilst `test_import_brain_silent_when_everything_lands` still passes — so the pair measures this change rather than itself.
- [x] `pytest tests/ -m "not stress" -n 4` against a live SurrealDB v3.2.0 — 7285 passed, 48 skipped, 1 xfailed, which is `main`'s 7283 plus exactly the two tests added here. Two tests in `tests/unit/test_dashboard_brains_scope.py` fail on this branch and on `main` alike: they want a live database and collide with one another under `-n`. Both pass when that file is run on its own.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 740 files already formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 354 source files.
- [x] Coverage under the CI gate: 72.40%, against 72.36% on `main`.
- [ ] `CHANGELOG.md` untouched — left to the release entry, as with #191–#193.

The CLI change itself has no test. The report is three `typer.echo` lines over a dict the storage layer already covers, and the existing `brain import` tests do not drive a live backend; adding a harness for it looked disproportionate to three print statements. Happy to add one if you would rather it were pinned.

## Related issues

None filed; this is the fix rather than the report. The nearest neighbour is issue #174, which described the identical *shape* — a bare `except: pass` swallowing a write — in `add_neuron`'s own `neuron_state` insert. #134 added the logging loops for projects and typed memories in this same function. Neither covers these three loops. I searched issues and pull requests for `import_brain`, `brain import`, `silent`, `collision`, `duplicate id` and `swallow` without finding anything else on it.

## Verified by

@RobertSigmundsson
