### PR TITLE
fix(server): PUT /memory/neurons refreshes content_hash and the embedding on a content change

### DIFF
--- a/src/surreal_memory/server/routes/memory.py
+++ b/src/surreal_memory/server/routes/memory.py
@@ -31,6 +31,7 @@ from surreal_memory.server.models import (
     SynapseUpdateRequest,
 )
 from surreal_memory.storage.base import NeuralStorage
+from surreal_memory.utils.content_refresh import content_refreshed
 
 router = APIRouter(
     prefix="/memory",
@@ -526,7 +527,29 @@ async def update_neuron(
     if request.metadata is not None:
         updates["metadata"] = request.metadata
 
-    updated = replace(neuron, **updates)
+    # Apply type/metadata first via replace(), then refresh content-derived
+    # fields (content_hash, embedding) only when content actually changed.
+    # Same helper as smem_edit (#166) and the engine paths (#193); a
+    # metadata-only PUT or a PUT with unchanged content stays a one-write op.
+    new_content = updates.pop("content", None)
+    updated = replace(neuron, **updates) if updates else neuron
+    if new_content is not None and new_content != updated.content:
+        # `_embedding` is an internal key (`utils/content_refresh.py` reads it
+        # to decide whether to re-embed). A PUT that ships `metadata` alongside
+        # a content change replaces the whole dict, so the pre-edit `_embedding`
+        # would be gone before the helper ever saw it — and the old vector
+        # would stay in the row, describing text that no longer exists. Carry
+        # the internal key forward (unless the caller explicitly provided
+        # one) so content_refreshed can refresh it.
+        if (
+            neuron.metadata.get("_embedding") is not None
+            and updated.metadata.get("_embedding") is None
+        ):
+            updated = replace(
+                updated,
+                metadata={**updated.metadata, "_embedding": neuron.metadata["_embedding"]},
+            )
+        updated = await content_refreshed(storage, updated, new_content)
     await storage.update_neuron(updated)
 
     return NeuronResponse(

--- a/tests/unit/test_server_update_neuron_content_refresh.py
+++ b/tests/unit/test_server_update_neuron_content_refresh.py
@@ -1,0 +1,259 @@
+"""Regression: PUT /neurons/{id} must refresh content_hash and the embedding.
+
+`update_neuron` in `server/routes/memory.py` used `dataclasses.replace(neuron,
+**updates)`, which only touches the fields it is given. `content_hash` and
+`metadata["_embedding"]` (both derived from the neuron's text) carried over
+from the pre-edit neuron, so a REST update that changed `content` persisted
+new text against an old fingerprint and old vector: recall by the new
+content missed, recall by the old content still hit. This is the same
+shape #166 fixed for `smem_edit` and #193 rolled out across the engine
+and MCP handlers via `utils/content_refresh.content_refreshed`; the REST
+route was the last write path left with the bug.
+
+The fix threads `content_refreshed` through the route, guarded so it only
+fires when `content` actually changed — a metadata-only PUT stays a
+one-write op.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.server.routes.memory import update_neuron
+from surreal_memory.utils.simhash import simhash
+
+
+class _Request:
+    """Minimal stand-in for NeuronUpdateRequest — only the fields the route reads."""
+
+    def __init__(
+        self,
+        *,
+        type: str | None = None,
+        content: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self.type = type
+        self.content = content
+        self.metadata = metadata
+
+
+def _neuron(*, content: str = "old content", metadata: dict[str, Any] | None = None) -> Neuron:
+    return Neuron(
+        id="n0",
+        type=NeuronType.CONCEPT,
+        content=content,
+        metadata=dict(metadata) if metadata else {},
+        created_at=datetime(2026, 9, 4, tzinfo=UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_content_change_refreshes_hash() -> None:
+    """The regression: a content-change PUT must recompute content_hash."""
+    old = _neuron(content="old content")
+    old_hash = old.content_hash
+
+    captured: dict[str, Neuron] = {}
+
+    async def _update(neuron: Neuron) -> None:
+        captured["written"] = neuron
+
+    storage = SimpleNamespace(
+        get_neuron=AsyncMock(return_value=old),
+        update_neuron=_update,
+        get_brain=AsyncMock(return_value=None),
+    )
+    brain = type("B", (), {"id": "brain-0"})()
+
+    response = await update_neuron(
+        neuron_id="n0",
+        request=_Request(content="new content"),
+        brain=brain,
+        storage=storage,
+    )
+
+    written = captured["written"]
+    assert written.content == "new content"
+    assert written.content_hash == simhash("new content"), (
+        f"expected content_hash to reflect the NEW content ({simhash('new content')!r}); "
+        f"got {written.content_hash!r} (unchanged from old={old_hash!r})"
+    )
+    assert response.content == "new content"
+
+
+@pytest.mark.asyncio
+async def test_content_change_refreshes_embedding_when_one_exists() -> None:
+    """Neuron with a stored `_embedding` — helper must refresh the vector, not
+    persist the old one against the new text."""
+    from unittest.mock import patch
+
+    old = _neuron(content="old content", metadata={"_embedding": [0.1, 0.2, 0.3]})
+
+    captured: dict[str, Neuron] = {}
+
+    async def _update(neuron: Neuron) -> None:
+        captured["written"] = neuron
+
+    storage = SimpleNamespace(
+        get_neuron=AsyncMock(return_value=old),
+        update_neuron=_update,
+        get_brain=AsyncMock(return_value=None),
+    )
+    brain = type("B", (), {"id": "brain-0"})()
+
+    # Patch content_refreshed at its import site inside the route module,
+    # so the assertion measures that the route CALLS the shared helper —
+    # the exact contract this PR restores. A live provider round-trip is
+    # covered by the sibling test_edit_forget suite via the same helper.
+    refreshed_marker = _neuron(content="new content", metadata={"_embedding": [0.9, 0.8, 0.7]})
+    from dataclasses import replace as dc_replace
+
+    from surreal_memory.utils.simhash import simhash as _simhash
+
+    refreshed_marker = dc_replace(refreshed_marker, content_hash=_simhash("new content"))
+
+    async def _fake_content_refreshed(_storage: Any, _neuron: Neuron, _new: str) -> Neuron:
+        return refreshed_marker
+
+    with patch(
+        "surreal_memory.server.routes.memory.content_refreshed",
+        side_effect=_fake_content_refreshed,
+    ) as spy:
+        await update_neuron(
+            neuron_id="n0",
+            request=_Request(content="new content"),
+            brain=brain,
+            storage=storage,
+        )
+
+    spy.assert_called_once()
+    written = captured["written"]
+    assert written.metadata["_embedding"] == [0.9, 0.8, 0.7], (
+        "embedding must be the refreshed vector, not the pre-edit one"
+    )
+
+
+@pytest.mark.asyncio
+async def test_metadata_only_put_does_not_call_content_refresh() -> None:
+    """Behaviour-preserving: metadata-only PUT stays a one-write op, no
+    accidental round-trip to the embed provider."""
+    from unittest.mock import patch
+
+    old = _neuron(content="unchanged", metadata={"_embedding": [0.1]})
+    captured: dict[str, Neuron] = {}
+
+    async def _update(neuron: Neuron) -> None:
+        captured["written"] = neuron
+
+    storage = SimpleNamespace(
+        get_neuron=AsyncMock(return_value=old),
+        update_neuron=_update,
+    )
+    brain = type("B", (), {"id": "brain-0"})()
+
+    with patch("surreal_memory.server.routes.memory.content_refreshed") as spy:
+        await update_neuron(
+            neuron_id="n0",
+            request=_Request(metadata={"tag": "new"}),
+            brain=brain,
+            storage=storage,
+        )
+
+    spy.assert_not_called()
+    assert captured["written"].content == "unchanged"
+
+
+@pytest.mark.asyncio
+async def test_content_and_metadata_put_preserves_embedding_for_refresh() -> None:
+    """Regression: a PUT that changes `content` AND ships `metadata` replaces
+    the whole metadata dict, so the pre-edit `_embedding` would be gone before
+    `content_refreshed` ever saw it — and the old vector would stay in the
+    row, describing text that no longer exists. The route must carry the
+    internal key forward so the helper re-embeds."""
+    from unittest.mock import patch
+
+    old = _neuron(content="old content", metadata={"_embedding": [0.1, 0.2, 0.3]})
+    old_vector = old.metadata["_embedding"]
+
+    captured: dict[str, Neuron] = {}
+
+    async def _update(neuron: Neuron) -> None:
+        captured["written"] = neuron
+
+    storage = SimpleNamespace(
+        get_neuron=AsyncMock(return_value=old),
+        update_neuron=_update,
+        get_brain=AsyncMock(return_value=None),
+    )
+    brain = type("B", (), {"id": "brain-0"})()
+
+    seen_by_helper: dict[str, Neuron] = {}
+
+    async def _fake_content_refreshed(storage_: Any, neuron: Neuron, new: str) -> Neuron:
+        seen_by_helper["neuron"] = neuron
+        refreshed = _neuron(
+            content=new, metadata={**neuron.metadata, "_embedding": [0.9, 0.8, 0.7]}
+        )
+        return refreshed
+
+    with patch(
+        "surreal_memory.server.routes.memory.content_refreshed",
+        side_effect=_fake_content_refreshed,
+    ) as spy:
+        await update_neuron(
+            neuron_id="n0",
+            request=_Request(content="new content", metadata={"tag": "shipped-with-content"}),
+            brain=brain,
+            storage=storage,
+        )
+
+    spy.assert_called_once()
+    handed = seen_by_helper["neuron"]
+    # The helper receives the pre-content neuron plus the new content string —
+    # content_refreshed itself performs the content swap. What the route must
+    # guarantee is that the metadata it hands over still carries the vector.
+    assert handed.content == "old content"
+    assert handed.metadata["tag"] == "shipped-with-content", "caller metadata must survive"
+    assert handed.metadata.get("_embedding") == old_vector, (
+        "the pre-edit vector must be carried into content_refreshed so it can "
+        f"be re-embedded; got {handed.metadata.get('_embedding')!r} (was {old_vector!r})"
+    )
+    assert captured["written"].metadata["_embedding"] == [0.9, 0.8, 0.7], (
+        "the refreshed vector must be what the storage write sees"
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_content_put_skips_content_refresh() -> None:
+    """Sending the same content in a PUT is a no-op on the derived fields —
+    guard prevents an unnecessary embed round-trip."""
+    from unittest.mock import patch
+
+    old = _neuron(content="same text")
+    captured: dict[str, Neuron] = {}
+
+    async def _update(neuron: Neuron) -> None:
+        captured["written"] = neuron
+
+    storage = SimpleNamespace(
+        get_neuron=AsyncMock(return_value=old),
+        update_neuron=_update,
+    )
+    brain = type("B", (), {"id": "brain-0"})()
+
+    with patch("surreal_memory.server.routes.memory.content_refreshed") as spy:
+        await update_neuron(
+            neuron_id="n0",
+            request=_Request(content="same text"),
+            brain=brain,
+            storage=storage,
+        )
+
+    spy.assert_not_called()


### PR DESCRIPTION
## Summary

- `PUT /memory/neurons/{id}` now refreshes `content_hash` and the embedding when the content changes, instead of re-saving the old ones against the new text.
- It carries the internal `_embedding` key forward when the same request also sends `metadata`, which is the case where refreshing the hash alone would leave the vector stranded.
- A metadata-only PUT, or one whose content is unchanged, stays a single write with no provider call.
- Adds five tests covering both halves and the 404.

## Why

The route built `replace(neuron, **updates)` with the new content and handed it to `update_neuron`, which derives `content_hash` from the object and the vector from `metadata["_embedding"]`. Both therefore continued to describe the text that had just been replaced: the memory stayed findable by content that no longer existed, and near-duplicate detection compared it against a fingerprint of the old text.

This is the class #166 fixed for `smem_edit` and #193 fixed for the engine paths. #193 explicitly left this route out as a separate surface with its own test story; this is that follow-up.

## The half that is easy to miss

`content_refreshed` re-embeds only when `metadata["_embedding"]` is present — that is how it tells "this neuron has a vector to refresh" apart from "this one never had one". A PUT that sends `metadata` alongside a content change replaces the whole dict, so the key is gone before the helper ever sees it. The hash gets refreshed, the vector silently does not, and nothing is logged.

That failure is invisible from the outside, which is why it is worth stating how it was measured rather than asserted. Against a live server and a live SurrealDB v3.2.0, with a neuron seeded with a 3072-dimension vector and matching `_embedding`:

| PUT | this branch | the same route without the carry-forward hunk |
|---|---|---|
| content only | refresh path entered | refresh path entered |
| **content + metadata** | **refresh path entered** | **not entered** |
| `content_hash`, either request | changes | **changes** |
| server log, content + metadata | `WARNING … Content of neuron … changed but the embeddings could not be recomputed - the stored vectors still describe the old content; run 'smem reindex --all' to repair them.` | silent |

Over the same pair of requests that is two entries against one. The content-only PUT behaves identically on both — it always reached the helper — so the whole difference sits in the row in bold. The hash changes either way, which is precisely how an earlier version of this change looked correct whilst half of it did nothing: measuring the hash proves nothing at all about the vector.

## Changes

- `server/routes/memory.py`: pop `content` out of the update set, apply the rest via `replace`, and call `content_refreshed` only when the content actually differs. Before that call, if the stored neuron had an `_embedding` and the incoming `metadata` does not carry one, the key is carried forward so the helper can act on it. A caller who supplies their own `_embedding` keeps it.
- `tests/unit/test_server_update_neuron_content_refresh.py` (new): content-only, content with metadata, metadata-only, unchanged content, and the 404.

## Test plan

- [x] `pytest tests/unit/test_server_update_neuron_content_refresh.py` — 5 passed.
- [x] Differential control in two layers, because the change has two halves:
  - Reverting the whole route to `main`: all 5 fail.
  - Reverting only the `_embedding` carry-forward and keeping the rest: exactly 1 fails, `test_content_and_metadata_put_preserves_embedding_for_refresh`. The other four still pass, which is what makes that test worth having.
- [x] Live, against `smem serve` and a SurrealDB v3.2.0 instance: the table above, plus a metadata-only PUT and an unchanged-content PUT that both correctly skip the refresh, `404` for an unknown id, `400` for a `type` outside the enum, and `405` for `PATCH`.
- [x] `pytest tests/ -m "not stress" -n 4` — 7288 passed, 48 skipped, 1 xfailed, which is `main`'s 7283 plus the five tests added here. Two tests in `tests/unit/test_dashboard_brains_scope.py` fail on this branch and on `main` alike: they want a live database and collide with one another under `-n`. Both pass when that file is run on its own.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 740 files already formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 354 source files.
- [x] Coverage under the CI gate: 72.40%, against 72.36% on `main`.
- [ ] `CHANGELOG.md` untouched — left to the release entry, as with #191–#193.

One limit, stated rather than glossed. The live box had no embedding provider installed, so the *new vector value* was not measured end to end: the refresh is attempted and reports that it could not complete. What the live run establishes is that the attempt happens at all, which is the entire difference between the two versions. The unit tests do not close that gap either — they patch `content_refreshed` itself, so they prove the route hands the helper a neuron that still carries `_embedding`, not that the helper then recomputes the vector. The helper's own behaviour is covered where the helper lives. If you would rather see the recomputation end to end before merging, say so and I will run it against a box with a provider.

## Verified by

@RobertSigmundsson
