### PR TITLE
feat(cli): reindex --stale rewrites only vectors that diverged from current content

### DIFF
--- a/docs/getting-started/cli-reference.md
+++ b/docs/getting-started/cli-reference.md
@@ -1098,6 +1098,8 @@ smem reindex [OPTIONS]
 | `--brain / -b` | text | No | `` | Target brain name (default: current) |
 | `--dry-run` | boolean | No | `False` | Report how many would be embedded; write nothing |
 | `--all` | boolean | No | `False` | Re-embed every neuron (default: only missing vectors) |
+| `--stale` | boolean | No | `False` | Re-embed, compare against stored vectors, rewrite only diverged ones |
+| `--threshold` | float | No | `0.98` | --stale: rewrite when cosine(stored, fresh) < this |
 | `--batch-size` | integer | No | `64` | Neurons per embedding batch |
 | `--json / -j` | boolean | No | `False` | Output as JSON |
 

--- a/src/surreal_memory/cli/commands/reindex.py
+++ b/src/surreal_memory/cli/commands/reindex.py
@@ -8,6 +8,14 @@ whatever the stored brain config says.
 Design notes:
     - Idempotent: ``--missing-only`` (default) only embeds neurons that lack a
       vector; ``--all`` re-embeds everything.
+    - ``--stale`` re-embeds everything it inspects, compares each fresh vector
+      against the stored one (cosine), and rewrites ONLY neurons whose vectors
+      diverge past ``--threshold`` (default 0.98) — the middle ground between
+      ``--missing-only`` (blind to a vector describing text the neuron no
+      longer contains) and ``--all`` (issue #199). The provider-cost caveat is
+      deliberate: a full sweep costs roughly like ``--all`` in embedding calls;
+      the saving is in writes and in being able to ANSWER whether the recall
+      index matches current content (``--stale --dry-run``).
     - ``--dry-run`` (default off) reports how many neurons *would* be embedded
       and writes nothing.
     - Fail-soft per neuron: a single embedding/update failure never aborts the
@@ -44,6 +52,17 @@ def reindex(
         bool,
         typer.Option("--all", help="Re-embed every neuron (default: only missing vectors)"),
     ] = False,
+    stale: Annotated[
+        bool,
+        typer.Option(
+            "--stale",
+            help="Re-embed, compare against stored vectors, rewrite only diverged ones",
+        ),
+    ] = False,
+    threshold: Annotated[
+        float,
+        typer.Option("--threshold", help="--stale: rewrite when cosine(stored, fresh) < this"),
+    ] = 0.98,
     batch_size: Annotated[
         int,
         typer.Option("--batch-size", help="Neurons per embedding batch"),
@@ -54,29 +73,61 @@ def reindex(
     ] = False,
 ) -> None:
     """Re-embed neurons for the current brain using the effective provider."""
-    run_async(_reindex_async(brain, dry_run, all_neurons, batch_size, json_output))
+    run_async(
+        _reindex_async(brain, dry_run, all_neurons, stale, threshold, batch_size, json_output)
+    )
 
 
-def _needs_embedding(neuron: Any, *, all_neurons: bool) -> bool:
+def _needs_embedding(neuron: Any, *, all_neurons: bool, stale: bool = False) -> bool:
     """Return True when a neuron should be embedded for this run."""
     if not neuron.content.strip():
         return False
+    if stale:
+        # Stale detection is the inverse selection: only neurons that HAVE a
+        # stored vector can carry one that describes text the neuron no longer
+        # contains.
+        return bool(neuron.metadata.get("_embedding"))
     if all_neurons:
         return True
     return not neuron.metadata.get("_embedding")
+
+
+def _cosine_similarity(stored: list[float], fresh: list[float]) -> float:
+    """Cosine similarity of two vectors (numpy when available, pure fallback)."""
+    try:
+        import numpy as np
+
+        a = np.asarray(stored, dtype=np.float64)
+        b = np.asarray(fresh, dtype=np.float64)
+        denom = float(np.linalg.norm(a) * np.linalg.norm(b))
+        return float(np.dot(a, b) / denom) if denom else 0.0
+    except ImportError:  # pragma: no cover - numpy is a soft dependency here
+        dot = sum(x * y for x, y in zip(stored, fresh, strict=True))
+        na = sum(x * x for x in stored) ** 0.5
+        nb = sum(y * y for y in fresh) ** 0.5
+        return dot / (na * nb) if na and nb else 0.0
 
 
 async def _reindex_async(
     brain: str,
     dry_run: bool,
     all_neurons: bool,
-    batch_size: int,
-    json_output: bool,
+    stale: bool = False,
+    threshold: float = 0.98,
+    batch_size: int = _BATCH_SIZE_DEFAULT,
+    json_output: bool = False,
 ) -> None:
     """Async implementation of the reindex command."""
     if batch_size < 1:
         typer.echo("Error: --batch-size must be >= 1", err=True)
         raise typer.Exit(code=1)
+    if stale and all_neurons:
+        typer.echo("Error: --stale and --all are mutually exclusive", err=True)
+        raise typer.Exit(code=1)
+    if not 0.0 < threshold <= 1.0:
+        typer.echo("Error: --threshold must be in (0, 1]", err=True)
+        raise typer.Exit(code=1)
+    mode = "stale" if stale else ("all" if all_neurons else "missing-only")
 
     config = get_config()
     storage = await get_storage(config, brain_name=brain or None)
@@ -107,7 +158,9 @@ async def _reindex_async(
         page_neurons = await storage.find_neurons(limit=page, offset=offset)
         if not page_neurons:
             break
-        candidates.extend(n for n in page_neurons if _needs_embedding(n, all_neurons=all_neurons))
+        candidates.extend(
+            n for n in page_neurons if _needs_embedding(n, all_neurons=all_neurons, stale=stale)
+        )
         offset += len(page_neurons)
         if len(page_neurons) < page:
             break
@@ -121,13 +174,14 @@ async def _reindex_async(
                 "dry_run": True,
                 "provider": provider_name,
                 "model": model_name,
-                "mode": "all" if all_neurons else "missing-only",
+                "mode": mode,
                 "would_embed": to_embed,
+                **({"threshold": threshold} if stale else {}),
             },
             human=(
                 f"[dry-run] provider={provider_name} model={model_name} "
-                f"mode={'all' if all_neurons else 'missing-only'} "
-                f"would embed {to_embed} neuron(s)"
+                f"mode={mode} would embed {to_embed} neuron(s)"
+                + (f" (threshold={threshold})" if stale else "")
             ),
         )
         return
@@ -154,6 +208,7 @@ async def _reindex_async(
 
     embedded = 0
     failed = 0
+    stale_kept_fresh = 0  # --stale: vectors matching current content
     first_error = ""
     consecutive_failures = 0
     aborted = False
@@ -191,6 +246,17 @@ async def _reindex_async(
         consecutive_failures = 0
 
         pairs = [(neuron.id, vector) for neuron, vector in zip(batch, vectors, strict=True)]
+        if stale:
+            kept: list[tuple[str, list[float]]] = []
+            for neuron, (nid, vector) in zip(batch, pairs, strict=True):
+                stored = neuron.metadata.get("_embedding") or []
+                if _cosine_similarity(stored, vector) >= threshold:
+                    stale_kept_fresh += 1
+                    continue
+                kept.append((nid, vector))
+            if not kept:
+                continue
+            pairs = kept
         try:
             await storage.update_neuron_embeddings(pairs)
             embedded += len(pairs)
@@ -207,19 +273,24 @@ async def _reindex_async(
         "dry_run": False,
         "provider": provider_name,
         "model": model_name,
-        "mode": "all" if all_neurons else "missing-only",
+        "mode": mode,
         "embedded": embedded,
         "failed": failed,
     }
+    if stale:
+        payload["kept_fresh"] = stale_kept_fresh
+        payload["threshold"] = threshold
     if first_error:
         payload["error"] = first_error
     if aborted:
         payload["aborted"] = True
-    _emit(
-        json_output,
-        payload,
-        human=f"Embedded {embedded} neuron(s), {failed} failed.",
-    )
+    human = f"Embedded {embedded} neuron(s), {failed} failed."
+    if stale:
+        human = (
+            f"Re-embedded {embedded} stale neuron(s) "
+            f"({stale_kept_fresh} already matched current content), {failed} failed."
+        )
+    _emit(json_output, payload, human=human)
 
     # A run that embedded nothing is a failure, not a quiet success: exiting 0
     # let `smem reindex` report "0 embedded, 4096 failed" while any script or

--- a/tests/unit/test_reindex_stale.py
+++ b/tests/unit/test_reindex_stale.py
@@ -1,0 +1,103 @@
+"""reindex --stale detects vectors that no longer describe their text (#199).
+
+``--missing-only`` is blind to a stored vector describing content the neuron
+no longer contains; ``--all`` rewrites everything. The stale mode re-embeds
+what it inspects, compares cosine(stored, fresh) against the threshold, and
+rewrites only what diverges. These tests pin the selection inverse, the
+cosine helper, and an end-to-end run against the in-memory backend with a
+canned provider.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from surreal_memory.cli.commands import reindex as reindex_mod
+from surreal_memory.core.brain import Brain
+from surreal_memory.core.neuron import Neuron, NeuronType
+from surreal_memory.storage.memory_store import InMemoryStorage
+
+
+def _unit(v: list[float]) -> list[float]:
+    n = math.sqrt(sum(x * x for x in v))
+    return [x / n for x in v]
+
+
+class TestHelpers:
+    def test_stale_selection_is_the_inverse(self) -> None:
+        with_vec = Neuron.create(
+            type=NeuronType.CONCEPT, content="x", neuron_id="a"
+        )
+        with_vec.metadata["_embedding"] = [0.1, 0.2]
+        without_vec = Neuron.create(
+            type=NeuronType.CONCEPT, content="x", neuron_id="b"
+        )
+        assert reindex_mod._needs_embedding(with_vec, all_neurons=False, stale=True)
+        assert not reindex_mod._needs_embedding(
+            without_vec, all_neurons=False, stale=True
+        )
+
+    def test_cosine_identical_vectors_is_one(self) -> None:
+        v = _unit([1.0, 2.0, 3.0])
+        assert reindex_mod._cosine_similarity(v, v[:]) == pytest.approx(1.0)
+
+    def test_cosine_orthogonal_is_zero(self) -> None:
+        assert reindex_mod._cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+
+class _CannedProvider:
+    """Returns a fixed vector per text: 'stale' text maps elsewhere."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        self.calls += 1
+        return [
+            _unit([1.0, 0.0]) if "stale" in t else _unit([0.0, 1.0]) for t in texts
+        ]
+
+
+@pytest.mark.asyncio
+async def test_stale_run_rewrites_only_diverged(monkeypatch: pytest.MonkeyPatch) -> None:
+    storage = InMemoryStorage()
+    brain = Brain.create(name="stale-test")
+    await storage.save_brain(brain)
+    storage.set_brain(brain.id)
+
+    fresh = Neuron.create(type=NeuronType.CONCEPT, content="fresh content", neuron_id="n1")
+    fresh.metadata["_embedding"] = _unit([0.0, 1.0])  # matches canned output
+    stale = Neuron.create(type=NeuronType.CONCEPT, content="stale content", neuron_id="n2")
+    stale.metadata["_embedding"] = _unit([0.0, 1.0])  # describes the OLD text;
+    # the canned provider embeds "stale content" to [1, 0] — orthogonal → diverged
+    missing = Neuron.create(type=NeuronType.CONCEPT, content="no vector", neuron_id="n3")
+    for n in (fresh, stale, missing):
+        await storage.add_neuron(n)
+
+    provider = _CannedProvider()
+    import surreal_memory.engine.semantic_discovery as sd
+
+    # reindex imports these inside the function body — patch the SOURCE module.
+    monkeypatch.setattr(sd, "_effective_embedding", lambda cfg: (True, "openai", "bge-m3"))
+    monkeypatch.setattr(sd, "_create_provider", lambda cfg, task_type=None: provider)
+    monkeypatch.setattr(reindex_mod, "get_config", lambda: type("C", (), {"data_dir": None})())
+    monkeypatch.setattr(reindex_mod, "get_storage", lambda *a, **k: _ret(storage))
+
+    async def _ret(s: InMemoryStorage) -> InMemoryStorage:
+        return s
+    written: list[tuple[str, list[float]]] = []
+
+    async def _capture(pairs: list[tuple[str, list[float]]]) -> None:
+        written.extend(pairs)
+
+    monkeypatch.setattr(storage, "update_neuron_embeddings", _capture)
+
+    await reindex_mod._reindex_async(
+        brain="", dry_run=False, all_neurons=False, stale=True,
+        threshold=0.98, batch_size=10, json_output=True,
+    )
+
+    assert [nid for nid, _ in written] == ["n2"], "only the diverged vector is rewritten"
+    assert provider.calls >= 1

--- a/tests/unit/test_reindex_stale.py
+++ b/tests/unit/test_reindex_stale.py
@@ -27,17 +27,11 @@ def _unit(v: list[float]) -> list[float]:
 
 class TestHelpers:
     def test_stale_selection_is_the_inverse(self) -> None:
-        with_vec = Neuron.create(
-            type=NeuronType.CONCEPT, content="x", neuron_id="a"
-        )
+        with_vec = Neuron.create(type=NeuronType.CONCEPT, content="x", neuron_id="a")
         with_vec.metadata["_embedding"] = [0.1, 0.2]
-        without_vec = Neuron.create(
-            type=NeuronType.CONCEPT, content="x", neuron_id="b"
-        )
+        without_vec = Neuron.create(type=NeuronType.CONCEPT, content="x", neuron_id="b")
         assert reindex_mod._needs_embedding(with_vec, all_neurons=False, stale=True)
-        assert not reindex_mod._needs_embedding(
-            without_vec, all_neurons=False, stale=True
-        )
+        assert not reindex_mod._needs_embedding(without_vec, all_neurons=False, stale=True)
 
     def test_cosine_identical_vectors_is_one(self) -> None:
         v = _unit([1.0, 2.0, 3.0])
@@ -55,9 +49,7 @@ class _CannedProvider:
 
     async def embed_batch(self, texts: list[str]) -> list[list[float]]:
         self.calls += 1
-        return [
-            _unit([1.0, 0.0]) if "stale" in t else _unit([0.0, 1.0]) for t in texts
-        ]
+        return [_unit([1.0, 0.0]) if "stale" in t else _unit([0.0, 1.0]) for t in texts]
 
 
 @pytest.mark.asyncio
@@ -87,6 +79,7 @@ async def test_stale_run_rewrites_only_diverged(monkeypatch: pytest.MonkeyPatch)
 
     async def _ret(s: InMemoryStorage) -> InMemoryStorage:
         return s
+
     written: list[tuple[str, list[float]]] = []
 
     async def _capture(pairs: list[tuple[str, list[float]]]) -> None:
@@ -95,8 +88,13 @@ async def test_stale_run_rewrites_only_diverged(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(storage, "update_neuron_embeddings", _capture)
 
     await reindex_mod._reindex_async(
-        brain="", dry_run=False, all_neurons=False, stale=True,
-        threshold=0.98, batch_size=10, json_output=True,
+        brain="",
+        dry_run=False,
+        all_neurons=False,
+        stale=True,
+        threshold=0.98,
+        batch_size=10,
+        json_output=True,
     )
 
     assert [nid for nid, _ in written] == ["n2"], "only the diverged vector is rewritten"


### PR DESCRIPTION
## Summary

- `smem reindex` gains `--stale` (mutually exclusive with `--all`) and `--threshold` (cosine cut-off, default 0.98): neurons WITH a stored vector are re-embedded, compared, and only rewritten when the fresh vector diverges past the threshold.
- `--stale --dry-run` reports how many vectors no longer describe their content without writing; the JSON payload carries `kept_fresh` and `threshold`.
- CLI reference regenerated (`gen_cli_docs.py`).

## Why

Closes #199. Content changes that bypass the derived-field refresh leave a vector describing text the neuron no longer contains — invisible to `--missing-only`, repairable today only by `--all` over the whole brain at full metered-provider cost. The reporter's framing: a general safety net for the whole class of drift, where a dry run alone answers whether the recall index matches current content. Cost caveat documented in the module docstring: a full sweep costs roughly like `--all` in embedding calls; the saving is in writes and in the answer itself.

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` — 7352 passed (4 new: inverse selection, cosine identity/orthogonality, end-to-end rewrite-only-diverged against the in-memory backend with a canned provider).
- [x] `ruff` clean; `mypy` — only the pre-existing google.genai noise; existing reindex suite intact.

## Verified by

@acidkill