### PR TITLE
fix(storage): address record rows by id, not by a rebuilt string

### DIFF
--- a/src/surreal_memory/storage/surrealdb/_ids.py
+++ b/src/surreal_memory/storage/surrealdb/_ids.py
@@ -45,6 +45,28 @@ def _to_surreal_id(record_id: str) -> str:
     )
 
 
+def _record_id_part(record_id: str) -> str:
+    """Bare id part of a record id, as ``_to_surreal_id`` would have produced it.
+
+    The inverse direction of the choke point above, and the reason it belongs
+    here rather than being spelled out per mixin: SurrealDB renders a record id
+    whose id part contains **no letter** in its quoted form —
+    ``alerts:⟨1122334455667788⟩`` — and a plain ``split(":")[-1]`` hands those
+    guillemets back to the caller. Feeding that back into ``_to_surreal_id``
+    maps them to underscores, so the id no longer addresses its own row: the
+    lookup misses and the caller is told the record does not exist.
+
+    Measured on SurrealDB 3.2.0: the quoted form appears for ``0001``,
+    ``1122334455667788``, ``12_34`` and ``_123``, but not for ``a1``,
+    ``123abc``, ``1_2a`` or ``_a1`` — i.e. exactly when the id carries no
+    letter. Ids minted as ``str(uuid4())`` almost always carry one; ids minted
+    as ``uuid4().hex[:16]`` (alerts) are letter-free about once in 1150.
+    """
+    if ":" in record_id:
+        record_id = record_id.rsplit(":", 1)[1]
+    return record_id.strip("⟨⟩`")
+
+
 def _safe_brain_id(brain_id: str) -> str:
     """Validate a brain id before it is inlined raw into a record id / SurQL.
 

--- a/src/surreal_memory/storage/surrealdb/alerts.py
+++ b/src/surreal_memory/storage/surrealdb/alerts.py
@@ -1,4 +1,25 @@
-"""SurrealDB alerts storage mixin."""
+"""SurrealDB alerts storage mixin.
+
+Single-alert lookups bind the *sanitised* id and rebuild the record id inside
+SurrealQL with ``type::record('alerts', $sid)``. Comparing ``id`` against a
+plain ``"alerts:<sid>"`` string is not a slower spelling of the same thing —
+``id`` holds a record id, so the predicate is unconditionally false and the row
+can never match. That silently disabled ``mark_alerts_seen``,
+``mark_alert_acknowledged`` and ``get_alert``. ``resolve_alerts_by_type`` was
+unaffected because it reuses the ``id`` value its own SELECT returned. Same
+lesson, same shape as the ``typed_memory`` / ``fiber`` lookups in this package.
+
+The writes then reuse that same ``id`` object rather than rebuilding
+``f"alerts:{sid}"``. Rebuilding it looks equivalent and is not: an all-digit
+sid (``uuid4().hex[:16]`` is all digits about once in 1150 — character 12 is
+always the version nibble ``4``, so only fifteen of the sixteen are random)
+round-trips
+through the SDK as a *numeric* record id, while ``record_alert`` stored a
+*string* one — so the SELECT would find the row and the merge would write to a
+different, empty record, and the call would report success having changed
+nothing. Reading the id back from the query is the only spelling that cannot
+drift from the row that was actually matched.
+"""
 
 from __future__ import annotations
 
@@ -7,7 +28,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from surreal_memory.core.alert import Alert, AlertStatus, AlertType
-from surreal_memory.storage.surrealdb._ids import _to_surreal_id
+from surreal_memory.storage.surrealdb._ids import _record_id_part, _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
@@ -34,8 +55,7 @@ def _parse_datetime(val: Any) -> datetime | None:
 def _row_to_alert(row: dict[str, Any]) -> Alert:
     """Convert a SurrealDB record to an Alert dataclass."""
     metadata = dict(row.get("metadata") or {})
-    raw_id = str(row.get("id", ""))
-    alert_id = raw_id.split(":")[-1] if ":" in raw_id else raw_id
+    alert_id = _record_id_part(str(row.get("id", "")))
 
     return Alert(
         id=alert_id,
@@ -107,9 +127,15 @@ class SurrealDBAlertsMixin:
             await conn.insert("alerts", record_data)
         except Exception:
             try:
-                await conn.delete(f"alerts:{sid}")
+                # Not conn.delete(f"alerts:{sid}"): an all-digit sid goes back
+                # through the SDK as a numeric record id, so that call deletes a
+                # different (absent) record, raises nothing, and leaves the
+                # clashing row in place — the retry below then fails the same
+                # way. Rebuilding the id in SurrealQL keeps it a string, which
+                # is what the insert above stored.
+                await self._query("DELETE type::record('alerts', $sid)", sid=sid)
             except Exception:
-                pass
+                logger.debug("alert insert retry: delete of the clashing row failed")
             await conn.insert("alerts", record_data)
 
         return alert.id
@@ -160,17 +186,17 @@ class SurrealDBAlertsMixin:
         updated = 0
 
         for aid in alert_ids:
-            sid = _to_surreal_id(aid)
             existing = await self._query(
                 "SELECT id FROM alerts"
-                " WHERE brain_id = $brain_id AND id = $rid AND status = 'active' LIMIT 1",
+                " WHERE brain_id = $brain_id AND id = type::record('alerts', $sid)"
+                " AND status = 'active' LIMIT 1",
                 brain_id=brain_id,
-                rid=f"alerts:{sid}",
+                sid=_to_surreal_id(aid),
             )
             if not existing:
                 continue
             await conn.merge(
-                f"alerts:{sid}",
+                existing[0]["id"],
                 {"status": AlertStatus.SEEN.value, "seen_at": now},
             )
             updated += 1
@@ -179,21 +205,20 @@ class SurrealDBAlertsMixin:
     async def mark_alert_acknowledged(self, alert_id: str) -> bool:
         """Mark a single alert as acknowledged. Returns True if updated."""
         brain_id = self._get_brain_id()
-        sid = _to_surreal_id(alert_id)
 
         existing = await self._query(
             "SELECT id FROM alerts"
-            " WHERE brain_id = $brain_id AND id = $rid"
+            " WHERE brain_id = $brain_id AND id = type::record('alerts', $sid)"
             " AND status IN ['active', 'seen'] LIMIT 1",
             brain_id=brain_id,
-            rid=f"alerts:{sid}",
+            sid=_to_surreal_id(alert_id),
         )
         if not existing:
             return False
 
         conn = self._ensure_conn()
         await conn.merge(
-            f"alerts:{sid}",
+            existing[0]["id"],
             {"status": AlertStatus.ACKNOWLEDGED.value, "acknowledged_at": utcnow()},
         )
         return True
@@ -236,9 +261,10 @@ class SurrealDBAlertsMixin:
         sid = _to_surreal_id(alert_id)
 
         rows = await self._query(
-            "SELECT * FROM alerts WHERE brain_id = $brain_id AND id = $rid LIMIT 1",
+            "SELECT * FROM alerts WHERE brain_id = $brain_id"
+            " AND id = type::record('alerts', $sid) LIMIT 1",
             brain_id=brain_id,
-            rid=f"alerts:{sid}",
+            sid=sid,
         )
         if not rows:
             return None

--- a/src/surreal_memory/storage/surrealdb/cognitive.py
+++ b/src/surreal_memory/storage/surrealdb/cognitive.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import Any
 from uuid import uuid4
 
-from surreal_memory.storage.surrealdb._ids import _to_surreal_id
+from surreal_memory.storage.surrealdb._ids import _record_id_part, _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
@@ -188,9 +188,11 @@ class SurrealDBCognitiveMixin:
             return
 
         conn = self._ensure_conn()
-        sid = f"{_to_surreal_id(brain_id)}_{_to_surreal_id(neuron_id)}"
+        # Merge by the id the SELECT above returned, for the same reason the
+        # upsert path does: a recomputed sid misses a row whose id still carries
+        # an older brain prefix, and the merge then silently writes nothing.
         await conn.merge(
-            f"cognitive_state:{sid}",
+            existing[0]["id"],
             {
                 "confidence": _clamp_confidence(confidence),
                 "evidence_for_count": int(evidence_for_count),
@@ -391,7 +393,7 @@ class SurrealDBCognitiveMixin:
         results: list[dict[str, Any]] = []
         for r in rows:
             raw_id = str(r.get("id", ""))
-            gap_id = raw_id.split(":")[-1] if ":" in raw_id else raw_id
+            gap_id = _record_id_part(raw_id)
             results.append(
                 {
                     "id": gap_id,
@@ -411,12 +413,18 @@ class SurrealDBCognitiveMixin:
         sid = _to_surreal_id(gap_id)
 
         rows = await self._query(
+            # Rebuild the record id in SurrealQL rather than comparing `id`
+            # with a "knowledge_gaps:<sid>" *string*: `id` holds a record id,
+            # so the string form is unconditionally false and this lookup
+            # returned None for every gap that existed. Same trap as the
+            # typed_memory / fiber / alerts lookups in this package.
             "SELECT id, topic, detected_at, detection_source,"
             " related_neuron_ids, resolved_at, resolved_by_neuron_id, priority"
             " FROM knowledge_gaps"
-            " WHERE brain_id = $brain_id AND id = $rid LIMIT 1",
+            " WHERE brain_id = $brain_id AND id = type::record('knowledge_gaps', $sid)"
+            " LIMIT 1",
             brain_id=brain_id,
-            rid=f"knowledge_gaps:{sid}",
+            sid=sid,
         )
         if not rows:
             return None
@@ -424,7 +432,7 @@ class SurrealDBCognitiveMixin:
         r = rows[0]
         raw_id = str(r.get("id", ""))
         return {
-            "id": raw_id.split(":")[-1] if ":" in raw_id else raw_id,
+            "id": _record_id_part(raw_id),
             "topic": str(r.get("topic", "")),
             "detected_at": _parse_datetime(r.get("detected_at")),
             "detection_source": str(r.get("detection_source", "")),
@@ -445,16 +453,17 @@ class SurrealDBCognitiveMixin:
 
         existing = await self._query(
             "SELECT id FROM knowledge_gaps"
-            " WHERE brain_id = $brain_id AND id = $rid AND resolved_at IS NONE LIMIT 1",
+            " WHERE brain_id = $brain_id AND id = type::record('knowledge_gaps', $sid)"
+            " AND resolved_at IS NONE LIMIT 1",
             brain_id=brain_id,
-            rid=f"knowledge_gaps:{sid}",
+            sid=sid,
         )
         if not existing:
             return False
 
         conn = self._ensure_conn()
         await conn.merge(
-            f"knowledge_gaps:{sid}",
+            existing[0]["id"],
             {
                 "resolved_at": utcnow(),
                 "resolved_by_neuron_id": resolved_by_neuron_id,

--- a/src/surreal_memory/storage/surrealdb/versions.py
+++ b/src/surreal_memory/storage/surrealdb/versions.py
@@ -1,4 +1,12 @@
-"""SurrealDB versions storage mixin (compressed brain snapshots)."""
+"""SurrealDB versions storage mixin (compressed brain snapshots).
+
+Single-version lookups rebuild the record id in SurrealQL with
+``type::record('brain_versions', $sid)``. Comparing ``id`` with a
+``"brain_versions:<sid>"`` *string* is unconditionally false — ``id`` holds a
+record id — so ``get_version`` and ``delete_version`` could never find a row,
+and every restore/diff path in ``engine/brain_versioning.py`` saw an empty
+result. Same trap as the ``typed_memory`` / ``alerts`` lookups in this package.
+"""
 
 from __future__ import annotations
 
@@ -11,7 +19,7 @@ from datetime import datetime
 from typing import Any
 
 from surreal_memory.engine.brain_versioning import BrainVersion
-from surreal_memory.storage.surrealdb._ids import _to_surreal_id
+from surreal_memory.storage.surrealdb._ids import _record_id_part, _to_surreal_id
 from surreal_memory.utils.timeutils import utcnow
 
 logger = logging.getLogger(__name__)
@@ -62,7 +70,7 @@ def _row_to_version(row: dict[str, Any]) -> BrainVersion:
         metadata = dict(metadata_raw or {})
 
     raw_id = str(row.get("id", ""))
-    vid = raw_id.split(":")[-1] if ":" in raw_id else raw_id
+    vid = _record_id_part(raw_id)
 
     return BrainVersion(
         id=vid,
@@ -121,9 +129,14 @@ class SurrealDBVersionsMixin:
             await conn.insert("brain_versions", record_data)
         except Exception:
             try:
-                await conn.delete(f"brain_versions:{sid}")
+                # Rebuild the id in SurrealQL rather than handing the SDK a
+                # "brain_versions:<sid>" string: a letter-free sid comes back
+                # as a *numeric* record id there, so the delete would clear a
+                # different, absent record without raising, and the retry below
+                # would hit the same collision. See _ids._record_id_part.
+                await self._query("DELETE type::record('brain_versions', $sid)", sid=sid)
             except Exception:
-                pass
+                logger.debug("version insert retry: delete of the clashing row failed")
             await conn.insert("brain_versions", record_data)
 
     async def get_version(
@@ -134,9 +147,10 @@ class SurrealDBVersionsMixin:
         """Get a version and its decompressed snapshot JSON by ID."""
         sid = _to_surreal_id(version_id)
         rows = await self._query(
-            "SELECT * FROM brain_versions WHERE brain_id = $brain_id AND id = $rid LIMIT 1",
+            "SELECT * FROM brain_versions WHERE brain_id = $brain_id"
+            " AND id = type::record('brain_versions', $sid) LIMIT 1",
             brain_id=brain_id,
-            rid=f"brain_versions:{sid}",
+            sid=sid,
         )
         if not rows:
             return None
@@ -181,16 +195,21 @@ class SurrealDBVersionsMixin:
         """Delete a specific version. Returns True if a row was deleted."""
         sid = _to_surreal_id(version_id)
         existing = await self._query(
-            "SELECT id FROM brain_versions WHERE brain_id = $brain_id AND id = $rid LIMIT 1",
+            "SELECT id FROM brain_versions WHERE brain_id = $brain_id"
+            " AND id = type::record('brain_versions', $sid) LIMIT 1",
             brain_id=brain_id,
-            rid=f"brain_versions:{sid}",
+            sid=sid,
         )
         if not existing:
             return False
 
         conn = self._ensure_conn()
-        rid = str(existing[0].get("id", ""))
+        rid = existing[0].get("id")
         if not rid:
             return False
+        # The id object the query returned, rather than an id rebuilt from
+        # ``sid``: a letter-free sid rebuilt as ``f"brain_versions:{sid}"``
+        # parses as a *numeric* record id and addresses a different, absent
+        # row -- the delete then reports success having removed nothing.
         await conn.delete(rid)
         return True

--- a/tests/unit/_surrealdb_live.py
+++ b/tests/unit/_surrealdb_live.py
@@ -50,6 +50,8 @@ LIVE_TEST_BRAIN_NAMES = frozenset(
         "kw-df-batch-live-4b8d2e",  # test_surrealdb_keyword_df_live.py
         "zz-dashboard-brains-scope-live",  # test_dashboard_brains_scope.py (list_brains_api)
         "zz-dashboard-stats-scope-live",  # test_dashboard_brains_scope.py (get_stats)
+        "alerts-recordid-live",  # test_surrealdb_alerts_recordid_live.py
+        "record-id-lookups-live",  # test_surrealdb_record_id_lookups_live.py
     }
 )
 

--- a/tests/unit/test_surrealdb_alerts_recordid_live.py
+++ b/tests/unit/test_surrealdb_alerts_recordid_live.py
@@ -1,0 +1,284 @@
+"""Live-DB proof that the alert lookups compare against a record id, not a string.
+
+``alerts.py`` used to bind ``rid=f"alerts:{sid}"`` — a *string* — and compare it
+with ``id = $rid``. On SurrealDB the left side is a record id, so the predicate
+is unconditionally false and the row can never match. Three lookups sat behind
+that predicate and all three were structurally dead:
+
+* ``mark_alerts_seen``      — an alert could never leave ``active``.
+* ``mark_alert_acknowledged`` — acknowledging silently reported "not found".
+* ``get_alert``             — reading a single alert always returned ``None``.
+
+``resolve_alerts_by_type`` was already correct (it reuses the ``id`` returned by
+its own query) and is covered here as the *positive control*: if it also failed,
+the fixture would be broken rather than the predicate.
+
+Every status assertion re-reads the row with a ``brain_id``-only query and
+matches in Python, so the check never leans on the very construct under test.
+Skipped unless ``SURREALDB_URL`` points at a running SurrealDB.
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import uuid4
+
+import pytest
+
+from surreal_memory.core.alert import Alert, AlertStatus, AlertType
+from surreal_memory.core.brain import Brain
+from surreal_memory.storage.surrealdb._ids import _to_surreal_id
+from surreal_memory.utils.timeutils import utcnow
+from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
+
+SURREALDB_URL = os.getenv("SURREALDB_URL")
+
+pytestmark = pytest.mark.skipif(
+    not SURREALDB_URL,
+    reason="requires SURREALDB_URL pointing to a running SurrealDB",
+)
+
+BRAIN_NAME = "alerts-recordid-live"
+
+
+@pytest.fixture
+async def storage():  # type: ignore[no-untyped-def]
+    ensure_real_surrealdb_sdk()
+    from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+    store = SurrealDBStorage(url=SURREALDB_URL)
+    await store.initialize()
+    brain = Brain.create(name=BRAIN_NAME)
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    yield store
+
+    try:
+        await cleanup_live_brains(store, own_brain_id=brain.id)
+    finally:
+        await store.close()
+
+
+async def _seed(store, alert_id: str, alert_type: AlertType = AlertType.STALE_FIBERS):  # type: ignore[no-untyped-def]
+    """Persist one active alert and assert it really landed (positive control)."""
+    alert = Alert(
+        id=alert_id,
+        brain_id=store._get_brain_id(),
+        alert_type=alert_type,
+        severity="medium",
+        message=f"recordid-live {alert_id}",
+        recommended_action="none",
+        status=AlertStatus.ACTIVE,
+        created_at=utcnow(),
+    )
+    assert await store.record_alert(alert) == alert_id
+    assert await _status_of(store, alert_id) == "active", "seeding did not persist the alert"
+    return alert
+
+
+async def _status_of(store, alert_id: str) -> str | None:  # type: ignore[no-untyped-def]
+    """Status straight from the DB, found without an ``id = ...`` predicate.
+
+    Deliberately brain-scoped only: using ``type::record`` here would make the
+    verification share the fix's own construct, and the test would pass for the
+    wrong reason if the construct were wrong.
+
+    The comparison is on the *sanitised* id, because that is what a record id
+    actually holds ('-' is not a legal record-name character). Matching on the
+    caller's raw id instead makes the dashed-uuid case fail inside this helper —
+    a broken probe, not a broken lookup.
+    """
+    rows = await store._query(
+        "SELECT id, status FROM alerts WHERE brain_id = $brain_id",
+        brain_id=store._get_brain_id(),
+    )
+    want = _to_surreal_id(alert_id)
+    for row in rows:
+        if str(row.get("id")).split(":", 1)[-1].strip("⟨⟩") == want:
+            return str(row.get("status"))
+    return None
+
+
+async def test_get_alert_finds_the_alert_it_just_stored(storage) -> None:  # type: ignore[no-untyped-def]
+    alert_id = uuid4().hex[:16]
+    await _seed(storage, alert_id)
+
+    found = await storage.get_alert(alert_id)
+
+    assert found is not None, "get_alert returned None for an alert that exists"
+    assert found.id == alert_id
+    assert found.status == AlertStatus.ACTIVE
+
+
+async def test_mark_alerts_seen_moves_the_row_out_of_active(storage) -> None:  # type: ignore[no-untyped-def]
+    alert_id = uuid4().hex[:16]
+    await _seed(storage, alert_id)
+
+    updated = await storage.mark_alerts_seen([alert_id])
+
+    assert updated == 1, "mark_alerts_seen reported no rows for an active alert"
+    # The return value is a claim; the row is the fact.
+    assert await _status_of(storage, alert_id) == "seen"
+
+
+async def test_mark_alert_acknowledged_persists_the_status(storage) -> None:  # type: ignore[no-untyped-def]
+    alert_id = uuid4().hex[:16]
+    await _seed(storage, alert_id)
+
+    assert await storage.mark_alert_acknowledged(alert_id) is True
+    assert await _status_of(storage, alert_id) == "acknowledged"
+
+
+async def test_lookups_work_for_a_dashed_uuid_id(storage) -> None:  # type: ignore[no-untyped-def]
+    """Ids are sanitised ('-' → '_') before becoming a record id.
+
+    The production alert id is a bare hex slug, so a fix that forgot the
+    sanitisation step would still pass the tests above. A dashed uuid makes the
+    stored record id differ from the caller's id and pins that half down.
+
+    What comes back is the *stored* id, not the caller's spelling: the alerts
+    table keeps no separate raw-id field, so the record id is the only identity
+    there is. That is not a leak in the round trip for real callers —
+    ``AlertHandler`` mints ``uuid4().hex[:16]`` (already in the record-name
+    charset) and every id it later acknowledges came out of
+    ``get_active_alerts``, i.e. already sanitised, and ``_to_surreal_id`` is
+    idempotent on that form.
+    """
+    alert_id = str(uuid4())
+    assert "-" in alert_id
+    await _seed(storage, alert_id, AlertType.HIGH_ORPHAN_RATIO)
+
+    found = await storage.get_alert(alert_id)
+    assert found is not None, "get_alert cannot resolve a dashed uuid alert id"
+    assert found.id == _to_surreal_id(alert_id)
+    assert _to_surreal_id(found.id) == found.id, "the returned id must be a fixed point"
+
+    assert await storage.mark_alert_acknowledged(alert_id) is True
+    assert await _status_of(storage, alert_id) == "acknowledged"
+    # And the sanitised spelling resolves too, which is the form a caller
+    # actually receives from get_active_alerts.
+    assert await storage.get_alert(found.id) is not None
+
+
+async def test_unknown_ids_are_still_reported_as_missing(storage) -> None:  # type: ignore[no-untyped-def]
+    """Negative control: the fix must not turn the predicate into a no-op.
+
+    ``type::record`` on an id that was never stored has to keep matching
+    nothing — otherwise every assertion above would pass for a fix that simply
+    dropped the id filter.
+
+    The brain must NOT be empty for that to mean anything: against an empty
+    table a lookup with no id filter also returns nothing, and this test would
+    pass for a build with the filter deleted. One decoy alert is what makes the
+    control discriminate.
+    """
+    decoy = uuid4().hex[:16]
+    await _seed(storage, decoy)
+    missing = uuid4().hex[:16]
+
+    assert await storage.get_alert(missing) is None
+    assert await storage.mark_alert_acknowledged(missing) is False
+    assert await storage.mark_alerts_seen([missing]) == 0
+
+    # The decoy must be untouched: a lookup that ignored the id would have
+    # matched it and moved it out of 'active'.
+    assert await _status_of(storage, decoy) == "active"
+
+
+async def test_an_all_digit_id_updates_the_row_it_matched(storage) -> None:  # type: ignore[no-untyped-def]
+    """A write must target the row the SELECT matched, not a rebuilt id.
+
+    ``record_alert`` stores the id as a *string* record id. Rebuilding
+    ``f"alerts:{sid}"`` for the write sends an all-digit sid back through the
+    SDK as a *numeric* record id — a different record. The row stays put while
+    the call reports success, which is worse than the bug being fixed here:
+    before it at least returned False. ``uuid4().hex[:16]`` is all digits
+    roughly once in 1150 alerts, so this is reachable, not theoretical.
+    """
+    all_digits = "9" + "".join(str(int(c, 16) % 10) for c in uuid4().hex[:15])
+    assert all_digits.isdigit()
+    await _seed(storage, all_digits, AlertType.HIGH_SYNAPSE_COUNT)
+
+    assert await storage.mark_alert_acknowledged(all_digits) is True
+    assert await _status_of(storage, all_digits) == "acknowledged", (
+        "acknowledge reported success but the row it matched was not updated"
+    )
+
+    seen_id = "8" + "".join(str(int(c, 16) % 10) for c in uuid4().hex[:15])
+    await _seed(storage, seen_id, AlertType.HIGH_NEURON_COUNT)
+    assert await storage.mark_alerts_seen([seen_id]) == 1
+    assert await _status_of(storage, seen_id) == "seen"
+
+
+async def test_record_alert_can_replace_a_clashing_all_digit_row(storage) -> None:  # type: ignore[no-untyped-def]
+    """The insert-retry path has to actually clear the row it collides with.
+
+    ``record_alert`` falls back to delete-then-insert when the first insert
+    raises. Addressing that delete with a rebuilt ``f"alerts:{sid}"`` string
+    hits a numeric record id for an all-digit sid: nothing is deleted, nothing
+    is raised, and the retry hits the same collision.
+    """
+    all_digits = "5" + "".join(str(int(c, 16) % 10) for c in uuid4().hex[:15])
+    assert all_digits.isdigit()
+    await _seed(storage, all_digits, AlertType.HIGH_FIBER_COUNT)
+
+    conn = storage._ensure_conn()
+    await storage._query("DELETE type::record('alerts', $sid)", sid=all_digits)
+    assert await _status_of(storage, all_digits) is None
+
+    # Re-create it, then force the collision path by inserting the same id again.
+    await _seed(storage, all_digits, AlertType.HIGH_FIBER_COUNT)
+    rows = await storage._query(
+        "SELECT id FROM alerts WHERE brain_id = $brain_id", brain_id=storage._get_brain_id()
+    )
+    before = len(rows)
+    assert before >= 1
+
+    # A second record_alert for the same id must not leave a duplicate behind.
+    await conn.merge(rows[0]["id"], {"status": "resolved"})  # clear the dedup cooldown
+    await _seed(storage, all_digits, AlertType.HIGH_FIBER_COUNT)
+    rows = await storage._query(
+        "SELECT id FROM alerts WHERE brain_id = $brain_id", brain_id=storage._get_brain_id()
+    )
+    assert len(rows) == before, "the retry path duplicated or stranded a row"
+    assert await _status_of(storage, all_digits) == "active"
+
+
+async def test_the_id_get_active_alerts_hands_back_can_be_acknowledged(storage) -> None:  # type: ignore[no-untyped-def]
+    """The caller's actual route, end to end, for a letter-free id.
+
+    ``AlertHandler`` never types an id: it lists alerts and acknowledges what
+    the listing gave it. SurrealDB renders a record id carrying no letter in
+    its quoted form (``alerts:⟨1122334455667788⟩``), so a row mapper that only
+    strips the table prefix hands the guillemets back to the caller — and
+    feeding those into ``_to_surreal_id`` maps them to underscores, producing
+    an id that no longer addresses its own row. Fixing the SELECT is not enough
+    if the id the caller receives cannot be passed back in.
+    """
+    all_digits = "1" + "".join(str(int(c, 16) % 10) for c in uuid4().hex[:15])
+    assert all_digits.isdigit()
+    await _seed(storage, all_digits, AlertType.LOW_CONNECTIVITY)
+
+    listed = await storage.get_active_alerts()
+    ids = [a.id for a in listed]
+    assert all_digits in ids, f"get_active_alerts returned a mangled id: {ids!r}"
+
+    assert await storage.mark_alert_acknowledged(ids[ids.index(all_digits)]) is True
+    assert await _status_of(storage, all_digits) == "acknowledged"
+
+
+async def test_resolve_alerts_by_type_still_works(storage) -> None:  # type: ignore[no-untyped-def]
+    """Positive control on the sibling that was never broken.
+
+    ``resolve_alerts_by_type`` reuses the ``id`` its own SELECT returned, so it
+    worked before this fix and must keep working after it. A red result here
+    would mean the fixture is broken, not the predicate.
+    """
+    alert_id = uuid4().hex[:16]
+    await _seed(storage, alert_id, AlertType.LOW_CONNECTIVITY)
+
+    resolved = await storage.resolve_alerts_by_type([AlertType.LOW_CONNECTIVITY.value])
+
+    assert resolved >= 1
+    assert await _status_of(storage, alert_id) == "resolved"

--- a/tests/unit/test_surrealdb_record_id_lookups_live.py
+++ b/tests/unit/test_surrealdb_record_id_lookups_live.py
@@ -1,0 +1,247 @@
+"""Live-DB proof for the remaining `id = $rid` string comparisons.
+
+Same defect as the alerts mixin: a lookup binds ``rid=f"<table>:{sid}"`` — a
+string — and compares it with ``id = $rid``. ``id`` holds a record id, so the
+predicate is unconditionally false and the row can never match. Two mixins
+still carried it:
+
+* ``cognitive.py`` — ``get_knowledge_gap`` and ``resolve_knowledge_gap``, so a
+  gap could never be read back or closed (``mcp/cognitive_handler.py`` calls
+  both).
+* ``versions.py`` — ``get_version`` and ``delete_version``, so restoring or
+  diffing a brain snapshot could never find its version
+  (``engine/brain_versioning.py`` calls ``get_version`` on four paths).
+
+Each test seeds a decoy row as well, so a build that simply drops the id filter
+fails here instead of passing: against a single-row table an unfiltered lookup
+is indistinguishable from a correct one.
+
+Skipped unless ``SURREALDB_URL`` points at a running SurrealDB.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from surreal_memory.core.brain import Brain
+from surreal_memory.engine.brain_versioning import BrainVersion
+from surreal_memory.utils.timeutils import utcnow
+from tests.unit._surrealdb_live import cleanup_live_brains, ensure_real_surrealdb_sdk
+
+SURREALDB_URL = os.getenv("SURREALDB_URL")
+
+pytestmark = pytest.mark.skipif(
+    not SURREALDB_URL,
+    reason="requires SURREALDB_URL pointing to a running SurrealDB",
+)
+
+BRAIN_NAME = "record-id-lookups-live"
+
+
+@pytest.fixture
+async def storage():  # type: ignore[no-untyped-def]
+    ensure_real_surrealdb_sdk()
+    from surreal_memory.storage.surrealdb.store import SurrealDBStorage
+
+    store = SurrealDBStorage(url=SURREALDB_URL)
+    await store.initialize()
+    brain = Brain.create(name=BRAIN_NAME)
+    await store.save_brain(brain)
+    store.set_brain(brain.id)
+
+    yield store
+
+    try:
+        await cleanup_live_brains(store, own_brain_id=brain.id)
+    finally:
+        await store.close()
+
+
+def _make_version(version_id: str, number: int) -> BrainVersion:
+    return BrainVersion(
+        id=version_id,
+        brain_id="",
+        version_name=f"v{number}",
+        version_number=number,
+        description="record-id-lookups-live",
+        neuron_count=1,
+        synapse_count=0,
+        fiber_count=0,
+        snapshot_hash=f"hash-{number}",
+        created_at=utcnow(),
+    )
+
+
+async def test_get_knowledge_gap_finds_the_gap_it_just_created(storage) -> None:  # type: ignore[no-untyped-def]
+    decoy = await storage.add_knowledge_gap(topic="decoy", detection_source="test")
+    gap_id = await storage.add_knowledge_gap(topic="target", detection_source="test")
+    assert decoy != gap_id
+
+    gap = await storage.get_knowledge_gap(gap_id)
+
+    assert gap is not None, "get_knowledge_gap returned None for a gap that exists"
+    assert gap["topic"] == "target", "the lookup ignored the id and returned another row"
+
+
+async def test_resolve_knowledge_gap_closes_the_right_row(storage) -> None:  # type: ignore[no-untyped-def]
+    decoy = await storage.add_knowledge_gap(topic="decoy", detection_source="test")
+    gap_id = await storage.add_knowledge_gap(topic="target", detection_source="test")
+
+    assert await storage.resolve_knowledge_gap(gap_id) is True
+
+    resolved = await storage.get_knowledge_gap(gap_id)
+    assert resolved is not None and resolved["resolved_at"] is not None
+    # The decoy must still be open: a lookup that ignored the id would have
+    # matched it instead.
+    still_open = await storage.get_knowledge_gap(decoy)
+    assert still_open is not None and still_open["resolved_at"] is None
+
+    # Already resolved: the second call must report no work done.
+    assert await storage.resolve_knowledge_gap(gap_id) is False
+
+
+async def test_unknown_gap_id_is_reported_as_missing(storage) -> None:  # type: ignore[no-untyped-def]
+    await storage.add_knowledge_gap(topic="decoy", detection_source="test")
+
+    assert await storage.get_knowledge_gap("00000000-0000-4000-8000-000000000000") is None
+    assert await storage.resolve_knowledge_gap("00000000-0000-4000-8000-000000000000") is False
+
+
+async def test_get_version_returns_the_requested_snapshot(storage) -> None:  # type: ignore[no-untyped-def]
+    brain_id = storage._get_brain_id()
+    decoy = _make_version("11111111-1111-4111-8111-111111111111", 1)
+    target = _make_version("22222222-2222-4222-8222-222222222222", 2)
+    await storage.save_version(brain_id, decoy, json.dumps({"which": "decoy"}))
+    await storage.save_version(brain_id, target, json.dumps({"which": "target"}))
+
+    result = await storage.get_version(brain_id, target.id)
+
+    assert result is not None, "get_version returned None for a version that exists"
+    version, snapshot_json = result
+    assert version.version_number == 2, "the lookup ignored the id and returned another row"
+    assert json.loads(snapshot_json) == {"which": "target"}
+
+
+async def test_delete_version_removes_only_the_named_one(storage) -> None:  # type: ignore[no-untyped-def]
+    brain_id = storage._get_brain_id()
+    decoy = _make_version("33333333-3333-4333-8333-333333333333", 3)
+    target = _make_version("44444444-4444-4444-8444-444444444444", 4)
+    await storage.save_version(brain_id, decoy, json.dumps({"which": "decoy"}))
+    await storage.save_version(brain_id, target, json.dumps({"which": "target"}))
+
+    assert await storage.delete_version(brain_id, target.id) is True
+
+    assert await storage.get_version(brain_id, target.id) is None
+    remaining = await storage.list_versions(brain_id)
+    assert [v.version_number for v in remaining] == [3], "delete hit the wrong row"
+
+    # Deleting it twice must report that there was nothing left to delete.
+    assert await storage.delete_version(brain_id, target.id) is False
+
+
+async def test_a_letter_free_version_id_round_trips(storage) -> None:  # type: ignore[no-untyped-def]
+    """An id carrying no letter must survive the row -> model -> lookup round trip.
+
+    SurrealDB renders such an id in its quoted form, so a mapper that only
+    strips the table prefix returns ``⟨1234…⟩`` — and that spelling cannot be
+    fed back into a lookup. ``str(uuid4())`` almost always carries a letter, so
+    this is rare in practice for versions; it is pinned here because the mapper
+    is shared with the reads above and the failure mode is a silent "not found".
+    """
+    brain_id = storage._get_brain_id()
+    numeric = "11112222_3333_4444_5555_666677778888"
+    await storage.save_version(
+        brain_id, _make_version(numeric, 7), json.dumps({"which": "numeric"})
+    )
+
+    listed = await storage.list_versions(brain_id)
+    ids = [v.id for v in listed]
+    assert numeric in ids, f"list_versions returned a mangled id: {ids!r}"
+
+    result = await storage.get_version(brain_id, ids[ids.index(numeric)])
+    assert result is not None, "the id list_versions handed back does not resolve"
+    assert await storage.delete_version(brain_id, numeric) is True
+
+
+async def test_a_letter_free_gap_id_round_trips(storage) -> None:  # type: ignore[no-untyped-def]
+    """Same round trip for knowledge gaps, through list_knowledge_gaps."""
+    conn = storage._ensure_conn()
+    numeric = "1234123412341234"
+    await conn.insert(
+        "knowledge_gaps",
+        {
+            "id": numeric,
+            "brain_id": storage._get_brain_id(),
+            "topic": "letter-free",
+            "detected_at": utcnow(),
+            "detection_source": "test",
+            "related_neuron_ids": [],
+            "priority": 0.5,
+        },
+    )
+
+    listed = await storage.list_knowledge_gaps()
+    ids = [g["id"] for g in listed]
+    assert numeric in ids, f"list_knowledge_gaps returned a mangled id: {ids!r}"
+
+    assert await storage.get_knowledge_gap(ids[ids.index(numeric)]) is not None
+    assert await storage.resolve_knowledge_gap(numeric) is True
+
+
+async def test_update_cognitive_evidence_writes_to_the_row_it_found(storage) -> None:  # type: ignore[no-untyped-def]
+    """The evidence update must target the row its own SELECT matched.
+
+    ``cognitive_state`` record ids are built as ``<brain>_<neuron>``, but the
+    lookup is by the ``brain_id`` *field*. After a brain rename the two diverge:
+    the row is still found, while an id recomputed from the current brain name
+    points at a record that does not exist — so the merge writes nothing and the
+    caller is told nothing. ``upsert_cognitive_state`` already carries that
+    lesson in a comment; this pins it for the evidence path too.
+
+    The divergence is staged directly, which is what a rename leaves behind:
+    a row whose id carries an older brain prefix but whose ``brain_id`` field
+    is current.
+    """
+    conn = storage._ensure_conn()
+    neuron_id = "aaaabbbb-cccc-4ddd-8eee-ffff00001111"
+    await conn.insert(
+        "cognitive_state",
+        {
+            "id": f"an_older_brain_name_{neuron_id.replace('-', '_')}",
+            "brain_id": storage._get_brain_id(),
+            "neuron_id": neuron_id,
+            "confidence": 0.5,
+            "evidence_for_count": 0,
+            "evidence_against_count": 0,
+            "status": "active",
+            "created_at": utcnow(),
+        },
+    )
+
+    await storage.update_cognitive_evidence(
+        neuron_id,
+        confidence=0.9,
+        evidence_for_count=7,
+        evidence_against_count=1,
+        status="resolved",
+    )
+
+    state = await storage.get_cognitive_state(neuron_id)
+    assert state is not None
+    assert state["evidence_for_count"] == 7, (
+        "update_cognitive_evidence reported nothing and wrote nothing"
+    )
+    assert state["status"] == "resolved"
+
+
+async def test_unknown_version_id_is_reported_as_missing(storage) -> None:  # type: ignore[no-untyped-def]
+    brain_id = storage._get_brain_id()
+    await storage.save_version(
+        brain_id, _make_version("55555555-5555-4555-8555-555555555555", 5), json.dumps({})
+    )
+
+    assert await storage.get_version(brain_id, "99999999-9999-4999-8999-999999999999") is None
+    assert await storage.delete_version(brain_id, "99999999-9999-4999-8999-999999999999") is False


### PR DESCRIPTION
## Summary

- Seven single-row lookups across `alerts.py`, `cognitive.py` and `versions.py` compared a record id with a Python string, a predicate that is unconditionally false, so none of them could ever match a row.
- The writes beside them now reuse the id their own SELECT returned instead of rebuilding it, which silently addressed a different record for letter-free ids.
- Row mappers now hand back an id the caller can pass straight back in, rather than one carrying SurrealDB's quoting.
- Adds eighteen live tests, each seeded with a decoy row.

## Why

The pattern was the same in all seven: bind `rid = f"<table>:{sid}"` and compare it with `id = $rid`. `id` holds a record id, not a string, so the comparison is false regardless of the data. These were not intermittent failures but structurally dead paths:

- `alerts.py` — an alert could never leave `active`, acknowledging one reported "not found", and reading a single alert always returned `None`.
- `cognitive.py` — a knowledge gap could not be read back or closed, both of which `mcp/cognitive_handler.py` calls.
- `versions.py` — `get_version` returned `None`, so every restore and diff path in `engine/brain_versioning.py` saw an empty result.

They now bind the sanitised id and rebuild the record id in SurrealQL with `type::record('<table>', $sid)`.

## The second half: rebuilt ids write into the void

Fixing the lookups alone would have left a worse bug in place. The writes rebuilt `f"<table>:{sid}"` too, and for an all-digit sid that parses back through the SDK as a *numeric* record id whilst the row was stored under a *string* one. The merge then writes to a different, empty record and reports success having changed nothing — which is harder to notice than the failure it replaces.

Measured on SurrealDB 3.2.0, against a row created with a string key:

```
UPDATE probe:1234567890123456 MERGE { v: 'after' };   -- no error
SELECT v FROM probe;                                  -- still 'before'
```

The same shape applied to `update_cognitive_evidence` and `delete_version`; `save_version`'s insert-retry had all three symptoms at once — a delete that cleared nothing, an `except: pass` that said nothing, and a retry straight back into the same collision.

## The third half: the id handed to the caller

SurrealDB renders a record id whose id part carries no letter in its quoted form — `alerts:⟨1122334455667788⟩`. The row mappers stripped only the table prefix, so the guillemets reached the caller, and `_to_surreal_id` then mapped them to underscores and produced an id matching nothing. `get_active_alerts` listed an alert that `mark_alert_acknowledged` then called missing.

Measured on 3.2.0: the quoted form appears for `0001`, `1122334455667788`, `12_34` and `_123`, and not for `a1`, `123abc`, `1_2a` or `_a1` — exactly when the id carries no letter. An `uuid4().hex[:16]` sid is letter-free about once in 1150: character 12 is always the version nibble `4`, so fifteen of the sixteen characters are random and the chance is `(10/16)**15`. A four-million-draw check gives one in 1130. `str(uuid4())` ids essentially never qualify, but they pass through the same mappers.

`_record_id_part` in `_ids.py` is the one place that knows the inverse of the sanitiser, and it sits beside it. It is deliberately not called `_from_surreal_id`: `store.py` already has a function by that name which also maps `_` back to `-`, which is a different question.

## Test plan

- [x] `pytest tests/unit/test_surrealdb_alerts_recordid_live.py tests/unit/test_surrealdb_record_id_lookups_live.py` — 18 passed against a live SurrealDB v3.2.0.
- [x] Differential control, stated precisely rather than roundly: with the three source files reverted to `main` and the tests kept, **14 of the 18 fail**. The four that pass are the controls and could not have failed — `test_unknown_ids_are_still_reported_as_missing`, `test_unknown_gap_id_is_reported_as_missing` and `test_unknown_version_id_is_reported_as_missing` assert that an unknown id is still reported missing, and `test_resolve_alerts_by_type_still_works` is the positive control for the one alert path that was never broken.
- [x] Each test seeds a decoy row alongside its target. Against a single-row table an unfiltered lookup is indistinguishable from a correct one, so without the decoy these tests would pass just as happily for a build with the id filter deleted.
- [x] `pytest tests/ -m "not stress" -n 4` — 7301 passed, 48 skipped, 1 xfailed, which is `main`'s 7283 plus exactly the eighteen tests added here. Two tests in `tests/unit/test_dashboard_brains_scope.py` fail on this branch and on `main` alike: they want a live database and collide with one another under `-n`. Both pass when that file is run on its own.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 741 files already formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 354 source files.
- [x] Coverage under the CI gate: 72.70%, against 72.36% on `main`.
- [ ] `CHANGELOG.md` untouched — left to the release entry, as with #191–#193.

## A note for whoever merges second

`tests/unit/_surrealdb_live.py` conflicts textually with the `change_log` FLEXIBLE fix and the sync-reader change that is stacked on it: both append a brain name to `LIVE_TEST_BRAIN_NAMES` immediately after the same entry. The resolution is to keep both lines; I will rebase whichever of us lands second.

## Verified by

@RobertSigmundsson
