### PR TITLE
fix(compression): the brain pre-fetch logs its failure instead of degrading in silence

### DIFF
--- a/src/surreal_memory/engine/compression.py
+++ b/src/surreal_memory/engine/compression.py
@@ -1006,6 +1006,15 @@ class CompressionEngine:
         try:
             brain = await self._storage.get_brain(self._storage.current_brain_id or "")
         except Exception:
+            # Fail-soft on purpose: the refresh helper re-fetches per fiber, so the
+            # pass still completes. It is logged all the same, because two
+            # consequences are otherwise invisible: the one-lookup-per-pass
+            # optimisation quietly degrades to one lookup per fiber with nothing to
+            # explain the slowdown, and a persistent storage fault reaches the
+            # operator as a content_refresh warning blaming the embedding provider.
+            logger.warning(
+                "Brain pre-fetch failed; falling back to a per-fiber lookup", exc_info=True
+            )
             brain = None
 
         for idx, fiber in enumerate(fibers):

--- a/tests/unit/test_compression_brain_prefetch_logging.py
+++ b/tests/unit/test_compression_brain_prefetch_logging.py
@@ -1,0 +1,60 @@
+"""The compression pass logs a failed brain pre-fetch instead of degrading in silence.
+
+``CompressionEngine.run`` fetches the brain once per pass because the derived-field
+refresh needs its embedding config. The fetch is deliberately fail-soft — the refresh
+helper looks the brain up per fiber when it is missing — but a silent fallback hides
+both the loss of the optimisation and the real cause of any downstream warning.
+"""
+
+from typing import Any
+
+import pytest
+
+from surreal_memory.core.brain import Brain
+from surreal_memory.engine.compression import CompressionEngine
+from surreal_memory.storage.memory_store import InMemoryStorage
+
+_PREFETCH_WARNING = "Brain pre-fetch failed"
+
+
+async def _storage_with_brain() -> InMemoryStorage:
+    storage = InMemoryStorage()
+    brain = Brain.create(name="prefetch-brain")
+    await storage.save_brain(brain)
+    storage.set_brain(brain.id)
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_failed_brain_prefetch_is_logged(caplog: pytest.LogCaptureFixture) -> None:
+    storage = await _storage_with_brain()
+
+    async def _raise(_brain_id: str) -> Any:
+        raise RuntimeError("storage unavailable")
+
+    storage.get_brain = _raise  # type: ignore[method-assign]
+
+    with caplog.at_level("WARNING", logger="surreal_memory.engine.compression"):
+        report = await CompressionEngine(storage).run()
+
+    assert report is not None, "the pass must still complete; the fallback is fail-soft"
+    warnings = [r for r in caplog.records if _PREFETCH_WARNING in r.getMessage()]
+    assert warnings, (
+        f"expected a {_PREFETCH_WARNING!r} warning; got: {[r.getMessage() for r in caplog.records]}"
+    )
+    assert warnings[0].exc_info is not None, "the cause must travel with the warning"
+
+    await storage.close()
+
+
+@pytest.mark.asyncio
+async def test_successful_brain_prefetch_stays_quiet(caplog: pytest.LogCaptureFixture) -> None:
+    """Positive control: a pass that fetches its brain must not warn."""
+    storage = await _storage_with_brain()
+
+    with caplog.at_level("WARNING", logger="surreal_memory.engine.compression"):
+        await CompressionEngine(storage).run()
+
+    assert not [r for r in caplog.records if _PREFETCH_WARNING in r.getMessage()]
+
+    await storage.close()


### PR DESCRIPTION
## Summary

- The once-per-pass brain pre-fetch in `CompressionEngine.run` now logs a warning with the cause when it fails, rather than falling back in silence.
- Adds two tests: the failing fetch must warn and the pass must still complete; a successful fetch must stay quiet.

## Why

This is follow-up 2 from the review on #193, which described the problem better than I can paraphrase: the pre-fetch is *"the only unlogged `except`"* in a file where every other one logs, and although it is *"correctly fail-soft — the helper re-fetches per fiber"*, two consequences are invisible.

The first is a performance cliff with no signal. The whole point of the pre-fetch is one brain lookup per pass instead of one per fiber; when it fails, the pass quietly reverts to the per-fiber shape it was written to avoid, and nothing in the log accounts for the slowdown.

The second is worse, because it misdirects. If the storage problem persists, the operator does eventually see a warning — but it comes from `content_refresh` and blames the embedding provider. The actual fault is a brain fetch, in a different module, that said nothing.

A `logger.warning(..., exc_info=True)` before the fallback fixes both. It changes nothing about when any code runs.

## Changes

- `engine/compression.py`: a `logger.warning` with `exc_info=True` in the `except` around the brain pre-fetch, before `brain = None`, and a comment recording why the branch stays fail-soft.
- `tests/unit/test_compression_brain_prefetch_logging.py` (new): `test_failed_brain_prefetch_is_logged` swaps `get_brain` for a coroutine that raises and asserts both the warning and that `run` still returns a report; `test_successful_brain_prefetch_stays_quiet` is the positive control.

## Test plan

- [x] `pytest tests/unit/test_compression_brain_prefetch_logging.py` — 2 passed.
- [x] With `engine/compression.py` reverted to `main` and the tests kept, `test_failed_brain_prefetch_is_logged` fails on `AssertionError: expected a 'Brain pre-fetch failed' warning; got: []`, whilst the positive control still passes.
- [x] `pytest tests/ -m "not stress" -n 4` against a live SurrealDB v3.2.0 — 7285 passed, 48 skipped, 1 xfailed, which is `main`'s 7283 plus the two tests added here. Two tests in `tests/unit/test_dashboard_brains_scope.py` fail on this branch and on `main` alike: they want a live database and collide with one another under `-n`. Both pass when that file is run on its own.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 740 files already formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 354 source files.
- [x] Coverage under the CI gate: 72.37%, against 72.36% on `main`.
- [ ] `CHANGELOG.md` untouched — left to the release entry, as with #191–#193.

## Related issues

Follow-up 2 from the #193 review. Follow-up 1 from the same review — the `GRAPH_ONLY_PLACEHOLDER` constant — is a separate PR, since it touches a different set of files for a different reason.

## Verified by

@RobertSigmundsson
