### PR TITLE
feat(mcp): per-call reconsolidate opt-out makes smem_recall a read-only probe when asked

### DIFF
--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -126,6 +126,7 @@ Query memories by semantic search with confidence ranking.
 | `valid_at` | string | No | — | ISO datetime string to filter memories valid at that point in time (e.g. '2026-02-01T12:00:00') |
 | `near` | object | No | — | Geospatial hard filter — keep only memories whose location is within radius_m metres of (lat, lon). Memories without ... |
 | `include_conflicts` | boolean | No | default: false | Include full conflict details in response (default: false). When false, only has_conflicts flag and conflict_count ar... |
+| `reconsolidate` | boolean | No | default: true | Allow this recall to reconsolidate the top matched memories (default: true). Set false for a read-only probe: recall ... |
 | `include_superseded` | boolean | No | — | Include superseded facts (those with valid_until set) in recall. Default false: superseded facts are hard-filtered ou... |
 | `trace` | boolean | No | — | Persist a retrieval trace for this recall and return its trace_id (telemetry — what fed the answer). Works even when ... |
 | `include_uncertainty` | boolean | No | — | Attach an 'uncertainty' block summarising how much to trust the answer (contradictions, superseded facts, low confide... |

--- a/docs/guides/mcp-server.md
+++ b/docs/guides/mcp-server.md
@@ -724,6 +724,20 @@ come from each tool's own schema.
 | `smem_visualize` | Generate charts from memory data |
 | `smem_watch` | Watch directories for file changes and auto-ingest into memory |
 
+### Recall writes by design
+
+`smem_recall` is not a read-only operation. By design, an activation-based
+memory strengthens what was activated: every recall flushes deferred writes
+(fiber conductivity, Hebbian strengthening) and — when it matches fibers —
+**reconsolidates** the top five matched memories so they absorb the query
+context. This is intended behaviour (see `reconsolidation.py`), gated globally
+by the per-brain `reconsolidation_enabled` switch (`BrainConfig`, default
+`true`).
+
+Speculative callers (agent harnesses probing several times per turn) that
+must not leave traces pass `reconsolidate: false` on the call — a read-only
+probe that skips the reconsolidation step for that invocation only.
+
 ---
 
 ## Tool Tiers

--- a/src/surreal_memory/engine/retrieval.py
+++ b/src/surreal_memory/engine/retrieval.py
@@ -241,6 +241,7 @@ class ReflexPipeline:
         tags: set[str] | None = None,
         session_id: str | None = None,
         exclude_ephemeral: bool = False,
+        reconsolidate: bool = True,
     ) -> RetrievalResult:
         """
         Execute the retrieval pipeline.
@@ -785,8 +786,15 @@ class ReflexPipeline:
             except Exception:
                 logger.debug("Deferred write flush failed (non-critical)", exc_info=True)
 
-        # Post-recall reconsolidation: recalled memories absorb current context
-        if getattr(self._config, "reconsolidation_enabled", True) and fibers_matched:
+        # Post-recall reconsolidation: recalled memories absorb current context.
+        # Per-call opt-out (False) makes recall a genuinely read-only probe for
+        # speculative callers; the per-brain reconsolidation_enabled switch stays
+        # the global source of truth (issue #198).
+        if (
+            reconsolidate
+            and getattr(self._config, "reconsolidation_enabled", True)
+            and fibers_matched
+        ):
             try:
                 from surreal_memory.engine.reconsolidation import reconsolidate_on_recall
 

--- a/src/surreal_memory/mcp/recall_handler.py
+++ b/src/surreal_memory/mcp/recall_handler.py
@@ -326,6 +326,9 @@ class RecallHandler:
         tags = _parse_tags(args)
         include_citations = args.get("include_citations", True)
         clean_for_prompt = bool(args.get("clean_for_prompt", False))
+        reconsolidate = args.get("reconsolidate", True)
+        if not isinstance(reconsolidate, bool):
+            return {"error": "reconsolidate must be a boolean"}
         min_trust: float | None = None
         raw_min_trust = args.get("min_trust")
         if raw_min_trust is not None:
@@ -411,6 +414,7 @@ class RecallHandler:
             tags=tags,
             session_id=f"mcp-{id(self)}",
             exclude_ephemeral=permanent_only,
+            reconsolidate=reconsolidate,
         )
 
         # Passive auto-capture on long queries

--- a/src/surreal_memory/mcp/tool_schemas.py
+++ b/src/surreal_memory/mcp/tool_schemas.py
@@ -373,6 +373,10 @@ _ALL_TOOL_SCHEMAS: list[dict[str, Any]] = [
                     "type": "boolean",
                     "description": "Include full conflict details in response (default: false). When false, only has_conflicts flag and conflict_count are returned.",
                 },
+                "reconsolidate": {
+                    "type": "boolean",
+                    "description": "Allow this recall to reconsolidate the top matched memories (default: true). Set false for a read-only probe: recall also strengthens fibers and flushes deferred writes by design — speculative callers that should not leave traces pass false. The per-brain reconsolidation_enabled switch remains the global source of truth.",
+                },
                 "include_superseded": {
                     "type": "boolean",
                     "description": "Include superseded facts (those with valid_until set) in recall. Default false: superseded facts are hard-filtered out. Set true to see the full history. Ignored when valid_at is given (point-in-time filtering takes over).",

--- a/tests/unit/test_recall_reconsolidation_optout.py
+++ b/tests/unit/test_recall_reconsolidation_optout.py
@@ -1,0 +1,113 @@
+"""smem_recall's reconsolidate opt-out (issue #198).
+
+Recall writes by design — deferred-write flush plus reconsolidation of the top
+matched fibers. The per-brain `reconsolidation_enabled` switch is the global
+source of truth; these tests pin the per-call opt-out: the MCP tool accepts
+`reconsolidate` (bool), threads it into ReflexPipeline.query, defaults to True,
+and rejects non-boolean values. The engine-side gate is additionally pinned at
+the signature level.
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _make_server() -> Any:
+    from surreal_memory.mcp.server import MCPServer
+
+    server = MCPServer.__new__(MCPServer)
+    server._config = MagicMock()
+    server._config.encryption = MagicMock(enabled=False, auto_encrypt_sensitive=False)
+    server._config.safety = MagicMock(auto_redact_min_severity=3)
+    server._config.auto = MagicMock(enabled=False)
+    server._config.dedup = MagicMock(enabled=False)
+    server._config.tool_tier = MagicMock(tier="full")
+    server._storage = None
+    server._hooks = None
+    server._eternal_trigger_count = 0
+    server.config = MagicMock()
+    server.config.auto.enabled = False  # skip passive capture on long queries
+    hooks = MagicMock()
+    hooks.emit = AsyncMock(return_value=None)
+    server.hooks = hooks
+    fake_storage = MagicMock()
+    fake_storage.current_brain_id = "b1"
+    fake_storage.get_brain = AsyncMock(return_value=SimpleNamespace(id="b1", config=MagicMock()))
+    server.get_storage = AsyncMock(return_value=fake_storage)
+    return server
+
+
+def _patched_pipeline(monkeypatch: pytest.MonkeyPatch, result: Any) -> dict[str, Any]:
+    """Replace ReflexPipeline inside recall_handler with a capturing fake."""
+    import surreal_memory.engine.retrieval as retrieval_mod
+
+    captured: dict[str, Any] = {}
+
+    class _FakePipeline:
+        def __init__(self, storage: Any, config: Any) -> None:
+            captured["storage"] = storage
+
+        async def query(self, **kwargs: Any) -> Any:
+            captured.update(kwargs)
+            return result
+
+    # recall_handler imports ReflexPipeline inside the function body, so the
+    # local `from ... import` resolves against the SOURCE module each call.
+    monkeypatch.setattr(retrieval_mod, "ReflexPipeline", _FakePipeline)
+    return captured
+
+
+_RESULT = SimpleNamespace(
+    answer="a",
+    confidence=0.9,
+    fibers_matched=[],
+    neurons_activated=1,
+    context="c",
+    latency_ms=1.0,
+    synthesis_method="test",
+    metadata={},
+    subgraph=SimpleNamespace(neuron_ids=[], synapse_ids=[], anchor_ids=[]),
+    co_activations={},
+    depth_used=SimpleNamespace(value=1),
+    tokens_used=10,
+    score_breakdown=None,
+)
+
+
+@pytest.mark.asyncio
+async def test_reconsolidate_defaults_to_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _patched_pipeline(monkeypatch, _RESULT)
+    server = _make_server()
+    await server._recall({"query": "how did we configure the gateway"})
+    assert captured["reconsolidate"] is True
+
+
+@pytest.mark.asyncio
+async def test_reconsolidate_false_threads_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = _patched_pipeline(monkeypatch, _RESULT)
+    server = _make_server()
+    await server._recall({"query": "how did we configure the gateway", "reconsolidate": False})
+    assert captured["reconsolidate"] is False
+
+
+@pytest.mark.asyncio
+async def test_reconsolidate_non_boolean_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patched_pipeline(monkeypatch, _RESULT)
+    server = _make_server()
+    result = await server._recall({"query": "q", "reconsolidate": "no"})
+    assert "error" in result and "reconsolidate" in result["error"]
+
+
+def test_engine_query_signature_has_the_optout_defaulting_true() -> None:
+    """The engine contract: ReflexPipeline.query carries the per-call opt-out."""
+    from surreal_memory.engine.retrieval import ReflexPipeline
+
+    params = inspect.signature(ReflexPipeline.query).parameters
+    assert "reconsolidate" in params, "query() must expose the per-call opt-out"
+    assert params["reconsolidate"].default is True


### PR DESCRIPTION
## Summary

- `smem_recall` gains a `reconsolidate` argument (boolean, default `true`), threaded through `ReflexPipeline.query` — `false` skips post-recall reconsolidation for that invocation only.
- `docs/guides/mcp-server.md` gains a "Recall writes by design" section: the deferred-write flush and reconsolidation behaviour, the per-brain `reconsolidation_enabled` switch, and when speculative callers should pass `false`.

## Why

Closes #198. Recall is a writing operation (conductivity flush + top-5 reconsolidation) gated by a per-brain switch that agent harnesses calling the MCP tool speculatively several times per turn cannot see or scope per call. The docs make the contract findable where callers look; the per-call opt-out gives a genuinely read-only probe without taking the global behaviour away from anyone.

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` — 7344 passed (4 new: default True threads through, explicit False threads through, non-boolean rejected, engine signature contract).
- [x] `ruff check` / `ruff format --check` clean; `mypy` — only the pre-existing google.genai attr-defined noise.
- [x] Tool schema updated (`reconsolidate` documented in the input schema).

## Verified by

@acidkill