### PR TITLE
fix(storage): ensure_schema converges a legacy SCHEMALESS change_log table

### DIFF
--- a/src/surreal_memory/storage/surrealdb/schema.py
+++ b/src/surreal_memory/storage/surrealdb/schema.py
@@ -611,6 +611,37 @@ def _parse_schema_statements(sql: str) -> list[str]:
     return statements
 
 
+async def _ensure_change_log_schemafull(conn: Any) -> bool:
+    """ALTER a legacy SCHEMALESS ``change_log`` table to SCHEMAFULL.
+
+    Databases that wrote change_log rows before the table was declared in the
+    schema carry an implicit SCHEMALESS table (and an export/import preserves
+    that shape). Field-level FLEXIBLE — which the ``payload`` define below
+    needs — is only valid on a SCHEMAFULL table, so without this conversion
+    every startup logs a schema warning and the field keeps its old shape
+    (issue #230). ``ALTER TABLE … SCHEMAFULL`` is the documented
+    schemaless-to-schemafull transition and keeps existing rows; every column
+    the writer produces is declared, so tightening rejects nothing. Fail-soft
+    by the same contract as the statement loop: a failed probe or ALTER only
+    means the warning persists.
+
+    Returns True when a conversion was attempted and succeeded.
+    """
+    try:
+        rows = await conn.query("INFO FOR DB;")
+        info = rows[0] if isinstance(rows, list) and rows else rows
+        tables = info.get("tables", {}) if isinstance(info, dict) else {}
+        definition = str(tables.get("change_log", "") or "")
+        if "SCHEMALESS" not in definition.upper():
+            return False
+        await conn.query("ALTER TABLE change_log SCHEMAFULL;")
+    except Exception:
+        logger.debug("change_log schemaless probe/ALTER failed", exc_info=True)
+        return False
+    logger.info("Converted legacy SCHEMALESS change_log table to SCHEMAFULL")
+    return True
+
+
 async def ensure_schema(conn: Any, embedding_dim: int = 3072) -> None:
     """Apply schema to SurrealDB. Safe to call multiple times.
 
@@ -640,6 +671,9 @@ async def ensure_schema(conn: Any, embedding_dim: int = 3072) -> None:
         f"FIELDS embedding_vec HNSW DIMENSION {dim} DIST COSINE"
     )
     statements.extend(SYNAPSE_V8_DDL)
+    # Before any change_log field defines: a legacy SCHEMALESS change_log would
+    # reject the payload FLEXIBLE define (issue #230), so converge it first.
+    await _ensure_change_log_schemafull(conn)
     for stmt in statements:
         try:
             await conn.query(stmt + ";")

--- a/tests/unit/test_schema_change_log_converge.py
+++ b/tests/unit/test_schema_change_log_converge.py
@@ -1,0 +1,98 @@
+"""ensure_schema converges a legacy SCHEMALESS change_log table (issue #230).
+
+Databases that predate the change_log table declaration (or were carried
+through export/import) hold it as SCHEMALESS; the `DEFINE FIELD … FLEXIBLE`
+for `payload` is only valid on a SCHEMAFULL table, so every startup warned and
+the field kept its old shape. The fix probes `INFO FOR DB` and runs
+`ALTER TABLE change_log SCHEMAFULL` before the statement loop — fail-soft, so
+a failed probe changes nothing relative to the previous behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from surreal_memory.storage.surrealdb.schema import ensure_schema
+
+
+class _FakeConn:
+    """Records queries; answers INFO FOR DB from a canned table map."""
+
+    def __init__(
+        self,
+        tables: dict[str, str] | None = None,
+        fail_alter: bool = False,
+        fail_probe: bool = False,
+    ) -> None:
+        self._tables = tables if tables is not None else {}
+        self._fail_alter = fail_alter
+        self._fail_probe = fail_probe
+        self.queries: list[str] = []
+
+    async def query(self, q: str) -> Any:
+        self.queries.append(q)
+        if q.startswith("INFO FOR DB"):
+            if self._fail_probe:
+                raise RuntimeError("probe unavailable")
+            return [{"tables": dict(self._tables)}]
+        if q.startswith("ALTER TABLE change_log") and self._fail_alter:
+            raise RuntimeError("alter rejected")
+        return []
+
+
+def _alter_queries(conn: _FakeConn) -> list[str]:
+    return [q for q in conn.queries if q.startswith("ALTER TABLE change_log")]
+
+
+def _change_log_field_defines(conn: _FakeConn) -> list[str]:
+    return [q for q in conn.queries if "DEFINE FIELD" in q and "ON change_log" in q]
+
+
+@pytest.mark.asyncio
+async def test_schemaless_table_is_converted_before_field_defines() -> None:
+    conn = _FakeConn(tables={"change_log": "DEFINE TABLE change_log TYPE ANY SCHEMALESS"})
+    await ensure_schema(conn, embedding_dim=1024)
+    assert _alter_queries(conn) == ["ALTER TABLE change_log SCHEMAFULL;"]
+    fields = _change_log_field_defines(conn)
+    assert fields, "the change_log field defines must still run"
+    alter_at = conn.queries.index("ALTER TABLE change_log SCHEMAFULL;")
+    assert alter_at < conn.queries.index(fields[0]), (
+        "the ALTER must precede the field defines it unblocks"
+    )
+
+
+@pytest.mark.asyncio
+async def test_schemafull_table_is_left_alone() -> None:
+    conn = _FakeConn(tables={"change_log": "DEFINE TABLE change_log SCHEMAFULL"})
+    await ensure_schema(conn, embedding_dim=1024)
+    assert _alter_queries(conn) == []
+
+
+@pytest.mark.asyncio
+async def test_fresh_database_without_change_log_skips_alter() -> None:
+    conn = _FakeConn(tables={})
+    await ensure_schema(conn, embedding_dim=1024)
+    assert _alter_queries(conn) == []
+    assert any(q.startswith("DEFINE TABLE change_log SCHEMAFULL") for q in conn.queries), (
+        "fresh databases still get the SCHEMAFULL declaration from SCHEMA_SQL"
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_alter_is_fail_soft() -> None:
+    conn = _FakeConn(
+        tables={"change_log": "DEFINE TABLE change_log TYPE ANY SCHEMALESS"},
+        fail_alter=True,
+    )
+    await ensure_schema(conn, embedding_dim=1024)  # must not raise
+    assert _change_log_field_defines(conn), "defines still attempted after a failed ALTER"
+
+
+@pytest.mark.asyncio
+async def test_failed_probe_is_fail_soft() -> None:
+    conn = _FakeConn(fail_probe=True)
+    await ensure_schema(conn, embedding_dim=1024)  # must not raise
+    assert _alter_queries(conn) == []
+    assert _change_log_field_defines(conn), "defines still attempted after a failed probe"


### PR DESCRIPTION
## Summary

- `ensure_schema` probes `INFO FOR DB`; when `change_log` exists as a legacy SCHEMALESS table it runs `ALTER TABLE change_log SCHEMAFULL` **before** the statement loop, so the `DEFINE FIELD OVERWRITE payload … FLEXIBLE` define becomes valid and the field finally converges.
- Probe and ALTER are fail-soft: any failure leaves behaviour exactly as before (the startup warning), never blocks startup.

## Why

Closes #230. Databases that predate the change_log declaration — including any carried through `surreal export | import` — keep the implicit SCHEMALESS table forever, so the 3.9.2 schema fix warned on every startup and the field kept its old `none | object` shape. `ALTER TABLE … SCHEMAFULL` is SurrealDB's documented transition for existing tables with data, and every column the writer produces is declared, so the tightening rejects nothing.

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` — 7340 passed (5 new: schemaless→ALTER-before-defines, schemafull untouched, fresh DB untouched, ALTER-fail and probe-fail fail-soft).
- [x] `ruff check` / `ruff format --check` clean; `mypy src/` clean.

## Verified by

@acidkill