### PR TITLE
docs(agents): the PR template's Verified-by line carries the handle only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ One paragraph: the problem this PR solves and why it solves it this way.
 
 ## Verified by
 
-@your-github-handle — built with <agent name + version>.
+@your-github-handle.
 ```
 
 ---


### PR DESCRIPTION
## Summary

- The PR body template's Verified-by line is now `@your-github-handle.` — the "built with <agent name + version>" footer is removed.

## Why

Closes #197. Hard Rule #2 forbids AI attribution in PR descriptions and withdraws the earlier guidance, but the mandatory template still required the footer — a contributor following the template writes exactly what `.pre-commit-config.yaml` rejects (`built with:.*(claude|codex|copilot)`). The GitHub account on the PR is the accountability record either way. CONTRIBUTING.md checked — no conflicting wording.

Maintainer note: this edit touches AGENTS.md with the mandate of this issue plus Toni's explicit instruction for run 018.

## Test plan

- [x] `grep -n 'built with' AGENTS.md` → template line clean; Hard Rule #2 section unchanged.
- [x] CONTRIBUTING.md audited — no "built with" wording to align.
- [x] Docs-only change; no code paths touched.

## Verified by

@acidkill