### PR TITLE
fix(dashboard): hold the background diagnostics refresh, and drain it in the live tests

### DIFF
--- a/src/surreal_memory/server/routes/dashboard_api.py
+++ b/src/surreal_memory/server/routes/dashboard_api.py
@@ -42,6 +42,7 @@ _GRADE_REFRESH_KEYS: set[str] = set()
 _BRAINS_LAST_GOOD: list[BrainSummary] | None = None
 _BRAINS_REFRESHING = False
 _BRAINS_REFRESH_TASKS: set[asyncio.Task[None]] = set()
+_GRADE_REFRESH_TASKS: set[asyncio.Task[Any]] = set()
 
 # Brain-wide uncertainty overview is bounded/cheap, but cached per brain for a short
 # window anyway to keep the dashboard's polling off the storage hot path (same
@@ -115,6 +116,10 @@ def _schedule_grade_refresh(storage: NeuralStorage, brain_name: str, key: str) -
         return report
 
     task = asyncio.get_running_loop().create_task(_refresh())
+    # Strong reference: the event loop discards tasks nobody holds, exactly as
+    # the brain refresh above already guards against.
+    _GRADE_REFRESH_TASKS.add(task)
+    task.add_done_callback(_GRADE_REFRESH_TASKS.discard)
     task.add_done_callback(_done)
 
 

--- a/tests/unit/test_dashboard_brains_scope.py
+++ b/tests/unit/test_dashboard_brains_scope.py
@@ -32,7 +32,9 @@ Two layers of coverage per endpoint, mirroring test_route_hub.py:
 
 from __future__ import annotations
 
+import asyncio
 import os
+from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -345,6 +347,27 @@ class TestGetStatsDoesNotLeakBrainState:
 )
 class TestListBrainsScopeLive:
     @pytest.fixture(autouse=True)
+    async def _drain_background_refreshes(self) -> AsyncIterator[None]:
+        """Let the route's background refreshes finish before the loop goes away.
+
+        `/api/dashboard/brains` serves stale data and refreshes behind the
+        request, so a task is still querying the store when the test returns.
+        pytest-asyncio then tears the function-scoped loop down and cancels that
+        task itself; most of the time it stops at once, and occasionally it is
+        inside the SDK's receive path and the loop waits on it until
+        pytest-timeout fires at 120 s. Draining the tasks here — on the loop
+        that owns them — keeps the teardown deterministic.
+        """
+        yield
+        from surreal_memory.server.routes import dashboard_api
+
+        pending = dashboard_api._BRAINS_REFRESH_TASKS | dashboard_api._GRADE_REFRESH_TASKS
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.wait(pending, timeout=10)
+
+    @pytest.fixture(autouse=True)
     def _reset_brains_module_state(self) -> Any:
         """Each test starts with a cold serve-stale state (isolated contract)."""
         from surreal_memory.server.routes import dashboard_api
@@ -403,6 +426,27 @@ class TestListBrainsScopeLive:
     reason="requires SURREALDB_URL env var pointing to a running SurrealDB",
 )
 class TestGetStatsScopeLive:
+    @pytest.fixture(autouse=True)
+    async def _drain_background_refreshes(self) -> AsyncIterator[None]:
+        """Let the route's background refreshes finish before the loop goes away.
+
+        `/api/dashboard/brains` serves stale data and refreshes behind the
+        request, so a task is still querying the store when the test returns.
+        pytest-asyncio then tears the function-scoped loop down and cancels that
+        task itself; most of the time it stops at once, and occasionally it is
+        inside the SDK's receive path and the loop waits on it until
+        pytest-timeout fires at 120 s. Draining the tasks here — on the loop
+        that owns them — keeps the teardown deterministic.
+        """
+        yield
+        from surreal_memory.server.routes import dashboard_api
+
+        pending = dashboard_api._BRAINS_REFRESH_TASKS | dashboard_api._GRADE_REFRESH_TASKS
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.wait(pending, timeout=10)
+
     @pytest.fixture(autouse=True)
     def _reset_brains_module_state(self) -> Any:
         """Each test starts with a cold serve-stale state (isolated contract)."""

--- a/tests/unit/test_dashboard_cache.py
+++ b/tests/unit/test_dashboard_cache.py
@@ -8,6 +8,7 @@ hit within TTL, miss after expiry, disable via ttl=0 / env, and invalidation.
 from __future__ import annotations
 
 import importlib
+import unittest.mock
 
 import pytest
 
@@ -276,3 +277,49 @@ class TestHealthReportTTL:
         from surreal_memory.server.routes.dashboard_api import _HEALTH_TTL_SECONDS
 
         assert _HEALTH_TTL_SECONDS >= 300
+
+
+class TestBackgroundRefreshKeepsItsTask:
+    """The scheduler promises a strong reference; asyncio only keeps a weak one.
+
+    `_schedule_grade_refresh` says in its own docstring that "a strong reference
+    to the task is kept until it finishes", because the loop discards tasks
+    nobody holds. The brain refresh alongside it does exactly that with a
+    module-level set; the grade refresh kept the task in a local that went out
+    of scope the moment the function returned.
+    """
+
+    @pytest.mark.asyncio
+    async def test_scheduled_refresh_is_held_until_it_finishes(self) -> None:
+        import asyncio
+
+        from surreal_memory.server.routes import dashboard_api
+
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        class _SlowEngine:
+            def __init__(self, storage: object) -> None:
+                self._storage = storage
+
+            async def analyze(self, brain_name: str) -> str:
+                started.set()
+                await release.wait()
+                return "report"
+
+        with unittest.mock.patch(
+            "surreal_memory.engine.diagnostics.DiagnosticsEngine", _SlowEngine
+        ):
+            dashboard_api._GRADE_REFRESH_KEYS.discard("brain:key")
+            dashboard_api._schedule_grade_refresh(object(), "brain", "brain:key")
+            await asyncio.wait_for(started.wait(), timeout=5)
+
+            assert dashboard_api._GRADE_REFRESH_TASKS, (
+                "the running refresh must be referenced somewhere other than the "
+                "event loop, or it can be garbage-collected mid-flight"
+            )
+
+            release.set()
+            await asyncio.wait(set(dashboard_api._GRADE_REFRESH_TASKS), timeout=5)
+
+        assert not dashboard_api._GRADE_REFRESH_TASKS, "a finished task must be dropped"


### PR DESCRIPTION
## Summary

- `_schedule_grade_refresh` keeps its task only in a local variable, although its docstring says a
  strong reference is held until the task finishes. The loop keeps only a weak reference, so the
  refresh can be collected mid-flight and the stale grade is never replaced.
- `_GRADE_REFRESH_TASKS` now holds it, exactly as `_BRAINS_REFRESH_TASKS` already holds the brain
  refresh a few lines below.
- That reference also gives the live dashboard tests something to wait for, which removes an
  intermittent 120 s teardown timeout in `Integration (SurrealDB)`.

## Why

The two background refreshes were written together and guard the same hazard, but only one of them
keeps its task:

```python
task = asyncio.get_running_loop().create_task(_refresh())
task.add_done_callback(_done)          # nothing else holds `task`
```

against, in `_refresh_in_background`:

```python
task = asyncio.get_running_loop().create_task(_run())
# Strong reference: the event loop discards tasks nobody holds.
_BRAINS_REFRESH_TASKS.add(task)
```

The consequence in production is a diagnostics refresh that may never finish, leaving the stale
report in place until the next request schedules another one.

The consequence in CI is a red job on unrelated branches. `/api/dashboard/brains` serves stale data
and refreshes behind the request, so a task is still querying the store when a test returns.
pytest-asyncio tears the function-scoped loop down and cancels it, and occasionally the loop waits
on a cancelled receive until pytest-timeout fires:

```
_ ERROR at teardown of TestListBrainsScopeLive.test_request_leaves_the_shared_singleton_on_the_active_brain _
E   Failed: Timeout (>120.0s) from pytest-timeout.
= 7285 passed, 48 skipped, 32 deselected, 1 xfailed, 1 error in 218.45s (0:03:38) =
```

## Changes

- `src/surreal_memory/server/routes/dashboard_api.py`: `_GRADE_REFRESH_TASKS` holds each scheduled
  diagnostics refresh and drops it in a done callback.
- `tests/unit/test_dashboard_cache.py`: a test schedules a refresh that blocks, asserts the task is
  referenced outside the loop while it runs, and asserts the set is empty once it finishes.
- `tests/unit/test_dashboard_brains_scope.py`: the two live classes cancel and await both task sets
  at teardown, on the loop that owns them.

## Test plan

- [x] `pytest tests/unit/test_dashboard_cache.py -k held_until` against `main`'s production code —
      fails. With the module-level set present but the task not added to it, the same test fails on
      `assert set()`, so it pins the behaviour rather than the symbol.
- [x] The same test on this branch — `15 passed` for the file.
- [x] The two live classes run 40 times in a row against a live SurrealDB v3.2.0, a freshly created
      namespace each time and nothing else running against that database — 40 clean. Before the
      change the same loop produced 3 teardown timeouts in 22 runs.
- [x] `pytest tests/ --timeout=120 -m "not stress"` serial on a fresh namespace, the
      `Integration (SurrealDB)` command — 7286 passed, 48 skipped, 1 xfailed, in 96 s. The control
      run of `main` immediately afterwards, same database, hit the timeout: 7285 passed and 1 error
      in 215 s.
- [x] `ruff check src/ tests/` clean; `ruff format --check src/ tests/` reports 739 files already
      formatted.
- [x] `mypy src/ --ignore-missing-imports` — success, no issues found in 354 source files.
- [ ] `CHANGELOG.md` untouched — left to the release entry.

## Related issues

Reported in #224.

## Verified by @RobertSigmundsson
