### PR TITLE
fix(consolidation): the lock honours SURREAL_MEMORY_DIR like the rest of the data dir

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -385,7 +385,7 @@ places, the environment wins.
 | `SURREAL_MEMORY_API_KEY` | `src/surreal_memory/unified_config.py` |
 | `SURREAL_MEMORY_BRAIN` | `src/surreal_memory/cli/_helpers.py`, `src/surreal_memory/cli/commands/brain.py`, `src/surreal_memory/unified_config.py` |
 | `SURREAL_MEMORY_DASHBOARD_CACHE_TTL` | `src/surreal_memory/server/dashboard_cache.py` |
-| `SURREAL_MEMORY_DIR` | `src/surreal_memory/cli/config.py`, `src/surreal_memory/cli/update_check.py`, `src/surreal_memory/engine/reasoning_injection.py`, +3 more |
+| `SURREAL_MEMORY_DIR` | `src/surreal_memory/cli/config.py`, `src/surreal_memory/cli/update_check.py`, `src/surreal_memory/engine/reasoning_injection.py`, +4 more |
 | `SURREAL_MEMORY_DISABLE_SUPERSEDED_FILTER` | `src/surreal_memory/mcp/recall_handler.py` |
 | `SURREAL_MEMORY_EMBEDDING_API_KEY` | `src/surreal_memory/engine/embedding/bge_m3_embedding.py` |
 | `SURREAL_MEMORY_EMBEDDING_DIMENSION` | `src/surreal_memory/engine/embedding/bge_m3_embedding.py`, `src/surreal_memory/unified_config.py` |

--- a/src/surreal_memory/utils/consolidation_lock.py
+++ b/src/surreal_memory/utils/consolidation_lock.py
@@ -21,8 +21,23 @@ _STALE_SECONDS = 3600  # 1 hour
 
 
 def _lock_path(brain_id: str = "") -> Path:
-    """Get the lock file path, optionally per-brain."""
-    base = Path.home() / ".surrealmemory"
+    """Get the lock file path, optionally per-brain.
+
+    Honours ``SURREAL_MEMORY_DIR`` like the rest of the data directory does
+    (``cli/config.get_default_data_dir``, ``cli/update_check._get_cache_path``).
+    Hard-coding ``Path.home()`` here made the lock the one piece of state that
+    a redirected data dir could not move: anything run against a throwaway
+    brain still created and deleted files in the operator's real
+    ``~/.surrealmemory``.
+
+    The trade-off is worth naming: two processes pointed at different
+    ``SURREAL_MEMORY_DIR`` values now take different locks and no longer
+    exclude one another. That is the intended reading -- they are working on
+    separate data directories -- but it does mean the lock is per data dir
+    rather than per machine.
+    """
+    env_dir = os.environ.get("SURREAL_MEMORY_DIR")
+    base = Path(env_dir).resolve() if env_dir else Path.home() / ".surrealmemory"
     base.mkdir(parents=True, exist_ok=True)
     safe_name = brain_id.replace("/", "_").replace("\\", "_") if brain_id else ""
     filename = f"consolidation-{safe_name}.lock" if safe_name else "consolidation.lock"

--- a/tests/unit/test_multi_agent.py
+++ b/tests/unit/test_multi_agent.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 import time
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -120,21 +121,41 @@ class TestAgentTagInjection:
 class TestConsolidationLock:
     """Test file-based consolidation lock.
 
-    _lock_path() is a real, fixed file under ~/.surrealmemory/ shared across
-    the whole process tree — not test-isolated. Under pytest-xdist's default
-    per-test scheduling, two of these tests can land on different worker
-    processes and race on that one file (reproduced live: a different subset
-    fails each full-suite run, 100% pass in isolation). xdist_group pins the
-    whole class to one worker, same fix as the aiosqlite leak-guard pair.
+    _lock_path() ignored SURREAL_MEMORY_DIR and derived its directory from
+    Path.home() alone. When #74 added xdist_group here, that made these tests
+    share one real lock file across the process tree and race on it, exactly as
+    the note it left said. #121 then gave the suite a session-scoped $HOME
+    redirect for unrelated reasons, which hands every xdist worker its own home
+    and therefore its own lock file -- so the race has not been reachable since,
+    and the note quietly stopped describing the present.
+
+    What the redirect does not do is make the intent explicit: a test that
+    relies on $HOME being someone else's problem is one refactor away from
+    writing into a real home again. The fixture below points SURREAL_MEMORY_DIR
+    at a per-test directory and the first test asserts the redirection, because
+    the failure mode is silent. xdist_group is kept as a guard against shared
+    state being reintroduced.
     """
 
     @pytest.fixture(autouse=True)
-    def _cleanup_lock(self) -> None:
-        """Remove lock file before/after each test."""
+    def _cleanup_lock(self, tmp_path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """Point the lock at a per-test directory, and leave nothing behind."""
+        monkeypatch.setenv("SURREAL_MEMORY_DIR", str(tmp_path))
         lock = _lock_path()
         lock.unlink(missing_ok=True)
         yield  # type: ignore[misc]
         lock.unlink(missing_ok=True)
+
+    def test_lock_lives_in_the_configured_data_dir(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        """SURREAL_MEMORY_DIR must move the lock, like it moves everything else.
+
+        The autouse fixture already redirects it; this asserts the redirection
+        rather than assuming it, because the failure mode is silent — the lock
+        simply appears in the real home directory instead.
+        """
+        assert _lock_path().parent == tmp_path.resolve()
+        assert _lock_path("some-brain").parent == tmp_path.resolve()
+        assert Path.home() / ".surrealmemory" != _lock_path().parent
 
     def test_acquire_fresh_lock(self) -> None:
         """Should acquire lock when no lock exists."""


### PR DESCRIPTION
## Summary

- `_lock_path` now honours `SURREAL_MEMORY_DIR`, so the consolidation lock moves with the data directory like everything else in the package.
- The lock test class gets a per-test directory and a test that asserts the redirection rather than assuming it.

## Why

`_lock_path` derived its directory from `Path.home()` alone. Everything else already reads the variable — `cli/config.get_default_data_dir` and `cli/update_check._get_cache_path` both do — which made the consolidation lock the one piece of state a redirected data dir could not move. A run against a throwaway brain still created and deleted files in the operator's real `~/.surrealmemory`.

Measured by asking `_lock_path` where it would put the file, with the variable set:

```
main:   SURREAL_MEMORY_DIR=/tmp/throwaway  ->  ~/.surrealmemory/consolidation-<brain>.lock
here:   SURREAL_MEMORY_DIR=/tmp/throwaway  ->  /tmp/throwaway/consolidation-<brain>.lock
```

## A trade-off, named rather than discovered

Two processes pointed at different `SURREAL_MEMORY_DIR` values now take different locks and no longer exclude one another. That is the intended reading — they are operating on separate data directories — but it does mean the lock is per data directory rather than per machine. If you would rather it stayed machine-wide, this is the wrong shape and I would rather know now.

## Changes

- `utils/consolidation_lock.py`: read `SURREAL_MEMORY_DIR`, falling back to `Path.home()/".surrealmemory"` as before, with the trade-off recorded in the docstring.
- `tests/unit/test_multi_agent.py`: the autouse fixture points `SURREAL_MEMORY_DIR` at a per-test directory, and `test_lock_lives_in_the_configured_data_dir` asserts the redirection. The failure mode is silent — the lock simply reappears in the real home — so it is worth an explicit assertion.

- `docs/reference/config.md`: regenerated with `scripts/gen_config_docs.py`, since that file is generated from these defaults and the `Docs Freshness` job checks it.

## A correction to that class's own docstring

The docstring says these tests race on one shared lock file under `xdist`, and that `xdist_group` pins the class to a single worker to prevent it. That was true when #74 wrote it, and is no longer true of the suite as it stands — which is worth stating carefully, because the note was not wrong, it was overtaken.

#121 later added a session-scoped `$HOME` redirect to `conftest` for unrelated reasons. That gives each worker its own home directory, and therefore its own lock file, so the race stopped being reachable and nothing updated the note. Checked directly: with `$HOME` redirected the lock lands under the fake home on `main` too, before any of this change.

What the redirect does not do is make the intent explicit. A test relying on `$HOME` being someone else's problem is one refactor away from writing to a real home again, which is why the fixture now says so in its own terms. `xdist_group` is kept as a guard against shared state being reintroduced, not as a live fix.

## Test plan

- [x] `pytest tests/unit/test_multi_agent.py` — 16 passed.
- [x] With `utils/consolidation_lock.py` reverted to `main` and the tests kept, exactly one fails: `test_lock_lives_in_the_configured_data_dir`. The other fifteen pass either way, which is the point — this change is meant to move a file, not alter locking behaviour.
- [x] `pytest tests/ -m "not stress" -n 4` — 7284 passed, 48 skipped, 1 xfailed, which is `main`'s 7283 plus the single test added here. Two tests in `tests/unit/test_dashboard_brains_scope.py` fail on this branch and on `main` alike: they want a live database and collide with one another under `-n`. Both pass when that file is run on its own.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 739 files already formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 354 source files.
- [x] Coverage under the CI gate: 72.37%, against 72.36% on `main`.
- [ ] `CHANGELOG.md` untouched — left to the release entry, as with #191–#193.

## Verified by

@RobertSigmundsson
