### PR TITLE
fix(smem-hygiene): remember the gate's refusals, not only its saves

### DIFF
--- a/src/surreal_memory/hooks/capture_state.py
+++ b/src/surreal_memory/hooks/capture_state.py
@@ -83,6 +83,26 @@ def content_key(content: str) -> str:
     return hashlib.md5(norm.encode("utf-8")).hexdigest()
 
 
+def rejected_key(ck: str, min_score: int) -> str:
+    """Key marking a candidate the write gate REJECTED at ``min_score``.
+
+    Rejected candidates were never marked as seen, so every Stop/PreCompact
+    re-submitted them to the gate for as long as the transcript tail carried
+    them. Measured 2026-08-08: 499 auto decisions in 24h held only 134 distinct
+    contents (one fragment judged 36 times), inflating the gate's denominator
+    ~3.7x and making the observed accept rate look several times worse than it
+    was (0.39% on rows vs ~1.4% on distinct content).
+
+    Namespaced by the threshold **on purpose**: marking a rejection as a plain
+    seen-key would silence that content for the rest of the session even if the
+    threshold were lowered afterwards -- trading duplicate noise for silent
+    loss, which is the worse failure. Because the key embeds the score it was
+    judged against, changing ``auto_capture_min_score`` stops matching these
+    keys and every previously-rejected candidate gets a fresh hearing.
+    """
+    return f"rej{min_score}:{ck}"
+
+
 def _load_all() -> dict[str, Any]:
     path = _state_path()
     if not path.exists():

--- a/src/surreal_memory/hooks/pre_compact.py
+++ b/src/surreal_memory/hooks/pre_compact.py
@@ -129,7 +129,13 @@ async def flush_text(text: str, project_name: str | None = None) -> dict[str, An
     from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
     from surreal_memory.engine.dedup.factory import build_dedup_pipeline
     from surreal_memory.engine.encoder import MemoryEncoder
-    from surreal_memory.hooks.capture_state import content_key, load_seen, mark_seen, session_key
+    from surreal_memory.hooks.capture_state import (
+        content_key,
+        load_seen,
+        mark_seen,
+        rejected_key,
+        session_key,
+    )
     from surreal_memory.mcp.auto_capture import analyze_text_for_memories
     from surreal_memory.safety.input_firewall import check_content
     from surreal_memory.safety.sensitive import auto_redact_content
@@ -186,9 +192,18 @@ async def flush_text(text: str, project_name: str | None = None) -> dict[str, An
         seen = load_seen(skey)
         captured_keys: list[str] = []
         duplicate_skipped = False
+        # Suppress both what we already stored and what the gate already turned
+        # down at this threshold -- shared seen-set with the Stop hook, so a
+        # rejection recorded there must silence the candidate here too.
+        gate_min_score = config.write_gate.auto_capture_min_score
         if seen:
             before = len(boosted)
-            boosted = [it for it in boosted if content_key(it["content"]) not in seen]
+            boosted = [
+                it
+                for it in boosted
+                if content_key(it["content"]) not in seen
+                and rejected_key(content_key(it["content"]), gate_min_score) not in seen
+            ]
             duplicate_skipped = len(boosted) < before
 
         if not boosted:
@@ -250,6 +265,9 @@ async def flush_text(text: str, project_name: str | None = None) -> dict[str, An
                             gate_result.rejection_reason,
                         )
                         gate_rejected = True
+                        # Remember the refusal, not just the save: without this the
+                        # next compaction re-submits the identical fragment.
+                        captured_keys.append(rejected_key(content_key(content), gate_min_score))
                         continue
 
                 redacted_content, matches, _ = auto_redact_content(

--- a/src/surreal_memory/hooks/stop.py
+++ b/src/surreal_memory/hooks/stop.py
@@ -352,7 +352,13 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
     from surreal_memory.core.memory_types import MemoryType, Priority, TypedMemory
     from surreal_memory.engine.dedup.factory import build_dedup_pipeline
     from surreal_memory.engine.encoder import MemoryEncoder
-    from surreal_memory.hooks.capture_state import content_key, load_seen, mark_seen, session_key
+    from surreal_memory.hooks.capture_state import (
+        content_key,
+        load_seen,
+        mark_seen,
+        rejected_key,
+        session_key,
+    )
     from surreal_memory.mcp.auto_capture import analyze_text_for_memories
     from surreal_memory.safety.input_firewall import check_content
 
@@ -406,9 +412,18 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
         captured_keys: list[str] = []
         had_candidate = bool(eligible)
         duplicate_skipped = False
+        # Suppress both what we already stored and what the gate already turned
+        # down at this threshold -- otherwise a rejected fragment is re-judged on
+        # every turn for as long as it survives in the transcript tail.
+        gate_min_score = config.write_gate.auto_capture_min_score
         if seen and eligible:
             before = len(eligible)
-            eligible = [it for it in eligible if content_key(it["content"]) not in seen]
+            eligible = [
+                it
+                for it in eligible
+                if content_key(it["content"]) not in seen
+                and rejected_key(content_key(it["content"]), gate_min_score) not in seen
+            ]
             duplicate_skipped = len(eligible) < before
         # All originally-detected fragments were duplicates (none survived the
         # filter above) -- nothing left to even attempt the gate/encode loop,
@@ -464,6 +479,9 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
                             gate_result.rejection_reason,
                         )
                         gate_rejected = True
+                        # Remember the refusal, not just the save: without this the
+                        # next turn re-submits the identical fragment to the gate.
+                        captured_keys.append(rejected_key(content_key(content), gate_min_score))
                         continue
 
                 redacted_content, matches, _ = auto_redact_content(
@@ -510,7 +528,10 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
             summary = _extract_session_summary(text)
             if summary:
                 summary_had_candidate = True
-                if content_key(summary) in seen:
+                if (
+                    content_key(summary) in seen
+                    or rejected_key(content_key(summary), gate_min_score) in seen
+                ):
                     duplicate_skipped = True
                     summary = None  # type: ignore[assignment]
             if summary and len(summary) > 30:
@@ -542,6 +563,8 @@ async def capture_text(text: str, project_name: str | None = None) -> dict[str, 
                             gate_result.rejection_reason,
                         )
                         gate_rejected = True
+                        # Key must be taken before `summary` is cleared below.
+                        captured_keys.append(rejected_key(content_key(summary), gate_min_score))
                         summary = None  # type: ignore[assignment]
 
                 if summary:

--- a/tests/unit/test_capture_state.py
+++ b/tests/unit/test_capture_state.py
@@ -14,6 +14,7 @@ from surreal_memory.hooks.capture_state import (
     content_key,
     load_seen,
     mark_seen,
+    rejected_key,
     session_key,
 )
 
@@ -156,3 +157,56 @@ class TestFailOpen:
         blocker.write_text("x", encoding="utf-8")
         monkeypatch.setenv("SURREAL_MEMORY_DIR", str(blocker / "nested"))
         mark_seen("any-session", ["hash1"])  # must not raise
+
+
+class TestRejectedKey:
+    """Gate refusals are remembered too -- but only for the threshold that refused.
+
+    Rejected candidates used to be left unmarked, so the hooks re-submitted them
+    to the gate on every invocation. Measured on production 2026-08-08: 499 auto
+    decisions in 24h carried only 134 distinct contents (one fragment judged 36
+    times), inflating the gate's denominator ~3.7x.
+    """
+
+    def test_rejected_key_differs_from_plain_key(self) -> None:
+        ck = content_key("Decision: c remains explicitly open and unresolved")
+        assert rejected_key(ck, 5) != ck, (
+            "a refusal must not be recorded as an acceptance -- otherwise lowering "
+            "the threshold could never revive the content"
+        )
+
+    def test_rejected_key_is_threshold_scoped(self) -> None:
+        ck = content_key("Insight: the harvester stalled on shard three")
+        assert rejected_key(ck, 5) != rejected_key(ck, 4)
+
+    def test_rejected_key_is_stable(self) -> None:
+        ck = content_key("Error: flush_batch named the remote file from a stale counter")
+        assert rejected_key(ck, 5) == rejected_key(ck, 5)
+
+    def test_refusal_suppresses_at_same_threshold(self, isolated_state_dir: Path) -> None:
+        ck = content_key("Decision: b is blocked awaiting human authorization")
+        mark_seen("sess-a", [rejected_key(ck, 5)])
+        seen = load_seen("sess-a")
+        assert rejected_key(ck, 5) in seen
+
+    def test_refusal_expires_when_threshold_changes(self, isolated_state_dir: Path) -> None:
+        """The whole point of scoping: a lowered bar must give a second hearing.
+
+        Marking a refusal as a plain seen-key would silence that content for the
+        rest of the session even after the operator lowered the threshold --
+        trading duplicate noise for silent loss, which is the worse failure.
+        """
+        ck = content_key("Decision: b is blocked awaiting human authorization")
+        mark_seen("sess-b", [rejected_key(ck, 5)])
+        seen = load_seen("sess-b")
+        assert ck not in seen
+        assert rejected_key(ck, 4) not in seen, (
+            "after the threshold moved 5->4 the candidate must be judged again"
+        )
+
+    def test_accepted_key_survives_threshold_change(self, isolated_state_dir: Path) -> None:
+        """Acceptance is unconditional -- it must not be revived by a threshold move."""
+        ck = content_key("Insight: rclone token rotation confirmed on every mount")
+        mark_seen("sess-c", [ck])
+        seen = load_seen("sess-c")
+        assert ck in seen

--- a/tests/unit/test_hook_capture_idempotency.py
+++ b/tests/unit/test_hook_capture_idempotency.py
@@ -1,9 +1,9 @@
 """Behavioral regression tests for auto-capture hook idempotency (upstream #80).
 
-Reproduces the defect confirmed manually in ~/expertP/smem-idempotency-80/
-CHECKPOINTS/F1: the Stop and PreCompact hooks re-encode a session summary
-(or fragment) every time they are invoked for the same session, even when
-the effectively-captured text has not changed since the previous call.
+The defect, confirmed manually during development: the Stop and PreCompact
+hooks re-encode a session summary (or fragment) every time they are invoked
+for the same session, even when the effectively-captured text has not
+changed since the previous call.
 
 Every test here runs against a real, isolated in-memory brain (a fresh tmp_path
 HOME) -- never the shared prod brain. Each test uses a unique brain name and
@@ -365,3 +365,183 @@ class TestIdempotencyFuzz:
 
         assert actual_total_saved == expected_total_saved
         assert actual_total_saved == len(seen_options)
+
+
+class TestRejectedContentNotResubmitted:
+    """A refusal must be remembered, not only a save.
+
+    Until this was fixed only *successful* encodes were marked seen, so a
+    fragment the gate turned down came back on every subsequent invocation and
+    was judged -- and logged to ``gate_decision`` -- again. Measured on the live
+    brain 2026-08-08: 499 auto decisions over 24h carried just 134 distinct
+    contents, one fragment appearing 36 times between 07:30 and 17:34. Because
+    the accept rate is computed over those rows, the inflated denominator made
+    the gate look ~4x more hostile than it was (0.39% vs ~1.4%).
+    """
+
+    async def _count_gate_calls(self, monkeypatch: pytest.MonkeyPatch) -> list[str]:
+        """Count every gate decision actually logged, in call order.
+
+        ``log_gate_decision`` is what writes the ``gate_decision`` row, so it is
+        the exact quantity that inflated the denominator -- assert on it rather
+        than on a proxy.
+        """
+        from surreal_memory.engine import gate_telemetry
+
+        calls: list[str] = []
+        real = gate_telemetry.log_gate_decision
+
+        async def counting(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+            calls.append(str(kwargs.get("reason", "")))
+            return await real(*args, **kwargs)  # type: ignore[arg-type]
+
+        # The hooks do a function-local ``from ... import log_gate_decision``,
+        # which resolves the attribute at call time -- so patching the module
+        # attribute is enough and no import-order trickery is needed.
+        monkeypatch.setattr(gate_telemetry, "log_gate_decision", counting)
+        return calls
+
+    async def test_stop_hook_does_not_rejudge_rejected_content(
+        self, isolated_brain_gate_enforce: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls = await self._count_gate_calls(monkeypatch)
+
+        first = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        assert first["saved"] == 0
+        after_first = len(calls)
+        assert after_first >= 1, "the first call must actually reach the gate"
+
+        second = await stop_hook.capture_text(_TEXT_A, project_name=None)
+        assert second["saved"] == 0
+        assert len(calls) == after_first, (
+            "identical content already refused this session must not be judged "
+            f"again; gate was invoked {len(calls) - after_first} extra time(s)"
+        )
+
+    async def test_pre_compact_honours_refusal_recorded_by_stop(
+        self, isolated_brain_gate_enforce: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PreCompact must not re-judge a fragment Stop already refused.
+
+        The earlier version of this test fed ``_TEXT_A`` straight to
+        ``flush_text()``, which never reaches the gate at all for that input —
+        the detector finds nothing above the emergency threshold, so the test
+        passed even with the fix entirely removed (``gate_calls=0`` on both
+        sides). This version forces the path: both hooks' detector is patched
+        to return one controlled fragment, the gate is patched to reject it,
+        and the test counts actual gate invocations — Stop must reach it
+        exactly once, PreCompact not at all.
+        """
+        from surreal_memory.engine.quality_scorer import QualityResult
+
+        gate_calls: list[str] = []
+
+        def _rejecting_gate(content: str, **kwargs: object) -> QualityResult:
+            gate_calls.append(content)
+            return QualityResult(
+                score=1, quality="low", rejected=True, rejection_reason="test refusal"
+            )
+
+        # Both hooks resolve check_write_gate via a function-local import, so
+        # patching the source module covers both paths.
+        monkeypatch.setattr(
+            "surreal_memory.engine.quality_scorer.check_write_gate", _rejecting_gate
+        )
+
+        fragment = {
+            "content": "The release manager approved the rollback plan after the incident review.",
+            "confidence": 0.95,
+            "priority": 5,
+            "type": "decision",
+        }
+
+        def _one_fragment(*args: object, **kwargs: object) -> list[dict[str, object]]:
+            return [dict(fragment)]
+
+        monkeypatch.setattr(
+            "surreal_memory.mcp.auto_capture.analyze_text_for_memories", _one_fragment
+        )
+
+        first = await stop_hook.capture_text(fragment["content"], project_name=None)
+        assert first["saved"] == 0
+        after_stop = len(gate_calls)
+        # The stop hook gates the fragment and (after the refusal) its session
+        # summary fallback, so >= 2 gate calls are expected there; what
+        # matters is that the fragment itself reached the gate and was refused.
+        assert after_stop >= 2, (
+            f"the stop hook must reach the gate at least twice (fragment + summary), "
+            f"got {after_stop}: {gate_calls}"
+        )
+
+        second = await pre_compact_hook.flush_text(fragment["content"], project_name=None)
+        assert second["saved"] == 0
+        assert len(gate_calls) == after_stop, (
+            "PreCompact re-judged content the Stop hook had already refused: "
+            f"gate was invoked {len(gate_calls) - after_stop} extra time(s)"
+        )
+
+    async def test_pre_compact_records_its_own_refusal(
+        self, isolated_brain_gate_enforce: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The refusal recording must also live in PreCompact's own reject
+        branch — a fragment PreCompact refuses (Stop never saw it) must not
+        be re-judged on the next PreCompact. Covers the `captured_keys.append`
+        hunk in `pre_compact.py` that the Stop-side test cannot reach."""
+        from surreal_memory.engine.quality_scorer import QualityResult
+
+        gate_calls: list[str] = []
+
+        def _rejecting_gate(content: str, **kwargs: object) -> QualityResult:
+            gate_calls.append(content)
+            return QualityResult(
+                score=1, quality="low", rejected=True, rejection_reason="test refusal"
+            )
+
+        monkeypatch.setattr(
+            "surreal_memory.engine.quality_scorer.check_write_gate", _rejecting_gate
+        )
+
+        fragment = {
+            "content": "The on-call engineer drained the failed node before the midnight rollout.",
+            "confidence": 0.95,
+            "priority": 5,
+            "type": "fact",
+        }
+
+        def _one_fragment(*args: object, **kwargs: object) -> list[dict[str, object]]:
+            return [dict(fragment)]
+
+        monkeypatch.setattr(
+            "surreal_memory.mcp.auto_capture.analyze_text_for_memories", _one_fragment
+        )
+
+        first = await pre_compact_hook.flush_text(fragment["content"], project_name=None)
+        assert first["saved"] == 0
+        after_first = len(gate_calls)
+        assert after_first >= 1, "the first PreCompact must actually reach the gate"
+
+        second = await pre_compact_hook.flush_text(fragment["content"], project_name=None)
+        assert second["saved"] == 0
+        assert len(gate_calls) == after_first, (
+            "PreCompact re-judged content it had already refused itself: "
+            f"gate was invoked {len(gate_calls) - after_first} extra time(s)"
+        )
+
+    async def test_new_content_still_reaches_the_gate(
+        self, isolated_brain_gate_enforce: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Positive control: suppression must be specific, not a blanket mute.
+
+        Without this, a bug that silenced *everything* after the first call would
+        pass both assertions above.
+        """
+        calls = await self._count_gate_calls(monkeypatch)
+
+        await stop_hook.capture_text(_TEXT_A, project_name=None)
+        after_first = len(calls)
+
+        await stop_hook.capture_text(_TEXT_B, project_name=None)
+        assert len(calls) > after_first, (
+            "different content must still be judged -- the refusal cache is "
+            "keyed on content, not on 'anything already tried'"
+        )


### PR DESCRIPTION
## Summary

- The auto-capture hooks now record the write gate's refusals in the idempotency ledger, not only its acceptances, so a rejected fragment is judged once per session instead of on every Stop.
- `PreCompact` honours a refusal `Stop` already recorded, and records its own.
- Adds ten tests, including three that count gate invocations rather than trusting a save count.

## Why

The ledger from #115 remembered what the gate accepted. A refusal left no trace at all, so the next Stop in the same session re-extracted the same fragment, re-encoded it, and put it to the gate again — which, being deterministic, refused it again. `PreCompact` then repeated the exercise from the top. Nothing crashes and nothing corrupts; the gate simply does the same homework on the same content forever, which is a shame in a mechanism that exists to stop precisely that.

Measured on one live brain over twenty-four hours on 2026-08-08: 499 auto decisions carried just 134 distinct contents, one fragment having been judged thirty-six times. That inflates the gate's denominator about 3.7-fold and makes its observed accept rate look several times worse than it is — 0.39% counted over rows against roughly 1.4% over distinct content. The wasted encoding is the smaller half of the cost; the misleading acceptance statistic is the half that gets acted upon.

## Changes

- `hooks/capture_state.py`: vocabulary for recording a refusal, keyed so that it is scoped to the threshold that produced it. A refusal recorded under one threshold does not suppress a re-judgement after the threshold changes, whilst an acceptance survives such a change.
- `hooks/stop.py`: the main capture loop records the refusal alongside the outcomes it already recorded.
- `hooks/pre_compact.py`: honours a refusal recorded by `Stop` rather than re-deciding it, and records its own refusals the same way.
- `tests/unit/test_capture_state.py` (+6) and `tests/unit/test_hook_capture_idempotency.py` (+4).

## One rough edge, disclosed rather than hidden

When every detected fragment was duplicate-filtered, the run reports the existing `duplicate content already captured` status and does not fall through to a session summary. Reusing that message is slightly imprecise — the two situations are not identical — but replacing an accurate duplicate status with a brand-new summary save would be the worse outcome, and a separate counter looked like more machinery than the distinction earns. Happy to split it if you would rather the two were distinguishable.

The module docstring in `test_hook_capture_idempotency.py` also loses a stale absolute path from a developer's machine. The file is being edited here anyway, so it seemed a good moment.

## Test plan

- [x] `pytest tests/unit/test_hook_capture_idempotency.py tests/unit/test_capture_state.py` — 43 passed.
- [x] Differential control, and the reason it is reported in two layers: an earlier shape of `test_pre_compact_honours_refusal_recorded_by_stop` **passed with the fix entirely removed**, because `PreCompact` never reached the gate on that input and the assertion could not distinguish that from success. The tests now count gate invocations and assert the gate *was* called before asserting it was not called again.
  - Reverting only `hooks/pre_compact.py`: 2 failed, 14 passed — `test_pre_compact_honours_refusal_recorded_by_stop` and `test_pre_compact_records_its_own_refusal`.
  - Reverting `hooks/pre_compact.py` and `hooks/stop.py`: 3 failed, 40 passed — the two above plus `test_stop_hook_does_not_rejudge_rejected_content`.
  - Each test is therefore pinned to the file whose hunk it covers.
- [x] Line coverage of the change itself, rather than of the modules: every executable line this PR adds to `capture_state.py`, `pre_compact.py` and `stop.py` is executed by the tests above — 12 statements, 0 uncovered. (The modules' own totals are low because they are large hook entry points with a great deal of unrelated code.)
- [x] `pytest tests/ -m "not stress" -n 4` against a live SurrealDB v3.2.0 — 7293 passed, 48 skipped, 1 xfailed, which is `main`'s 7283 plus exactly the ten tests added here. Two tests in `tests/unit/test_dashboard_brains_scope.py` fail on this branch and on `main` alike: they want a live database and collide with one another under `-n`. Both pass when that file is run on its own.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 739 files already formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 354 source files.
- [x] Coverage under the CI gate: 72.44%, against 72.36% on `main`.
- [ ] `CHANGELOG.md` untouched — left to the release entry, as with #191–#193.

## Related issues

None filed. #115 introduced the ledger this extends; the refusal half was simply never part of it.

## Verified by

@RobertSigmundsson
