### PR TITLE
fix(tests): reset the process-global embed-unavailable counter between tests

### DIFF
--- a/tests/unit/test_encoder_provider_unavailable.py
+++ b/tests/unit/test_encoder_provider_unavailable.py
@@ -50,6 +50,17 @@ class _FailingProvider:
         raise RuntimeError("connection refused: bge-m3 endpoint unreachable")
 
 
+@pytest.fixture(autouse=True)
+def _reset_unavailable_counter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The throttle counter is process-global, so no test here may inherit a
+    count bumped by an earlier test in the same process — the warning the
+    reindex-hint case asserts for only fires on occurrence 1 and every 100th
+    (reproduced with test_inline_embed_timeout.py running first under xdist)."""
+    import surreal_memory.engine.encoder as encoder_mod
+
+    monkeypatch.setattr(encoder_mod, "_EMBED_UNAVAILABLE_COUNT", 0)
+
+
 @pytest.mark.asyncio
 async def test_provider_unavailable_logs_warning_with_reindex_hint(
     monkeypatch: Any, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
## Summary

- `test_encoder_provider_unavailable.py` gets an autouse fixture resetting `encoder._EMBED_UNAVAILABLE_COUNT` to 0, the same pattern the file's own `TestProviderUnavailableThrottling` class already applies.
- The reindex-hint test assumed the counter starts at 0; any earlier test in the same process that drives the encoder into the provider-unavailable branch consumes occurrence 1, the warning drops to DEBUG, and the test fails. Reproduced deterministically with `test_inline_embed_timeout.py` scheduled first under xdist; passes solo.

## Why

Follow-up to #216, spotted while gating the 3.9.2 batch locally: the suite run with `-n auto` failed only in that ordering, and the CI ordering happened not to trip it. The throttle counter is process-global by design; the tests must not depend on which test ran before them.

## Test plan

- [x] `pytest tests/unit/test_inline_embed_timeout.py tests/unit/test_encoder_provider_unavailable.py tests/unit/test_embedding_provider.py` — 92 passed (previously failing ordering).
- [x] `pytest tests/unit/test_encoder_provider_unavailable.py` — 3 passed solo.
- [x] `ruff check` / `ruff format --check` clean.

## Verified by

@acidkill