### PR TITLE
fix(consolidation): LIFECYCLE reads access_frequency from NeuronState, not metadata

### DIFF
--- a/src/surreal_memory/engine/consolidation.py
+++ b/src/surreal_memory/engine/consolidation.py
@@ -2803,18 +2803,49 @@ class ConsolidationEngine:
         config = CompressionConfig()
         states_updated = 0
 
-        for neuron in neurons:
-            # Retrieve last_accessed_at and access_frequency from neuron metadata
-            # (access_frequency is stored in neuron_states, not neurons directly)
-            last_accessed_raw: str | None = neuron.metadata.get("last_accessed_at")
-            last_accessed_at: datetime | None = None
-            if last_accessed_raw:
-                try:
-                    last_accessed_at = datetime.fromisoformat(last_accessed_raw)
-                except ValueError:
-                    pass
+        # access_frequency and last_activated live on NeuronState (schema.py neuron_state
+        # table), not on neuron.metadata — the dead-neuron / orphan pass in this same
+        # class already knows this (_prune, ~L1000) and prefetches with the exact
+        # pattern below. Without this, access_score and recency_score (0.8 of the heat
+        # weight) were pinned to zero and heat reduced to priority * 0.2.
+        try:
+            states_by_id: dict[str, Any] = {
+                s.neuron_id: s for s in await self._storage.get_all_neuron_states()
+            }
+            use_prefetched_states = True
+        except Exception:
+            _logger.debug(
+                "LIFECYCLE: get_all_neuron_states failed; falling back to a batch fetch",
+                exc_info=True,
+            )
+            states_by_id = {}
+            use_prefetched_states = False
 
-            access_count: int = int(neuron.metadata.get("access_frequency", 0))
+        # Fallback cache. `neurons` is already the whole pass — the paging above
+        # accumulates into one list — so this is a single get_neuron_states_batch
+        # over every id, not one per page, and it is populated on the first miss
+        # and never again. On a brain at the 10 000 cap that one call is the
+        # fallback's whole cost; _prune measures roughly ten seconds per five
+        # thousand ids on the same backend, so budget for it accordingly. The
+        # alternative — one query per neuron — is what this cache exists to avoid.
+        fallback_states: dict[str, Any] = {}
+        fallback_ids: set[str] = set()
+
+        async def _state_for(nid: str) -> Any:
+            nonlocal fallback_states, fallback_ids
+            if use_prefetched_states:
+                return states_by_id.get(nid)
+            if nid not in fallback_ids:
+                fallback_ids = {n.id for n in neurons}
+                fallback_states = await self._storage.get_neuron_states_batch(list(fallback_ids))
+            return fallback_states.get(nid)
+
+        for neuron in neurons:
+            # Real access_frequency / last_activated come from NeuronState; priority
+            # stays on neuron.metadata (that is where the writer puts it).
+            state = await _state_for(neuron.id)
+            last_accessed_at: datetime | None = state.last_activated if state is not None else None
+            access_count: int = state.access_frequency if state is not None else 0
             priority: int = int(neuron.metadata.get("priority", 5))
 
             heat = calculate_heat_score(

--- a/tests/unit/test_lifecycle_heat_score.py
+++ b/tests/unit/test_lifecycle_heat_score.py
@@ -1,0 +1,154 @@
+"""Regression: LIFECYCLE heat score must read access_frequency from NeuronState.
+
+Before the fix, `_lifecycle` read `access_frequency` and `last_accessed_at` from
+`neuron.metadata` — neither field ever lives there. Both are columns on the
+`neuron_state` table, prefetched the same way the dead-neuron / orphan pass at
+`consolidation.py:_prune` already does via `get_all_neuron_states()`. Net
+effect was that `access_score` (weight 0.4) and `recency_score` (weight 0.4)
+were pinned to zero for every neuron; a neuron recalled a thousand times an
+hour aged into COOL/COMPRESSED/ARCHIVED on the same schedule as one nobody
+had ever touched.
+
+The test spies on `calculate_heat_score` inside `_lifecycle` and asserts that
+the argument `access_count` reflects the value stored on `NeuronState`, not
+zero.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from surreal_memory.core.brain import Brain
+from surreal_memory.core.neuron import Neuron, NeuronState, NeuronType
+from surreal_memory.engine.consolidation import (
+    ConsolidationEngine,
+    ConsolidationReport,
+)
+from surreal_memory.storage.memory_store import InMemoryStorage
+from surreal_memory.utils.timeutils import utcnow
+
+BRAIN_ID = "heat-score-brain"
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_reads_access_frequency_from_neuron_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = InMemoryStorage()
+    brain = Brain.create(name="heat_test", brain_id=BRAIN_ID)
+    await storage.save_brain(brain)
+    storage.set_brain(brain.id)
+
+    hot = Neuron.create(type=NeuronType.ENTITY, content="hot", neuron_id="n-hot")
+    cold = Neuron.create(type=NeuronType.ENTITY, content="cold", neuron_id="n-cold")
+    await storage.add_neuron(hot)
+    await storage.add_neuron(cold)
+
+    # The whole point: state is on NeuronState, not neuron.metadata.
+    await storage.update_neuron_state(
+        NeuronState(neuron_id=hot.id, access_frequency=42, last_activated=utcnow())
+    )
+    await storage.update_neuron_state(NeuronState(neuron_id=cold.id, access_frequency=0))
+
+    seen: list[dict[str, Any]] = []
+    # calculate_heat_score is imported inside `_lifecycle` from
+    # surreal_memory.engine.compression — patch there so the spy actually
+    # intercepts the call (the same module also owns determine_lifecycle_state,
+    # which we do NOT patch — we want the real routing).
+    import surreal_memory.engine.compression as _compression
+
+    real_calculate = _compression.calculate_heat_score
+
+    def spy_calculate_heat_score(**kwargs: Any) -> float:
+        seen.append(dict(kwargs))
+        return float(real_calculate(**kwargs))
+
+    monkeypatch.setattr(_compression, "calculate_heat_score", spy_calculate_heat_score)
+
+    engine = ConsolidationEngine(storage=storage)
+    report = ConsolidationReport()
+    # dry_run=True avoids invoking update_neuron_lifecycle (InMemoryStorage
+    # inherits the base's NotImplementedError for that write).
+    await engine._lifecycle(
+        report,
+        reference_time=utcnow(),
+        dry_run=True,
+    )
+
+    counts = [call["access_count"] for call in seen]
+    assert 42 in counts, (
+        "expected access_count=42 to reach calculate_heat_score for the neuron "
+        f"whose NeuronState.access_frequency was 42; got {counts}"
+    )
+    assert 0 in counts, (
+        "expected access_count=0 for the neuron whose NeuronState.access_frequency "
+        f"was 0 (control); got {counts}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_falls_back_to_one_batch_when_the_prefetch_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fallback must still find the states, in one query rather than per neuron.
+
+    ``get_all_neuron_states`` is the fast path; when it raises, the pass falls
+    back to ``get_neuron_states_batch`` over every id it is about to score.
+    Two things matter and neither is obvious from reading it: the fallback must
+    produce the same answer as the prefetch, and it must ask once rather than
+    once per neuron, which is what the cache around it is for.
+    """
+    storage = InMemoryStorage()
+    brain = Brain.create(name="heat_fallback", brain_id="heat-fallback-brain")
+    await storage.save_brain(brain)
+    storage.set_brain(brain.id)
+
+    hot = Neuron.create(type=NeuronType.ENTITY, content="hot", neuron_id="f-hot")
+    cold = Neuron.create(type=NeuronType.ENTITY, content="cold", neuron_id="f-cold")
+    await storage.add_neuron(hot)
+    await storage.add_neuron(cold)
+    await storage.update_neuron_state(
+        NeuronState(neuron_id=hot.id, access_frequency=42, last_activated=utcnow())
+    )
+    await storage.update_neuron_state(NeuronState(neuron_id=cold.id, access_frequency=0))
+
+    async def _raise() -> Any:
+        raise RuntimeError("prefetch unavailable")
+
+    storage.get_all_neuron_states = _raise  # type: ignore[method-assign]
+
+    batch_calls: list[list[str]] = []
+    real_batch = storage.get_neuron_states_batch
+
+    async def _spy_batch(ids: list[str]) -> Any:
+        batch_calls.append(list(ids))
+        return await real_batch(ids)
+
+    storage.get_neuron_states_batch = _spy_batch  # type: ignore[method-assign]
+
+    seen: list[dict[str, Any]] = []
+    import surreal_memory.engine.compression as _compression
+
+    real_calculate = _compression.calculate_heat_score
+
+    def spy_calculate_heat_score(**kwargs: Any) -> float:
+        seen.append(dict(kwargs))
+        return float(real_calculate(**kwargs))
+
+    monkeypatch.setattr(_compression, "calculate_heat_score", spy_calculate_heat_score)
+
+    engine = ConsolidationEngine(storage=storage)
+    await engine._lifecycle(ConsolidationReport(), reference_time=utcnow(), dry_run=True)
+
+    assert len(batch_calls) == 1, (
+        "the fallback must ask once for the whole pass, not once per neuron; "
+        f"got {len(batch_calls)} calls: {batch_calls}"
+    )
+    assert set(batch_calls[0]) == {hot.id, cold.id}, (
+        f"the single batch must cover every neuron being scored; got {batch_calls[0]}"
+    )
+    counts = [call["access_count"] for call in seen]
+    assert 42 in counts, f"the fallback must reach the same state as the prefetch; got {counts}"
+    assert 0 in counts, f"expected the control neuron's 0 as well; got {counts}"


### PR DESCRIPTION
## Summary

- The LIFECYCLE heat-score pass now reads `access_frequency` and `last_activated` from `NeuronState`, where they live, instead of from `neuron.metadata`, where they never did.
- Adds two tests: one that the value reaches `calculate_heat_score`, and one covering the fallback path that had no coverage at all.

## Why

`_lifecycle` read both fields off `neuron.metadata`. Neither is stored there — both are columns on `neuron_state`, keyed by `neuron_id` — and `_row_to_neuron` copies only the JSON `metadata` blob, so the `neuron` table's own columns of those names never reach the dataclass either.

The reads therefore returned their defaults for every neuron on every pass. `calculate_heat_score` weights access at 0.4 and recency at 0.4 against priority's 0.2, so eighty per cent of the calculation was pinned to zero and heat collapsed to `priority * 0.2`. A neuron recalled a thousand times an hour aged into COOL, COMPRESSED and ARCHIVED on exactly the same schedule as one nobody had ever touched — the tiering worked, it was simply being fed constants.

The fix borrows the pattern the dead-neuron and orphan pass in the same class already uses: a brain-wide prefetch through `get_all_neuron_states`, with a `get_neuron_states_batch` fallback when that call is unavailable. `priority` stays on `neuron.metadata`, which is where the writer puts it.

## A behaviour change worth flagging

On an existing brain the first LIFECYCLE pass after this lands will recompute `lifecycle_state` for everything, because eighty per cent of the heat weight comes back to life at once. Neurons that were quietly demoted on a constant will be re-evaluated against what `NeuronState` actually records, and `compression_tier` follows `lifecycle_state`. That is the intended correction rather than a side effect, but it is a one-off reshuffle rather than a quiet improvement, and it seemed better said than discovered.

One caveat on what "actually records" means, since it changes how the result should be read: `last_activated` is also stamped by the decay pass, and a comment in that pass already notes that a decay pass is not usage. So `recency_score` will read more recent than pure recall history would suggest, and with the default weights a neuron with a few recalls behind it will tend to stay warm. That is a pre-existing property of the field rather than something this change introduces, but this change is what makes it visible.

## About the fallback, and what it costs

The fallback is one query for the whole pass — not one per page, and certainly not one per neuron. `neurons` is already the entire accumulated set by the time it runs, so the cache is filled on the first miss and never touched again. On a brain at the 10 000 cap that single call is the fallback's whole cost, which is worth knowing: the prune pass in the same file measures roughly ten seconds per five thousand ids against the same backend, and this runs inside a per-strategy timeout. The comment in the code now says so.

An earlier draft of this change described that fallback as "per-page", and the variables were named accordingly. They were not paging anything. Both are corrected here rather than left to mislead the next reader.

## Test plan

- [x] `pytest tests/unit/test_lifecycle_heat_score.py` — 2 passed.
- [x] `test_lifecycle_reads_access_frequency_from_neuron_state` spies on `calculate_heat_score` and asserts `access_count` is 42 for a neuron whose `NeuronState.access_frequency` is 42, and 0 for the control. Without the fix the spy sees zero for both.
- [x] `test_lifecycle_falls_back_to_one_batch_when_the_prefetch_fails` makes `get_all_neuron_states` raise and asserts `get_neuron_states_batch` is called exactly once, covers every id being scored, and yields the same answer the prefetch would have. That branch was previously reached by no test.
- [x] With `engine/consolidation.py` reverted to `main` and both tests kept, both fail.
- [x] `pytest tests/ -m "not stress" -n 4` — 7285 passed, 48 skipped, 1 xfailed, which is `main`'s 7283 plus the two tests added here. Two tests in `tests/unit/test_dashboard_brains_scope.py` fail on this branch and on `main` alike: they want a live database and collide with one another under `-n`. Both pass when that file is run on its own.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 740 files already formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 354 source files.
- [x] Coverage under the CI gate: 72.42%, against 72.36% on `main`.
- [ ] `CHANGELOG.md` untouched — left to the release entry, as with #191–#193.

## Verified by

@RobertSigmundsson
