### PR TITLE
fix(config): the scheduled-consolidation default includes "mature"

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -101,7 +101,7 @@ Proactive brain maintenance configuration.
 | `expiry_cleanup_max_per_run` | `int` | `100` |  |
 | `scheduled_consolidation_enabled` | `bool` | `true` |  |
 | `scheduled_consolidation_interval_hours` | `int` | `24` |  |
-| `scheduled_consolidation_strategies` | `tuple[str, ...]` | `['prune', 'merge', 'enrich']` |  |
+| `scheduled_consolidation_strategies` | `tuple[str, ...]` | `['prune', 'merge', 'mature', 'enrich']` |  |
 | `version_check_enabled` | `bool` | `true` |  |
 | `version_check_interval_hours` | `int` | `24` |  |
 | `decay_enabled` | `bool` | `true` |  |

--- a/src/surreal_memory/unified_config.py
+++ b/src/surreal_memory/unified_config.py
@@ -623,7 +623,7 @@ class MaintenanceConfig:
     expiry_cleanup_max_per_run: int = 100
     scheduled_consolidation_enabled: bool = True
     scheduled_consolidation_interval_hours: int = 24
-    scheduled_consolidation_strategies: tuple[str, ...] = ("prune", "merge", "enrich")
+    scheduled_consolidation_strategies: tuple[str, ...] = ("prune", "merge", "mature", "enrich")
     version_check_enabled: bool = True
     version_check_interval_hours: int = 24
     # Auto-decay in serve daemon
@@ -697,7 +697,7 @@ class MaintenanceConfig:
         if isinstance(strategies, list):
             strategies = tuple(strategies)
         sched_strategies = data.get(
-            "scheduled_consolidation_strategies", ("prune", "merge", "enrich")
+            "scheduled_consolidation_strategies", ("prune", "merge", "mature", "enrich")
         )
         if isinstance(sched_strategies, list):
             sched_strategies = tuple(sched_strategies)

--- a/tests/unit/test_scheduled_consolidation_handler.py
+++ b/tests/unit/test_scheduled_consolidation_handler.py
@@ -291,8 +291,23 @@ class TestScheduledConsolidationConfig:
         assert cfg.scheduled_consolidation_strategies == (
             "prune",
             "merge",
+            "mature",
             "enrich",
         )
+
+    def test_defaults_include_mature(self) -> None:
+        """`mature` is the only strategy that advances EPISODIC → SEMANTIC; leaving
+        it out of the scheduled-consolidation default meant `smem serve` never
+        promoted anything, since its `_consolidation_loop` has no op-triggered
+        `auto_consolidate` fallback. Guards against a silent regression back to a
+        default tuple that would leave the HTTP daemon quietly non-maturing."""
+        cfg = MaintenanceConfig()
+        assert "mature" in cfg.scheduled_consolidation_strategies
+        # Same guarantee via the from_dict fallback path — HTTP daemon rebuilds
+        # MaintenanceConfig from a dict on every reload, so the fallback matters
+        # just as much as the field default.
+        restored = MaintenanceConfig.from_dict({})
+        assert "mature" in restored.scheduled_consolidation_strategies
 
     def test_roundtrip(self) -> None:
         """to_dict/from_dict preserves scheduled consolidation fields."""
@@ -316,5 +331,6 @@ class TestScheduledConsolidationConfig:
         assert restored.scheduled_consolidation_strategies == (
             "prune",
             "merge",
+            "mature",
             "enrich",
         )


### PR DESCRIPTION
## Summary

- `MaintenanceConfig`'s default scheduled-consolidation strategies now include `mature`, in the field default and in the `from_dict` fallback.
- `docs/reference/config.md` follows, since it is generated from those defaults.
- Adds a test that pins `mature` through both paths.

## Why

The default tuple was `("prune", "merge", "enrich")`. `mature` is the strategy that owns the EPISODIC to SEMANTIC transition — `ConsolidationStrategy.MATURE` dispatches to `_mature`, which is the only place that transition happens — so the *scheduled* pass on the defaults never promoted anything. The MCP server's own consolidation defaults do include `mature`, so a deployment driven through MCP still matures; the gap is specific to whatever relies on the scheduled pass.

That matters most for `smem serve`. Its `_consolidation_loop` is a plain background task with no operation-triggered `auto_consolidate` behind it, so if the scheduled pass does not mature, nothing does. The brain accumulates episodic memories indefinitely and nothing errors, which is why this is easy to run into and hard to notice.

Both the field default and the `from_dict` fallback change, because the HTTP daemon rebuilds `MaintenanceConfig` from a dict on every reload and would otherwise pick the old tuple straight back up.

## A behaviour change worth flagging

On a deployment that has been running on the defaults, the next scheduled pass will start maturing memories it has been leaving alone — a backlog's worth on the first run, in one go. That is the point of the change rather than a side effect, but it is a visible one-off rather than a quiet improvement.

It does not reach everyone. `from_dict` only falls back to the default when the key is absent, so an installation whose `config.toml` already records `scheduled_consolidation_strategies` keeps whatever it has, including the old three. Those operators need to add `"mature"` themselves; this PR cannot do it for them without editing their configuration, which would be the wrong sort of helpful.

## On ordering

Order is not significant. The engine groups strategies into `STRATEGY_TIERS`, a tuple of frozensets, and runs them tier by tier rather than in the order the configuration lists them. `mature` sits between `merge` and `enrich` for readability, nothing more — worth saying, because the tuple reads like a pipeline and is not one.

## Test plan

- [x] `pytest tests/unit/test_scheduled_consolidation_handler.py` — 17 passed.
- [x] With `unified_config.py` reverted to `main` and the tests kept, 3 fail: `test_defaults`, `test_from_dict_defaults` (both already pinned the tuple and are updated here) and the new `test_defaults_include_mature`, which asserts through the field default and the `from_dict` fallback separately.
- [x] `pytest tests/ -m "not stress" -n 4` — 7284 passed, 48 skipped, 1 xfailed, which is `main`'s 7283 plus the one test added here. Two tests in `tests/unit/test_dashboard_brains_scope.py` fail on this branch and on `main` alike: they want a live database and collide with one another under `-n`. Both pass when that file is run on its own.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 739 files already formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 354 source files.
- [x] Coverage under the CI gate: 72.36%, unchanged from `main`.
- [ ] `CHANGELOG.md` untouched — left to the release entry, as with #191–#193.

## Verified by

@RobertSigmundsson
