### PR TITLE
fix(cli): listing previews show essence for GRAPH_ONLY anchors; tombstone literal becomes a shared constant

### DIFF
--- a/src/surreal_memory/cli/commands/listing.py
+++ b/src/surreal_memory/cli/commands/listing.py
@@ -8,10 +8,42 @@ from typing import Annotated, Any
 import typer
 
 from surreal_memory.cli._helpers import get_config, get_storage, output_result, run_async
+from surreal_memory.core.constants import GRAPH_ONLY_PLACEHOLDER
 from surreal_memory.core.memory_types import MemoryType, Priority
 from surreal_memory.safety.freshness import evaluate_freshness, format_age
 
 logger = logging.getLogger(__name__)
+
+
+async def _fiber_preview_content(fiber: Any, storage: Any) -> str:
+    """Preview text for a fiber: ``summary → anchor.content → essence``.
+
+    Behaviour-preserving over the previous two-step chain
+    (``summary → anchor.content``) for every case except one: when the anchor
+    has been reduced to the ``GRAPH_ONLY`` compression sentinel
+    (``"[graph-only]"``) the helper falls through to ``fiber.essence``.
+    ``_essence_backfill`` in ``engine/consolidation.py`` may have generated a
+    real essence from the anchor's original content before compression ran,
+    so the tombstone is precisely the case where essence is the correct thing
+    to render.
+
+    Kept in this module (rather than folded into ``adapters/langchain.py``'s
+    ``_page_content``) because langchain's helper uses a different order
+    (``anchor → summary → essence``) tuned for retrieval, and unifying the
+    two would change ``smem list``'s user-visible behaviour beyond the
+    scope of this fix.
+    """
+    if fiber.summary:
+        return str(fiber.summary)
+    if fiber.anchor_neuron_id:
+        anchor = await storage.get_neuron(fiber.anchor_neuron_id)
+        if anchor is not None:
+            content = getattr(anchor, "content", None)
+            if content and content != GRAPH_ONLY_PLACEHOLDER:
+                return str(content)
+    if fiber.essence:
+        return str(fiber.essence)
+    return ""
 
 
 def list_memories(
@@ -87,14 +119,7 @@ def list_memories(
             memories_data = []
             for tm in expired_memories[:limit]:
                 fiber = await storage.get_fiber(tm.fiber_id)
-                content = ""
-                if fiber:
-                    if fiber.summary:
-                        content = fiber.summary
-                    elif fiber.anchor_neuron_id:
-                        anchor = await storage.get_neuron(fiber.anchor_neuron_id)
-                        if anchor:
-                            content = anchor.content
+                content = await _fiber_preview_content(fiber, storage) if fiber else ""
 
                 memories_data.append(
                     {
@@ -130,11 +155,7 @@ def list_memories(
             fibers = await storage.get_fibers(limit=limit)
             memories_data = []
             for fiber in fibers:
-                content = fiber.summary or ""
-                if not content and fiber.anchor_neuron_id:
-                    anchor = await storage.get_neuron(fiber.anchor_neuron_id)
-                    if anchor:
-                        content = anchor.content
+                content = await _fiber_preview_content(fiber, storage)
 
                 freshness = evaluate_freshness(fiber.created_at)
                 memories_data.append(
@@ -160,14 +181,7 @@ def list_memories(
         memories_data = []
         for tm in typed_memories:
             fiber = await storage.get_fiber(tm.fiber_id)
-            content = ""
-            if fiber:
-                if fiber.summary:
-                    content = fiber.summary
-                elif fiber.anchor_neuron_id:
-                    anchor = await storage.get_neuron(fiber.anchor_neuron_id)
-                    if anchor:
-                        content = anchor.content
+            content = await _fiber_preview_content(fiber, storage) if fiber else ""
 
             freshness = evaluate_freshness(tm.created_at)
             expiry_info = None
@@ -336,14 +350,8 @@ def cleanup(
         to_delete = []
         for tm in expired_memories:
             fiber = await storage.get_fiber(tm.fiber_id)
-            content = ""
-            if fiber:
-                if fiber.summary:
-                    content = fiber.summary[:50]
-                elif fiber.anchor_neuron_id:
-                    anchor = await storage.get_neuron(fiber.anchor_neuron_id)
-                    if anchor:
-                        content = anchor.content[:50]
+            full_content = await _fiber_preview_content(fiber, storage) if fiber else ""
+            content = full_content[:50]
 
             to_delete.append(
                 {

--- a/src/surreal_memory/core/constants.py
+++ b/src/surreal_memory/core/constants.py
@@ -1,0 +1,12 @@
+"""Shared string constants.
+
+``GRAPH_ONLY_PLACEHOLDER`` is the anchor-content tombstone the compression
+engine writes when a fiber is reduced to the GRAPH_ONLY tier (see the
+``contents_refreshed(..., "[graph-only]", ...)`` call in
+``engine/compression.py``). Previously the literal appeared fourteen times
+across eight files — a rename in one place silently broke every other check,
+which is exactly what this constant exists to make loud (follow-up on the
+#193 review).
+"""
+
+GRAPH_ONLY_PLACEHOLDER = "[graph-only]"

--- a/src/surreal_memory/engine/compression.py
+++ b/src/surreal_memory/engine/compression.py
@@ -26,6 +26,7 @@ from datetime import datetime
 from enum import IntEnum, StrEnum
 from typing import TYPE_CHECKING, Any
 
+from surreal_memory.core.constants import GRAPH_ONLY_PLACEHOLDER
 from surreal_memory.utils.content_refresh import content_refreshed, contents_refreshed
 from surreal_memory.utils.timeutils import ensure_naive_utc, utcnow
 
@@ -728,7 +729,7 @@ class CompressionEngine:
             brain_id = self._storage.current_brain_id or ""
             now_iso = utcnow().isoformat()
             for neuron in neurons.values():
-                if neuron.content and neuron.content != "[graph-only]":
+                if neuron.content and neuron.content != GRAPH_ONLY_PLACEHOLDER:
                     try:
                         await self._storage.save_neuron_snapshot(
                             neuron_id=neuron.id,
@@ -750,10 +751,10 @@ class CompressionEngine:
             # Neurons already carrying the placeholder with the sentinel hash
             # are done - re-deriving their fields would only spend a provider
             # call on a known result.
-            pending_clear = [n for n in neurons.values() if n.content != "[graph-only]"]
+            pending_clear = [n for n in neurons.values() if n.content != GRAPH_ONLY_PLACEHOLDER]
             # The placeholder is a tombstone, not content, so it gets the
             # codebase's "no meaningful fingerprint" sentinel rather than
-            # simhash("[graph-only]"). That SimHash is one constant for every
+            # simhash(GRAPH_ONLY_PLACEHOLDER). That SimHash is one constant for every
             # graph-only anchor, and the consolidation census compares anchors
             # by Hamming distance - identical fingerprints would read as a
             # near-duplicate pair and persist a false "duplicate of" edge
@@ -761,7 +762,7 @@ class CompressionEngine:
             refreshed = [
                 dc_replace(n, content_hash=0)
                 for n in await contents_refreshed(
-                    self._storage, [(n, "[graph-only]") for n in pending_clear], brain=brain
+                    self._storage, [(n, GRAPH_ONLY_PLACEHOLDER) for n in pending_clear], brain=brain
                 )
             ]
             # Tombstones written before this change carry the SimHash of their
@@ -771,7 +772,7 @@ class CompressionEngine:
             refreshed.extend(
                 dc_replace(n, content_hash=0)
                 for n in neurons.values()
-                if n.content == "[graph-only]" and n.content_hash != 0
+                if n.content == GRAPH_ONLY_PLACEHOLDER and n.content_hash != 0
             )
             for cleared in refreshed:
                 try:

--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -20,6 +20,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from surreal_memory.core.constants import GRAPH_ONLY_PLACEHOLDER
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.synapse import Synapse, SynapseType
@@ -2517,7 +2518,7 @@ class ConsolidationEngine:
             # near-duplicate-match a genuine memory and persist a false ALIAS
             # edge. Guard on content like every other fingerprint consumer;
             # tombstones stamped with the sentinel are already skipped above.
-            if anchor_a.content == "[graph-only]":
+            if anchor_a.content == GRAPH_ONLY_PLACEHOLDER:
                 continue
 
             for anchor_b in anchors[i + 1 :]:
@@ -2525,7 +2526,7 @@ class ConsolidationEngine:
                     continue
                 if anchor_b.content_hash is None or anchor_b.content_hash == 0:
                     continue
-                if anchor_b.content == "[graph-only]":
+                if anchor_b.content == GRAPH_ONLY_PLACEHOLDER:
                     continue
 
                 if is_near_duplicate(

--- a/src/surreal_memory/engine/dedup/pipeline.py
+++ b/src/surreal_memory/engine/dedup/pipeline.py
@@ -9,6 +9,7 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from surreal_memory.core.constants import GRAPH_ONLY_PLACEHOLDER
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.engine.dedup.config import DedupConfig
 from surreal_memory.utils.simhash import hamming_distance, simhash
@@ -131,7 +132,7 @@ class DedupPipeline:
         # Filter to anchor neurons only. GRAPH_ONLY tombstones are excluded
         # here, ahead of every tier: legacy ones still carry the SimHash of
         # their DELETED text, so tier 1 could canonicalise a brand-new memory
-        # onto a tombstone - the new fiber would anchor to "[graph-only]" and
+        # onto a tombstone - the new fiber would anchor to GRAPH_ONLY_PLACEHOLDER and
         # its text survive only as an alias neuron. (The FTS analyzer happily
         # tokenises the placeholder into "graph"/"only", so tombstones do turn
         # up in this candidate search.) Same guard the census uses.
@@ -140,7 +141,7 @@ class DedupPipeline:
             for n in candidates
             if n.metadata.get("is_anchor", False)
             and n.type == NeuronType.CONCEPT
-            and n.content != "[graph-only]"
+            and n.content != GRAPH_ONLY_PLACEHOLDER
         ]
 
     def _tier1_simhash(

--- a/src/surreal_memory/engine/interference.py
+++ b/src/surreal_memory/engine/interference.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import TYPE_CHECKING
 
+from surreal_memory.core.constants import GRAPH_ONLY_PLACEHOLDER
 from surreal_memory.core.synapse import Synapse, SynapseType
 from surreal_memory.utils.simhash import hamming_distance, simhash
 
@@ -119,7 +120,7 @@ async def detect_interference(
         # the same Hamming distance from the new memory, and one save could
         # persist a CONTRADICTS edge to all of them at once. The fallback is
         # for real content that merely lost its hash; a placeholder is not that.
-        if candidate.content == "[graph-only]":
+        if candidate.content == GRAPH_ONLY_PLACEHOLDER:
             continue
 
         cand_hash = candidate.content_hash or simhash(candidate.content)

--- a/src/surreal_memory/engine/pipeline_steps.py
+++ b/src/surreal_memory/engine/pipeline_steps.py
@@ -36,6 +36,7 @@ from dataclasses import replace as dc_replace
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
+from surreal_memory.core.constants import GRAPH_ONLY_PLACEHOLDER
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.memory_types import suggest_memory_type
 from surreal_memory.core.neuron import Neuron, NeuronType
@@ -259,7 +260,7 @@ async def _find_similar_entity(storage: NeuralStorage, text: str) -> Neuron | No
                 # carries the SimHash of its deleted text; reusing it here would
                 # bind the new entity reference to a placeholder. Same guard as
                 # the census and the dedup pipeline.
-                if candidate.content == "[graph-only]":
+                if candidate.content == GRAPH_ONLY_PLACEHOLDER:
                     continue
                 if candidate.content_hash and is_near_duplicate(text_hash, candidate.content_hash):
                     return candidate

--- a/src/surreal_memory/engine/prediction_error.py
+++ b/src/surreal_memory/engine/prediction_error.py
@@ -18,6 +18,7 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from surreal_memory.core.constants import GRAPH_ONLY_PLACEHOLDER
 from surreal_memory.engine.pipeline import PipelineContext
 from surreal_memory.utils.simhash import hamming_distance, simhash
 
@@ -139,7 +140,7 @@ async def compute_surprise_bonus(
         # A GRAPH_ONLY tombstone has no content to be surprised by - and a
         # legacy one still carries the SimHash of its deleted text, which would
         # deflate the novelty of a new memory resembling content that is gone.
-        if neuron.content == "[graph-only]":
+        if neuron.content == GRAPH_ONLY_PLACEHOLDER:
             continue
 
         # Contradiction check

--- a/src/surreal_memory/engine/retrieval.py
+++ b/src/surreal_memory/engine/retrieval.py
@@ -12,6 +12,7 @@ import time
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from surreal_memory.core.constants import GRAPH_ONLY_PLACEHOLDER
 from surreal_memory.core.fiber import Fiber
 from surreal_memory.core.neuron import NeuronType
 from surreal_memory.core.synapse import Synapse, SynapseType
@@ -1472,7 +1473,7 @@ class ReflexPipeline:
             # vectors are identical brain-wide - for a query anywhere near that
             # region they would tie with each other and crowd genuine memories
             # out of the top-k anchor slots. Same skip as semantic discovery.
-            if neuron.content == "[graph-only]":
+            if neuron.content == GRAPH_ONLY_PLACEHOLDER:
                 continue
             stored_embedding = neuron.metadata.get("_embedding")
             if stored_embedding and isinstance(stored_embedding, list):

--- a/src/surreal_memory/engine/semantic_discovery.py
+++ b/src/surreal_memory/engine/semantic_discovery.py
@@ -20,6 +20,7 @@ import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from surreal_memory.core.constants import GRAPH_ONLY_PLACEHOLDER
 from surreal_memory.core.neuron import Neuron, NeuronType
 from surreal_memory.core.synapse import Synapse, SynapseType
 from surreal_memory.engine.edge_identity import deterministic_edge_id
@@ -392,7 +393,7 @@ async def discover_semantic_synapses(
                 # Linking them would persist a false SIMILAR_TO edge on every
                 # consolidation pass; the dedup census skips these anchors for
                 # the same reason (their content_hash carries the 0 sentinel).
-                if n.content == "[graph-only]":
+                if n.content == GRAPH_ONLY_PLACEHOLDER:
                     continue
                 emb = n.metadata.get("_embedding")
                 if emb:

--- a/tests/unit/test_listing_fallback_essence.py
+++ b/tests/unit/test_listing_fallback_essence.py
@@ -1,0 +1,177 @@
+"""Regression: `smem list` and `smem cleanup --dry-run` must not surface the
+`"[graph-only]"` compression sentinel as a memory's preview content.
+
+Four call sites in `cli/commands/listing.py` used a two-step
+`fiber.summary → anchor.content` fallback with no third rung. When a fiber
+was compressed to the `GRAPH_ONLY` tier, `compression.py` overwrites the
+anchor neuron's content with the literal string `"[graph-only]"` — that write
+does NOT clear `fiber.essence`, and `_essence_backfill` in
+`engine/consolidation.py` may have already generated a real essence from
+`anchor.content` before compression ran. Net effect: `smem list` printed
+`[graph-only]` as if it were the memory, and `smem cleanup --dry-run` used
+the same broken preview right before deletion.
+
+The fix adds a helper (`fiber.summary → anchor.content (skipping
+"[graph-only]") → fiber.essence → ""`) and threads it through the four
+sites. Behaviour-preserving for everything else — the only user-visible
+change is that a `GRAPH_ONLY`-compressed fiber now shows its essence
+instead of the tombstone.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from surreal_memory.cli.commands.listing import _fiber_preview_content, list_memories
+
+
+def _fiber(
+    *,
+    summary: str | None = None,
+    essence: str | None = None,
+    anchor_neuron_id: str | None = "n0",
+) -> Any:
+    """Minimal fiber-like object with just the fields the helper reads."""
+    return SimpleNamespace(
+        summary=summary,
+        essence=essence,
+        anchor_neuron_id=anchor_neuron_id,
+    )
+
+
+def _neuron(content: str) -> Any:
+    return SimpleNamespace(content=content)
+
+
+class TestFiberPreviewContent:
+    """The helper used by all four listing.py call sites."""
+
+    @pytest.mark.asyncio
+    async def test_returns_summary_when_present(self) -> None:
+        storage = SimpleNamespace(get_neuron=AsyncMock())
+        fiber = _fiber(summary="short summary", essence="deep essence")
+        result = await _fiber_preview_content(fiber, storage)
+        assert result == "short summary"
+        # Fast-path: don't touch storage if summary already gives us text.
+        storage.get_neuron.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_anchor_content_when_summary_empty(self) -> None:
+        storage = SimpleNamespace(get_neuron=AsyncMock(return_value=_neuron("real anchor text")))
+        fiber = _fiber(summary=None, essence="deep essence")
+        result = await _fiber_preview_content(fiber, storage)
+        assert result == "real anchor text"
+
+    @pytest.mark.asyncio
+    async def test_skips_graph_only_sentinel_and_falls_through_to_essence(self) -> None:
+        """The regression: GRAPH_ONLY compressed anchor + backfilled essence."""
+        storage = SimpleNamespace(get_neuron=AsyncMock(return_value=_neuron("[graph-only]")))
+        fiber = _fiber(summary=None, essence="real human-written essence")
+        result = await _fiber_preview_content(fiber, storage)
+        assert result == "real human-written essence"
+
+    @pytest.mark.asyncio
+    async def test_returns_essence_when_summary_and_anchor_both_empty(self) -> None:
+        storage = SimpleNamespace(get_neuron=AsyncMock(return_value=None))
+        fiber = _fiber(summary=None, essence="only essence available")
+        result = await _fiber_preview_content(fiber, storage)
+        assert result == "only essence available"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_string_when_nothing_available(self) -> None:
+        storage = SimpleNamespace(get_neuron=AsyncMock(return_value=None))
+        fiber = _fiber(summary=None, essence=None)
+        result = await _fiber_preview_content(fiber, storage)
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_skips_lookup_when_no_anchor_neuron_id(self) -> None:
+        """Guard: no anchor_neuron_id → don't hit storage, jump to essence."""
+        storage = SimpleNamespace(get_neuron=AsyncMock())
+        fiber = _fiber(summary=None, essence="essence only", anchor_neuron_id=None)
+        result = await _fiber_preview_content(fiber, storage)
+        assert result == "essence only"
+        storage.get_neuron.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_summary_still_wins_even_if_anchor_is_graph_only(self) -> None:
+        """Behaviour-preserving check: summary path unchanged from before the fix."""
+        storage = SimpleNamespace(get_neuron=AsyncMock())
+        fiber = _fiber(summary="a summary", essence="an essence")
+        result = await _fiber_preview_content(fiber, storage)
+        assert result == "a summary"
+        storage.get_neuron.assert_not_called()
+
+
+class TestListMemoriesCallSites:
+    """The helper is only half the fix — these tests go through the actual
+    `list_memories` call sites. With the call sites reverted to the old
+    two-step chain, both fail (the preview renders the literal tombstone);
+    they exist because an earlier version of this PR's tests measured only
+    the helper in isolation and passed with all four call sites unwired."""
+
+    @staticmethod
+    def _patched_storage(
+        monkeypatch: pytest.MonkeyPatch, *, typed: Any | None, expired: Any | None
+    ) -> Any:
+        import surreal_memory.cli.commands.listing as listing_mod
+
+        storage = SimpleNamespace()
+        if typed is not None:
+            storage.find_typed_memories = AsyncMock(return_value=typed)
+        if expired is not None:
+            storage.get_expired_memories = AsyncMock(return_value=expired)
+        storage.get_fiber = AsyncMock(
+            return_value=SimpleNamespace(
+                summary=None,
+                essence="real human essence",
+                anchor_neuron_id="n1",
+                created_at=datetime(2026, 9, 4, tzinfo=UTC),
+                id="f1",
+            )
+        )
+        storage.get_neuron = AsyncMock(return_value=SimpleNamespace(content="[graph-only]"))
+        monkeypatch.setattr(listing_mod, "get_storage", AsyncMock(return_value=storage))
+        monkeypatch.setattr(listing_mod, "get_config", lambda: SimpleNamespace())
+        return storage
+
+    def test_expired_branch_renders_essence_not_tombstone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
+
+        tm = TypedMemory.create(
+            fiber_id="f1", memory_type=MemoryType.DECISION, priority=Priority.NORMAL, source="t"
+        )
+        self._patched_storage(monkeypatch, typed=None, expired=[tm])
+        import surreal_memory.cli.commands.listing as listing_mod
+
+        echoed: list[str] = []
+        monkeypatch.setattr(listing_mod.typer, "echo", lambda s, **kw: echoed.append(str(s)))
+        list_memories(show_expired=True, json_output=False)
+        assert any("real human essence" in line for line in echoed), (
+            f"expired listing must show the essence, not the tombstone; got {echoed}"
+        )
+
+    def test_typed_branch_renders_essence_not_tombstone(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
+
+        tm = TypedMemory.create(
+            fiber_id="f1", memory_type=MemoryType.DECISION, priority=Priority.NORMAL, source="t"
+        )
+        self._patched_storage(monkeypatch, typed=[tm], expired=None)
+        import surreal_memory.cli.commands.listing as listing_mod
+
+        echoed: list[str] = []
+        monkeypatch.setattr(listing_mod.typer, "echo", lambda s, **kw: echoed.append(str(s)))
+        list_memories(json_output=False)
+        assert any("real human essence" in line for line in echoed), (
+            f"typed-memory listing must show the essence, not the tombstone; got {echoed}"
+        )


### PR DESCRIPTION
## Summary

- `smem list` and `smem cleanup --dry-run` no longer render the `GRAPH_ONLY` tombstone as a memory's preview: the four preview call sites fall through to `fiber.essence` when the anchor holds the placeholder.
- The placeholder literal becomes `core.constants.GRAPH_ONLY_PLACEHOLDER`, imported everywhere it is compared — follow-up 1 from the review on #193.
- Adds nine tests, two of which drive `list_memories` itself rather than the helper in isolation.

## Why

The four call sites in `cli/commands/listing.py` walked the preview fallback only as far as the anchor neuron:

```python
# src/surreal_memory/cli/commands/listing.py — the same shape in all four sites
if fiber.summary:
    content = fiber.summary
elif fiber.anchor_neuron_id:
    anchor = await storage.get_neuron(fiber.anchor_neuron_id)
    if anchor:
        content = anchor.content
# fiber.essence is never consulted
```

That misses precisely the case compression creates. At the `GRAPH_ONLY` tier, `CompressionEngine.compress_fiber` overwrites the anchor's content with the sentinel through its `pending_clear` batch. The write does not touch `fiber.essence`, and `ConsolidationEngine._essence_backfill` may already have produced a real essence from the anchor's original text before compression ran. A fiber with no summary, a tombstoned anchor and a perfectly serviceable essence therefore listed as `[graph-only]` — indistinguishable, to someone skimming, from genuinely cryptic content. `cleanup --dry-run` printed the same unhelpful preview immediately before offering to delete the thing.

## The constant, and the count

Follow-up 1 on the #193 review asked for this directly: the literal had, in the reviewer's count, reached *"fourteen occurrences across eight"* files, every guard comparing against a bare string, so changing the placeholder text in `compression.py` *"would type-check, lint clean, and silently disable every guard"*. All fourteen now import `GRAPH_ONLY_PLACEHOLDER` from `core/constants.py`. The fix above needed a fifteenth comparison in `listing.py`; it imports the constant rather than becoming a ninth file with a literal in it.

The test suite still compares against the raw string in several places. That is deliberate — those are the assertions that ought to fail loudly if the value ever changes, which is the whole point of the exercise.

## Changes

- `core/constants.py` (new): `GRAPH_ONLY_PLACEHOLDER`, with a docstring pointing at the write site.
- `engine/`: `compression.py`, `consolidation.py`, `dedup/pipeline.py`, `interference.py`, `pipeline_steps.py`, `prediction_error.py`, `retrieval.py`, `semantic_discovery.py` — every literal replaced, one import per file.
- `cli/commands/listing.py`: new `_fiber_preview_content(fiber, storage)` helper ordering `fiber.summary` → `anchor.content` (skipping the placeholder) → `fiber.essence` → `""`, used by all four sites: `list_memories`'s expired, fiber-fallback and typed-memory branches, and `cleanup --dry-run`'s preview. The cleanup site still truncates to `[:50]`.
- `tests/unit/test_listing_fallback_essence.py` (new): seven helper-level tests covering each branch and guard, plus `test_expired_branch_renders_essence_not_tombstone` and `test_typed_branch_renders_essence_not_tombstone`, which go through `list_memories` with patched storage and assert on the rendered output.

The helper keeps `summary → anchor → essence` rather than adopting `adapters/langchain.py`'s `anchor → summary → essence`, which is tuned for retrieval. Unifying the two would change what `smem list` shows for every fiber that has both a summary and anchor content — a separate decision from this bug. The helper's docstring records the divergence.

## Not touched, on purpose

- Compression's write of the placeholder. The tombstone is deliberate; only the rendering was wrong.
- `typed_memory.content`, defined in `storage/surrealdb/schema.py` but never written and never read. It came up alongside this bug, but it is a schema question on a `SCHEMALESS` table and unrelated to the preview chain. Happy to raise it separately if it is worth anyone's time.
- `adapters/langchain.py` and `engine/fidelity.py`, which already consult all three fields in orders suited to what they render.

## Test plan

- [x] `pytest tests/unit/test_listing_fallback_essence.py` — 9 passed.
- [x] Differential control, measured the strict way: keeping the helper and reverting **only the four call sites** to the old two-step chain leaves 7 passed and fails both call-site tests, which render `[graph-only]`. An earlier version of this test file passed 7/7 in that state, which is why the two call-site tests exist.
- [x] `pytest tests/unit/test_listing_fallback_essence.py tests/unit/test_compression.py tests/unit/test_consolidation.py` — 119 passed.
- [x] `pytest tests/ -m "not stress" -n 4` against a live SurrealDB v3.2.0 — 7292 passed, 48 skipped, 1 xfailed, which is `main`'s 7283 plus exactly the nine tests added here. Two tests in `tests/unit/test_dashboard_brains_scope.py` fail on this branch and on `main` alike: they want a live database and collide with one another under `-n`. Both pass when that file is run on its own.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 741 files already formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 355 source files, one more than `main` for the new module.
- [x] Coverage under the CI gate: 72.64%, against 72.36% on `main`.
- [ ] `CHANGELOG.md` untouched — left to the release entry, as with #191–#193.

## Related issues

Follow-up 1 from the #193 review is done here. Follow-up 2 from the same review — the unlogged `except` around the brain pre-fetch in `compression.py` — is a separate one-line change and gets its own PR rather than riding along in this diff.

## Verified by

@RobertSigmundsson
