### PR TITLE
chore(release): 3.9.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Reflex-based memory system for AI agents with SurrealDB backend. Stores experiences as interconnected neurons, recalls through spreading activation — not search.",
-    "version": "3.9.2"
+    "version": "3.9.3"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "repo": "acidkill/surreal-memory"
       },
       "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
-      "version": "3.9.2",
+      "version": "3.9.3",
       "author": {
         "name": "Toni Nowak / AI-Flow NOWAK"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "surreal-memory",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "description": "Reflex-based memory system for AI agents with SurrealDB backend — stores experiences as interconnected neurons and recalls them through spreading activation, mimicking how the human brain works.",
   "author": {
     "name": "Toni Nowak / AI-Flow NOWAK"

--- a/.zcode/plans/plan-sess_f28cb906-44bf-4a1c-8299-1940017e589f.md
+++ b/.zcode/plans/plan-sess_f28cb906-44bf-4a1c-8299-1940017e589f.md
@@ -1,0 +1,105 @@
+# Plan run 017: resize k3s-4 + limity 48Gi/8CPU + timeouty MCP 3 min + upstream #229/#230 + release 3.9.3
+
+## Role i narzędzia
+- **Nadzór/bramki: glm-5.3 [S]** (review planów/diffów, go/no-go przed każdą operacją destrukcyjną).
+- **Wykonanie: glm-5.3-flash [F]** (agenty wykonawcze z instrukcją modelu flash).
+- **serena** — WSZYSTKIE edycje w repo (activate_project: `k3s-cluster` → `surreal-memory` → `localos`; wzorce: `replace_content{needle,repl,mode:literal}`, `search_for_pattern{substring_pattern}`, `create_text_file`). Serena jest zatrzymana po run 016 — F0 ją wznawia (`serena start-mcp-server --transport streamable-http --port 9121 --project …` + helper JSON-RPC).
+- **sequential-thinking** — bramka przed każdą fazą (prerekwizyty) i przy anomaliach.
+- **smem CLI** — `smem remember` na start/koniec faz (w plan-mode zablokowany — notatki zbierane po zatwierdzeniu planu).
+- **context7** — wykorzystany: `/surrealdb/docs.surrealdb.com` potwierdza `ALTER TABLE … SCHEMAFULL` jako oficjalną konwersję istniejącej tabeli schemaless **z danymi** + semantykę pola `FLEXIBLE` (podstawa projektu #230).
+
+## Zweryfikowane fakty i korekty
+- **k3s-4 = VM 304 na pve4** (12c/94GB, PVE 9.2), definiowana w `k3s-cluster/terraform/proxmox/variables.tf` (blok `k3s_nodes`): dziś **40960 MB / 8 cores**. Cel: **73728 MB / 10 cores** (limit walidacji 4096–131072 OK; vmid 304 w allowliście).
+- **Nagłówek `vms.tf`: zmiana pamięci wymaga wpisu w DECISIONS.md** (konwencja run ledger).
+- **Resize = zimny restart VM** (precedens run 005/008): cordon+drain → terraform apply (provider restartuje VM) → uncordon → **poll allocatable** (kubelet pokazuje stare wartości — pułapka zapisana 2×). Balloon: k3s-4 ma floating=0, ale zweryfikować `qm config 304` (root@192.168.1.97). **Pułapka terraform: bpg provider łączy się tylko przez ssh-agent** (`eval "$(ssh-agent -s)"; ssh-add ~/.ssh/id_ed25519`).
+- **Brama hosta (CLAUDE.md #11)**: STOP gdy wolny RAM pve4 < dedicated+1.5GB. pve4: 94GB − LXC100 (8GB, running) − host ≈ ~80+ wolnych; 73.7 się mieści, ale cienko — **obowiązkowy live-check w F0**.
+- **surrealdb resources (deploy values, live)**: requests 2CPU/8Gi, **limits 6CPU/32Gi** (nie 16Gi — koryguję założenie; cel 48Gi zgodnie z dyspozycją). Ustalone z Tobą: **limits → 8CPU/48Gi, requests → 4CPU/16Gi**. Bilans po resize węzła 10c/~70Gi: limity 8+1+0.5=9.5CPU / 48+2+0.5=50.5Gi — mieści się z zapasem.
+- **Downtime**: WSZYSTKIE pody surreal-memory są nodePinowane na k3s-4 → drain = pełna przerwa w działaniu bazy i aplikacji na czas restartu VM (~minuty).
+- **Timeouty MCP (macierz możliwości — zweryfikowana)**: Claude **Code**: udokumentowane `MCP_TIMEOUT`/`MCP_TOOL_TIMEOUT` przez `env` w `~/.claude/settings.json` ✅; Claude **Desktop**: client-side limit **zahardkodowany ~60s** (anthropics/claude-code#22542, #5221 — brak env); **omp**: per-server `timeout` (ms) ✅; **zcode**: brak knoba; **codex**: tylko `startup_timeout_sec`. Wniosek: dla Desktop/zcode/codex realną dźwignią jest **serwerowa zmienna z #229** (`SURREAL_MEMORY_MCP_TOOL_TIMEOUT`) — obecne latencje (context 2.1s, recall ~19s) mieszczą się pod 60s Desktopu, więc podniesienie limitu 30s→180s po stronie serwera wystarcza; client-side knoby podnoszę tam, gdzie istnieją.
+- **#229**: `_TOOL_CALL_TIMEOUT = 30.0` zahardkodowane (`mcp/server.py:578`); fix = env-configurowalne.
+- **#230**: baza ma legacy tabelę `change_log` SCHEMALESS; fix = wykrycie + `ALTER TABLE change_log SCHEMAFULL` + re-DEFINE pól (context7-potwierdzone), fail-soft zachowany.
+- **Release**: fixes-only → **v3.9.3**; proces wprost z udanego 3.9.2 (release PR bumpuje 16 plików wersji — `pre_ship.py` waliduje; **draft GitHub Release `--target main` PRZED merge'em**; tag tworzy się przy publish po merge'u przez `auto-publish-release.yml`; draft PR zostaje dla Ciebie).
+- **Poza zakresem** (odnotowane, nie wykonuję): deploy 3.9.3 na k3s/titan (env z F3 aktywuje się automatycznie po przyszłym upgrade).
+
+---
+
+## FAZA 0 — Pre-flight [S]
+- **T0.1** Serena: start + `activate_project k3s-cluster`; helper JSON-RPC odtworzony; `search_for_pattern "40960"` → potwierdzenie lokalizacji bloku k3s-4.
+- **T0.2** Bramy live: `ssh root@192.168.1.97 'pvesh get /nodes/pve4/status'` → wolny RAM vs **73.7+1.5GB** (STOP jeśli <); `qm config 304` (brak balloon, cores=8); `kubectl get node k3s-4` (allocatable 8c/~39Gi baseline); `helm list` (rev 13); terraform `init && plan` na niezmienionym kodzie (state fresh, brak drifty).
+- **T0.3** `smem remember` run 017 start; plan bramki sequential-thinking.
+
+**GATE 0 [S]**: headroom hosta PASS, brak driftu terraform, baseline'y zebrane. STOP-warstwa: jeśli pve4 wolny RAM < 75.2GB → wstrzymać F1-F2 i zgłosić (opcje: przenieść LXC100 / zmniejszyć cel).
+
+## FAZA 1 — IaC: edycje (serena) [F, review S]
+- **T1.1** Branch `run/017-k3s4-resize` (z origin/master; master lokalnie zajęty przez worktree — pracować na branchu, merge przez PR jak run 016).
+- **T1.2** `.goal/runs/017-k3s4-resize/DECISIONS.md` — wpis D-decyzji: 40960→73728 MB / 8→10 cores, uzasadnienie (48Gi limit dla surrealdb; RSS 12.2Gi + bursty konsolidacji/eksportu), brak zmian disk/usb (konwencja z nagłówka vms.tf).
+- **T1.3** serena: `variables.tf` k3s-4 → `memory_dedicated_mb = 73728`, `cores = 10` (reszta bloku nietknięta, komentarz zigbee zostaje).
+- **T1.4** serena: `deploy/surreal-memory-toni/values.yaml` surrealdb.resources → requests 4CPU/16Gi, limits 8CPU/48Gi + aktualizacja komentarza sizingowego (nowa matematyka węzła 10c/~70Gi); chart default zostaje (override-only wg wzorca).
+- **T1.5** terraform: ssh-agent → `plan -out 017.tfplan`; **[S] review planu**: dokładnie `0 add / 1 change / 0 destroy` (in-place update VM 304), bez zmian disk/usb/ innych VM.
+- **T1.6** Commit (2 zmiany logiczne): `feat(fleet): k3s-4 → 72GB/10 cores (run 017)` + `chore(surreal-memory): surrealdb requests 4c/16Gi, limits 8c/48Gi`; push branch (bez merge — apply najpierw).
+
+**GATE 1 [S]**: tfplan zgodny 1:1, diff values zgodny z decyzją.
+
+## FAZA 2 — Wykonanie resize (DOWNTIME) [F, gate S przed drain]
+- **T2.1** Świeży backup bazy: `surreal export` (run-016 RUNBOOK U1 — `/surreal`, `--endpoint`, creds z env poda) → `~/backups/smem-pre-resize-$(date +%F).surql` + sha256 → zanotować.
+- **T2.2** `kubectl cordon k3s-4 && kubectl drain k3s-4 --ignore-daemonsets --delete-emptydir-data --timeout=300s` (precedens run-008). [S] potwierdzenie: pody surreal-memory down — początek okna.
+- **T2.3** `terraform apply 017.tfplan` (VM cold-restart przez provider); weryfikacja `qm config 304` (10c/73728) po starcie.
+- **T2.4** `kubectl uncordon k3s-4`; czekać Ready; **poll allocatable** aż 10CPU/~70Gi (kubelet stale-capacity trap — poll, nie jednorazowy odczyt).
+- **T2.5** Helm: `--dry-run` (render: tylko resources) → `helm upgrade` (committed values + SOPS); `rollout status deploy/surrealdb deploy/smem-app`; `/health` 3.9.2; pody Running.
+- **T2.6** Post-checki: pve4 wolny RAM po resize (brama #11 ponownie), `kubectl top pods` po 10 min, E2E `smem remember/recall` przez wss, dashboard stats ciepłe.
+- **T2.7** Ledger: STATE.md (evidence: tfplan summary, allocatable before/after, top, sha backupu) + RUNBOOK.md (procedura); PR `run/017` → merge (wzorzec PR #3).
+- **Rollback**: terraform (revert wartości variables.tf → apply, ponowny zimny restart) + helm (git revert values → upgrade). Backup z T2.1 jako ostateczność (`surreal import`).
+
+**GATE 2 [S]**: węzeł 10c/~70Gi allocatable, pody zdrowe, limity 8c/48Gi live (`kubectl get pod -o jsonpath resources`), E2E OK.
+
+## FAZA 3 — Lokalne limity MCP → 3 min [F]
+- **T3.1** Claude Code: `~/.claude/settings.json` → `"env": {"MCP_TOOL_TIMEOUT": "180000"}` (dokumentowane; MCP_TIMEOUT startup nie ruszam).
+- **T3.2** omp: `~/.omp/agent/mcp.json` surreal-memory `timeout: 120000 → 180000`.
+- **T3.3** `~/.config/environment.d/claude-secrets.conf` → `SURREAL_MEMORY_MCP_TOOL_TIMEOUT=180` (przyszłościowa: nieznana dla 3.9.2, **aktywna po deploy 3.9.3**; pokrywa Desktop/zcode/codex startowane z sesji) + `systemctl --user set-environment` dla bieżącej sesji.
+- **T3.4** Walidacja: `jq`/JSON parse, smoke MCP (initialize + tools/list przez stdio), wpis do tabeli weryfikacji. Odnotować: Desktop ma client-side sufit ~60s (brak knoba — źródła: anthropics/claude-code#22542, #5221) — wystarcza, bo recall ~19s.
+
+**GATE 3 [S]**: 3 knoby ustawione, smoke MCP przechodzi.
+
+## FAZA 4 — Upstream #229 (surreal-memory, serena) [F, review S]
+- **T4.1** Branch `fix/mcp-tool-timeout-env` (z main; serena `activate_project surreal-memory`).
+- **T4.2** Implementacja: `_TOOL_CALL_TIMEOUT` czytane z `SURREAL_MEMORY_MCP_TOOL_TIMEOUT` (float, >0, cap 600s; niepoprawne → WARN + default 30); efektywny timeout logowany przy starcie serwera (INFO).
+- **T4.3** Testy: parser (valid/invalid/0/NaN/cap), override wpływa na stałą modułu, startup-log. Quality gate lokalny (ruff/mypy/pytest fast) → push → **PR** (szablon AGENTS.md, brak atrybucji AI, `Closes #229`) → 9/9 CI zielone → review+merge (wzorzec z batch-run 3.9.2).
+- **T4.4** [stretch, timebox 45 min, nie blokuje release'u]: próba root-cause powolności (probe: `get_fibers` wisiał in-process przy szybkim CLI) — jeśli tania przyczyna: osobny PR / aktualizacja #229; w przeciwnym razie dokumentacja dalszych kroków w issue.
+
+**GATE 4 [S]**: PR #229-fix zmergowany, CI 9/9.
+
+## FAZA 5 — Upstream #230 (surreal-memory, serena) [F, review S]
+- **T5.1** Branch `fix/change-log-schemaless-converge`; `ensure_schema`: przed definicjami pól `change_log` sprawdź typ tabeli (query `INFO FOR TABLE`); jeśli SCHEMALESS → wykonaj `ALTER TABLE change_log SCHEMAFULL` (konwersja z danymi — context7), potem zwykły przebieg DEFINE FIELD (incl. `OVERWRITE payload … FLEXIBLE`); ALTER/DEFINE nadal fail-soft, ale po skutecznej konwersji warning znika (info-level log o konwersji raz).
+- **T5.2** Testy: mock-conn (schemaless → ALTER wykonane → defines OK; schemafull → bez ALTER; ALTER fail → zachowanie jak dziś), opcjonalny live-test (utwórz schemaless, init, assert schemafull + pole FLEXIBLE — pominie bez SURREALDB_URL).
+- **T5.3** Quality gate → PR (`Closes #230`) → CI → merge. Nota: na produkcji efekt po przyszłym deployu 3.9.3+ (poza zakresem runu).
+
+**GATE 5 [S]**: PR #230-fix zmergowany, CI 9/9.
+
+## FAZA 6 — Tag + draft release PR 3.9.3 [S]
+- **T6.1** Branch `release/3.9.3`: bump wersji w **16 lokalizacjach** (wzorzec #228: pyproject, `__init__`, test_health_fixes, plugin/marketplace.json, openclaw.plugin.json, 3×package.json, 3×package-lock ×2); `scripts/pre_ship.py` 10/10 (CHANGELOG check w środku).
+- **T6.2** CHANGELOG `## [3.9.3] — <data> — <one-liner>`: Fixed — konfigurowalny timeout tooli MCP (env), konwergencja schemaless change_log (+ ewentualny root-cause fix z T4.4 jeśli był).
+- **T6.3** Draft PR (checklista jak #228) — CI zielone; **draft GitHub Release `v3.9.3 --target main`** z notes z changelogu. Tag materializuje się przy publish po Twoim merge'u release PR-a (auto-publish) — dokładnie proces 3.9.2 (uwaga U13: nie publishować draftu z branch-target).
+
+**GATE 6 [S]**: pre_ship 10/10, draft PR + draft release gotowe dla Ciebie.
+
+## FAZA 7 — Zamknięcie [S]
+`smem remember` podsumowanie; pamięć ZCode (update `run016-smem-392-upgrade` o run 017); ewentualny wpis REVISIT (watch pve4 headroom po resize); raport końcowy z matrycą weryfikacji; sprzątanie (serena stop, tmp).
+
+## Matryca weryfikacji
+| Obszar | Check | Oczekiwane |
+|---|---|---|
+| VM 304 | `qm config 304` | 10 cores / 73728 MB |
+| Node | `kubectl describe node k3s-4` allocatable | 10CPU / ~70Gi (po poll) |
+| pve4 | wolny RAM | ≥ ~12GB rezerwy (brama #11) |
+| surrealdb | `kubectl get pod -o jsonpath` resources | req 4c/16Gi, lim 8c/48Gi |
+| Serwis | /health, E2E recall | 3.9.2, OK |
+| Lokalne MCP | smoke stdio + knoby | 3 knoby ustawione |
+| Upstream | PR #229/#230 | merged, CI 9/9 |
+| Release | pre_ship, draft PR/release | 10/10 / gotowe drafty |
+
+## Ryzyka
+- **Pełny downtime bazy** podczas drain+restart (jedyny node) → świeży backup w T2.1, okno poza aktywnością konsolidacji (check logów jak w run 016).
+- **Cienki headroom pve4** (~73.7 z ~80 wolnych) → brama #11 w F0 i re-check w T2.6; STOP-path zdefiniowana.
+- Kubelet stale allocatable → poll; terraform ssh-agent trap → eval+add; balloon → weryfikacja qm config.
+- Desktop ~60s client ceiling → znane, nie usuwalne lokalnie; pokryte przez #229 (recall 19s < 60s).
+- #230 ALTER na produkcji → dopiero z 3.9.3+; przy merge fazy weryfikacja na mockach + ewentualny live-test CI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.3] — 2026-09-07 — a slow database deserves a longer fuse
+
+Two fixes for the remote-database topology found while deploying 3.9.2 against
+SurrealDB over wss.
+
+### Fixed
+
+- `SURREAL_MEMORY_MCP_TOOL_TIMEOUT` (seconds) makes the MCP server's per-tool-call
+  budget configurable instead of the hardcoded 30 s. A client talking to a remote
+  SurrealDB can legitimately need more — recall runs embedding + vector search +
+  rerank across the wire — and the fixed budget made `smem_recall` and
+  `smem_context` time out for every desktop client while the same operations
+  succeeded from the CLI. Values above 600 s clamp with a warning (a millisecond
+  typo must not become a five-hour hang), invalid values warn and fall back to
+  the 30 s default, and the effective timeout is logged at server start.
+- `ensure_schema` converges a legacy SCHEMALESS `change_log` table before applying
+  the field definitions: it probes `INFO FOR DB` and runs
+  `ALTER TABLE change_log SCHEMAFULL` — the documented schemaless-to-schemafull
+  transition, keeping existing rows and rejecting nothing the writer produces.
+  Databases that wrote change-log rows before the table was declared in the
+  schema (a shape an export/import preserves) previously warned on every startup
+  and the `payload` field never converged to its declared FLEXIBLE form. Probe
+  and ALTER are fail-soft: a failure preserves the previous behaviour exactly.
+
 ## [3.9.2] — 2026-09-07 — the writes were fine; the bookkeeping around them was not
 
 A batch release: twenty fixes that landed together, most of them in the

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -460,7 +460,7 @@ con `RunnableWithMessageHistory`.
 git clone https://github.com/acidkill/surreal-memory
 cd surreal-memory && pip install -e ".[dev]"
 smem doctor --dev        # Verificar configuración de colaborador
-pytest tests/ -v          # 7400+ tests
+pytest tests/ -v          # 7500+ tests
 ruff check src/ tests/    # Lint
 make verify               # Full CI gate
 ```

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ with `RunnableWithMessageHistory`.
 git clone https://github.com/acidkill/surreal-memory
 cd surreal-memory && pip install -e ".[dev]"
 smem doctor --dev        # Verify contributor setup
-pytest tests/ -v          # 7400+ tests
+pytest tests/ -v          # 7500+ tests
 ruff check src/ tests/    # Lint
 make verify               # Full CI gate
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 > Forward-looking vision. What's next, what's possible, where we're going.
 > ZERO LLM dependency — pure algorithmic, regex, graph-based.
 
-**Current state**: v3.5.1 — 57 MCP tools, 7400+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
+**Current state**: v3.5.1 — 57 MCP tools, 7500+ tests, neuroscience engine (10 brain-inspired algorithms), tiered memory loading (HOT/WARM/COLD).
 
 **Storage**: SurrealDB is the only persistent backend — schema v10 — and `storage_backend`
 defaults to it. `#141` removed the SQLite backend entirely; selecting `storage_backend = "sqlite"`

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -556,7 +556,7 @@ Surreal-Memory is designed for **AI agent memory** — not as a general-purpose 
 
 | Aspect | Status |
 |--------|--------|
-| **Test suite** | 7400+ tests; CI gate 65% coverage, release gate 67% |
+| **Test suite** | 7500+ tests; CI gate 65% coverage, release gate 67% |
 | **Security** | Input validation, ReDoS protection, activation queue caps, sensitive content detection |
 | **Stability** | 51+ releases, used daily by the maintainers in production AI workflows |
 | **Scalability** | Tested up to 5,000 neurons with sub-ms latency; designed for agent-scale data, not big data |

--- a/docs/promo/hackernews.md
+++ b/docs/promo/hackernews.md
@@ -12,7 +12,7 @@ Core idea: memories are stored as typed neurons connected by 41 typed synapses (
 
 No embedding API calls needed for core recall — it's pure algorithmic graph traversal. Embeddings are optional for semantic (vector) search (supports Ollama, sentence-transformers, Gemini, OpenAI). Core encode + recall costs $0.00 per query.
 
-Backed by SurrealDB's multi-model engine (document + graph + vector HNSW in one database — no separate vector store). 57 MCP tools, 7400+ tests, 67%+ CI coverage, Python 3.11+, MIT.
+Backed by SurrealDB's multi-model engine (document + graph + vector HNSW in one database — no separate vector store). 57 MCP tools, 7500+ tests, 67%+ CI coverage, Python 3.11+, MIT.
 
 All Pro-tier features (HNSW vector search, smart merge, 5-tier compression, sleep consolidation) are free via the bundled community plugin — no license keys.
 

--- a/integrations/surreal-memory-client/package-lock.json
+++ b/integrations/surreal-memory-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@acidkill/surreal-memory-client",
-      "version": "3.9.2",
+      "version": "3.9.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/integrations/surreal-memory-client/package.json
+++ b/integrations/surreal-memory-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acidkill/surreal-memory-client",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "description": "TypeScript client for the Surreal-Memory REST API \u2014 typed access to brains, neurons, synapses, fibers, recall, and sync.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/integrations/surrealmemory/openclaw.plugin.json
+++ b/integrations/surrealmemory/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "kind": "memory",
   "name": "Surreal-Memory",
   "description": "Brain-inspired persistent memory for AI agents — neurons, synapses, and fibers. REQUIRED: set plugins.slots.memory = \"surrealmemory\" in openclaw.json to disable the default memory-core plugin and activate Surreal-Memory as the exclusive memory provider.",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "configSchema": {
     "jsonSchema": {
       "type": "object",

--- a/integrations/surrealmemory/package-lock.json
+++ b/integrations/surrealmemory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@surrealmemory/openclaw-plugin",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@surrealmemory/openclaw-plugin",
-      "version": "3.9.2",
+      "version": "3.9.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.2.2",

--- a/integrations/surrealmemory/package.json
+++ b/integrations/surrealmemory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "surrealmemory",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "description": "Surreal-Memory plugin for OpenClaw \u2014 graph-based persistent memory for AI agents with SurrealDB backend",
   "type": "module",
   "main": "dist/index.js",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "surreal-memory"
-version = "3.9.2"
+version = "3.9.3"
 description = "Reflex-based memory system for AI agents with SurrealDB backend — retrieval through activation, not search"
 readme = "README.md"
 license = "MIT"

--- a/src/surreal_memory/__init__.py
+++ b/src/surreal_memory/__init__.py
@@ -16,7 +16,7 @@ from surreal_memory.engine.encoder import EncodingResult, MemoryEncoder
 from surreal_memory.engine.reflex_activation import CoActivation, ReflexActivation
 from surreal_memory.engine.retrieval import DepthLevel, ReflexPipeline, RetrievalResult
 
-__version__ = "3.9.2"
+__version__ = "3.9.3"
 
 __all__ = [
     "__version__",

--- a/tests/unit/test_health_fixes.py
+++ b/tests/unit/test_health_fixes.py
@@ -485,7 +485,7 @@ class TestVersionBump:
     def test_version_is_current(self) -> None:
         import surreal_memory
 
-        assert surreal_memory.__version__ == "3.9.2"
+        assert surreal_memory.__version__ == "3.9.3"
 
 
 class TestPackageIntegrity:

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "surrealmemory",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "surrealmemory",
-      "version": "3.9.2",
+      "version": "3.9.3",
       "license": "MIT",
       "dependencies": {
         "cytoscape": "^3.33.1",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "surrealmemory",
   "displayName": "Surreal-Memory",
   "description": "Visual brain explorer, inline recall, and memory management for Surreal-Memory",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "publisher": "ai-flow-nowak",
   "license": "MIT",
   "preview": true,


### PR DESCRIPTION
## Summary

Release 3.9.3. Version bumped across all 16 version-bearing locations, with a `CHANGELOG.md` section covering everything since 3.9.2: the two remote-topology fixes found while deploying 3.9.2 against SurrealDB over wss.

PATCH rather than MINOR: one configurable-env knob (#231, closes the stopgap half of #229 — root-cause stays open there) and one schema-convergence fix (#232, closes #230); no new surface beyond the env var.

## Why

Deploying 3.9.2 on the remote topology exposed both issues live: MCP tool calls dying at the hardcoded 30 s while the CLI succeeded, and the legacy SCHEMALESS `change_log` table rejecting the `payload … FLEXIBLE` define on every startup.

## Contents

- #231 — `SURREAL_MEMORY_MCP_TOOL_TIMEOUT` (seconds, 600 s clamp, warn-and-default, startup log). 19 new tests; config reference regenerated (54th env row).
- #232 — `ensure_schema` probes `INFO FOR DB` and runs `ALTER TABLE change_log SCHEMAFULL` before the field defines; fail-soft. 5 new tests.
- Mechanical: `sync_refs --fix` (test-count references → 7500+ after +24 tests).

## Test plan

- [x] `python scripts/pre_ship.py` — all 10 sections pass (16/16 at 3.9.3, CHANGELOG check, ruff, mypy, fast suite, docs gates).
- [x] Both content PRs green on all 9 CI checks before merge.
- [ ] Post-publish: confirm artefacts on PyPI, npm (plugin + SDK), ClawHub, VS Code Marketplace — publish steps are failure-tolerant, a green job is not proof.

## Verified by

@acidkill