### PR TITLE
fix(tests): the mock embedding provider must not depend on the hash seed

### DIFF
--- a/tests/unit/test_embedding_provider.py
+++ b/tests/unit/test_embedding_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import math
 import sys
 import types
@@ -25,7 +26,10 @@ class MockEmbeddingProvider(EmbeddingProvider):
 
     async def embed(self, text: str) -> list[float]:
         """Simple deterministic embedding based on text hash."""
-        h = hash(text) % 1000
+        # blake2b rather than hash(): the built-in is salted per interpreter, so the
+        # vectors — and any collisions between them — change from one run to the next.
+        digest = hashlib.blake2b(text.encode("utf-8"), digest_size=8).digest()
+        h = int.from_bytes(digest, "big") % 1000
         vec = [(h + i) / 1000.0 for i in range(self._dim)]
         # Normalize
         norm = math.sqrt(sum(v * v for v in vec))
@@ -132,6 +136,23 @@ class TestEmbeddingProvider:
         v1 = await provider.embed("text a")
         v2 = await provider.embed("text b")
         assert v1 != v2
+
+    @pytest.mark.asyncio
+    async def test_embedding_does_not_depend_on_the_hash_seed(self) -> None:
+        """The same text must embed the same way in every interpreter.
+
+        The built-in hash() is salted per process, so a mock built on it returns
+        different vectors — and collides between different texts — depending on
+        PYTHONHASHSEED. These constants pin the values; they fail on a salted hash
+        under every seed but the one that happened to produce them.
+        """
+        provider = MockEmbeddingProvider(dim=4)
+        assert await provider.embed("text a") == pytest.approx(
+            [0.4964469643895588, 0.49881099755331865, 0.5011750307170785, 0.5035390638808382]
+        )
+        assert await provider.embed("text b") == pytest.approx(
+            [0.49896989968480343, 0.4996562406747413, 0.5003425816646792, 0.501028922654617]
+        )
 
 
 # ── Cosine similarity tests ─────────────────────────────────────


### PR DESCRIPTION
## Summary

- `MockEmbeddingProvider` derives its vector from the built-in `hash()`, which CPython salts per
  interpreter, so the mock returns different vectors from run to run.
- With a modulus of 1000, two different texts collide roughly once in a thousand runs, and
  `test_different_texts_differ` then fails on two byte-identical vectors.
- `blake2b` gives the same digest in every process, so a collision between two texts is now a
  property of the texts rather than of the seed the job happened to draw.

## Why

`Test (Python 3.11)` failed on a pull request whose diff touched `unified_config.py` and a
consolidation test, several directories away from embeddings:

```
tests/unit/test_embedding_provider.py:134: in test_different_texts_differ
    assert v1 != v2
E   assert [0.4987766778715924, …] != [0.4987766778715924, …]
```

A mock written for determinism should be deterministic; a failure whose cause is the hash seed
teaches contributors to re-run the job rather than read it, which is a habit worth avoiding.

## Changes

- `tests/unit/test_embedding_provider.py`: `MockEmbeddingProvider.embed` derives `h` from
  `hashlib.blake2b(text.encode("utf-8"), digest_size=8)` instead of `hash(text)`.
- The same file gains `test_embedding_does_not_depend_on_the_hash_seed`, which pins the vectors
  for `"text a"` and `"text b"`. On a salted hash it fails under every seed but the one that
  produced the constants, so the old behaviour cannot return unnoticed.

## Test plan

- [x] `PYTHONHASHSEED=99 pytest tests/unit/test_embedding_provider.py` on `main` — `1 failed,
      82 passed`, the failure being `test_different_texts_differ` with two identical vectors.
      Seed 99 is simply one that collides; most seeds pass, which is the bug.
- [x] The same command on this branch — `84 passed`. Also green under seeds 0, 1, 7, 12345 and
      424242, each `84 passed`.
- [x] With the change reverted and both tests kept, `test_embedding_does_not_depend_on_the_hash_seed`
      fails under all four seeds tried, and seed 99 additionally fails `test_different_texts_differ`.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 739 files already
      formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 354 source files.
- [x] `pytest tests/ --timeout=120 -m "not stress"` against a live SurrealDB v3.2.0 on a freshly
      created namespace, serial as the `Integration (SurrealDB)` job runs it — 7286 passed, 48
      skipped, 1 xfailed, which is `main`'s 7285 measured in the same environment plus the one
      test added here.
- [ ] `CHANGELOG.md` untouched — left to the release entry.

## Related issues

Reported in #226.

## Verified by @RobertSigmundsson
