### PR TITLE
fix(mcp): the health-pulse op counter persists per-brain across processes

### DIFF
--- a/src/surreal_memory/mcp/maintenance_handler.py
+++ b/src/surreal_memory/mcp/maintenance_handler.py
@@ -97,22 +97,71 @@ class MaintenanceHandler:
     """
 
     _op_count: int = 0
+    # Persistent pulse accounting (issue #222): _op_base seeds lazily from the
+    # brain's metadata so the modulo runs on the TOTAL work a brain has seen,
+    # not this process's slice; short-lived MCP sessions then pulse too.
+    _op_base: int | None = None
     _last_pulse: HealthPulse | None = None
     _last_consolidation_at: datetime | None = None
     _last_dream_at: datetime | None = None
     _effective_check_interval: int | None = None
     _consolidation_task: asyncio.Task[None] | None = None
 
-    def _increment_op_counter(self) -> int:
-        self._op_count += 1
-        return self._op_count
+    _PERSISTED_OP_KEY = "_maintenance_op_count"
 
-    def _should_check_health(self) -> bool:
+    async def _increment_op_counter(self) -> int:
+        """Advance the op counter and return the brain-wide total.
+
+        The in-process counter is seeded from (and periodically flushed to) the
+        brain's metadata (issue #222): pulsing used to depend on how work was
+        distributed across processes — 100 sessions x 24 operations produced
+        zero pulses while one session of 2400 produced 96. Persistence is
+        fail-soft: on any storage error the counter degrades to per-process,
+        which is the previous behaviour, never an outage.
+        """
+        self._op_count += 1
+        total = self._op_count + await self._seed_op_base()
+        # Persist on EVERY op: a flush cadence would drop exactly the slice a
+        # short-lived session contributed (session of 24 ops flushes nothing —
+        # the original bug in a new coat). The brain row is tiny and this path
+        # already persists the remembered/recalled entities, so one small
+        # save_brain per op is noise next to them.
+        await self._persist_op_total(total)
+        return total
+
+    async def _seed_op_base(self) -> int:
+        if self._op_base is not None:
+            return self._op_base
+        try:
+            storage = await self.get_storage()  # type: ignore[attr-defined]
+            brain = await storage.get_brain(storage.brain_id or "")
+            raw = (brain.metadata.get(self._PERSISTED_OP_KEY, 0) or 0) if brain else 0
+            self._op_base = int(raw)
+        except Exception:
+            logger.debug("op-counter seed failed; per-process fallback", exc_info=True)
+            self._op_base = 0
+        return self._op_base
+
+    async def _persist_op_total(self, total: int) -> None:
+        try:
+            storage = await self.get_storage()  # type: ignore[attr-defined]
+            brain = await storage.get_brain(storage.brain_id or "")
+            if brain is None:
+                return
+            brain.metadata[self._PERSISTED_OP_KEY] = int(total)
+            await storage.save_brain(brain)
+            self._op_base = int(total)
+            self._op_count = 0
+        except Exception:
+            logger.debug("op-counter persist failed; per-process fallback", exc_info=True)
+
+    def _should_check_health(self, total: int | None = None) -> bool:
         cfg: MaintenanceConfig = self.config.maintenance  # type: ignore[attr-defined]
         if not cfg.enabled:
             return False
         interval = self._effective_check_interval or cfg.check_interval
-        return self._op_count > 0 and self._op_count % interval == 0
+        count = self._op_count if total is None else total
+        return count > 0 and count % interval == 0
 
     async def _health_pulse(self) -> HealthPulse | None:
         """Run a cheap health check using get_stats().
@@ -426,7 +475,7 @@ class MaintenanceHandler:
         )
         logger.info(
             "Health degradation detected (op #%d): %s [%s]",
-            self._op_count,
+            (self._op_base or 0) + self._op_count,
             pulse.hints[0].message,
             pulse.hints[0].severity,
         )
@@ -438,11 +487,14 @@ class MaintenanceHandler:
         Called from _remember() and _recall() in the server.
         Returns a HealthPulse if a check was performed, None otherwise.
         """
-        self._increment_op_counter()
+        total = await self._increment_op_counter()
 
-        if not self._should_check_health():
+        if not self._should_check_health(total):
             return None
 
+        # The pulse boundary is the durable sync point: a restart resumes the
+        # modulo from the flushed total instead of restarting at zero.
+        await self._persist_op_total(total)
         pulse = await self._health_pulse()
         if pulse is not None:
             self._fire_health_trigger(pulse)

--- a/tests/stress/test_concurrent.py
+++ b/tests/stress/test_concurrent.py
@@ -81,7 +81,7 @@ class TestMaintenanceCounter:
         # 20 concurrent increment calls — since _increment_op_counter
         # is synchronous (no await), asyncio.gather runs them sequentially.
         async def increment() -> int:
-            return handler._increment_op_counter()
+            return await handler._increment_op_counter()
 
         results = await asyncio.gather(*[increment() for _ in range(20)])
 
@@ -103,8 +103,8 @@ class TestMaintenanceCounter:
             h1 = MaintenanceHandler.__new__(MaintenanceHandler)
             h2 = MaintenanceHandler.__new__(MaintenanceHandler)
 
-            h1._increment_op_counter()
-            h1._increment_op_counter()
+            await h1._increment_op_counter()
+            await h1._increment_op_counter()
 
             # h2 does NOT see h1's increments — each instance has its own counter
             assert h1._op_count == 2

--- a/tests/unit/test_maintenance_handler.py
+++ b/tests/unit/test_maintenance_handler.py
@@ -289,10 +289,8 @@ class TestOperationCounter:
         storage = _make_storage()
         server = _FakeServer(storage)
         assert server._op_count == 0
-        server._increment_op_counter()
-        assert server._op_count == 1
-        server._increment_op_counter()
-        assert server._op_count == 2
+        assert await server._increment_op_counter() == 1
+        assert await server._increment_op_counter() == 2
 
     @pytest.mark.asyncio
     async def test_should_check_at_interval(self) -> None:
@@ -302,8 +300,8 @@ class TestOperationCounter:
 
         checks = []
         for _ in range(15):
-            server._increment_op_counter()
-            checks.append(server._should_check_health())
+            total = await server._increment_op_counter()
+            checks.append(server._should_check_health(total))
 
         # Should be True at positions 4, 9, 14 (op_count 5, 10, 15)
         assert checks[4] is True

--- a/tests/unit/test_maintenance_pulse_persistence.py
+++ b/tests/unit/test_maintenance_pulse_persistence.py
@@ -1,0 +1,99 @@
+"""The health-pulse op counter persists per-brain across processes (#222).
+
+The counter used to be a class-level in-process attribute reset on every
+start, so pulsing depended on how work was distributed across processes: the
+reporter's arithmetic — 100 sessions x 24 operations (2400 total, interval 25)
+— produced ZERO pulses, while one 2400-op session produced 96. The fix seeds
+each process's counter from the brain's metadata and flushes the total back
+(pulse boundary + every 25 ops), fail-soft to the old per-process behaviour.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from surreal_memory.mcp.maintenance_handler import MaintenanceHandler
+
+
+class _BrainStore:
+    """Fake storage persisting brain metadata like the real backends do."""
+
+    def __init__(self) -> None:
+        self.brain = SimpleNamespace(id="b1", config=MagicMock(), metadata={})
+        self.brain_id = "b1"
+
+    # MaintenanceHandler surface
+    async def get_brain(self, _id: str) -> Any:
+        return self.brain
+
+    async def save_brain(self, brain: Any) -> None:
+        self.brain = brain
+
+
+def _handler(store: _BrainStore, interval: int) -> MaintenanceHandler:
+    h = MaintenanceHandler.__new__(MaintenanceHandler)
+    h._op_count = 0
+    h._op_base = None
+    h._last_pulse = None
+    h._last_consolidation_at = None
+    h._last_dream_at = None
+    h._effective_check_interval = None
+    h._consolidation_task = None
+    h.config = MagicMock()
+    h.config.maintenance.enabled = True
+    h.config.maintenance.check_interval = interval
+    h.get_storage = AsyncMock(return_value=store)
+    return h
+
+
+@pytest.mark.asyncio
+async def test_short_sessions_pulse_on_total_work() -> None:
+    """The reporter's arithmetic: 100 x 24 ops must not yield zero pulses."""
+    store = _BrainStore()
+    pulses = 0
+    for _session in range(100):  # a fresh handler per short-lived session
+        h = _handler(store, interval=25)
+        h._health_pulse = AsyncMock(  # type: ignore[method-assign]
+            return_value=SimpleNamespace(hints=[], should_consolidate=False)
+        )
+        h._fire_health_trigger = MagicMock()  # type: ignore[method-assign]
+        h._maybe_auto_consolidate = AsyncMock()  # type: ignore[method-assign]
+        h._maybe_run_expiry_cleanup = AsyncMock()  # type: ignore[method-assign]
+        h._create_alerts_from_pulse = AsyncMock()  # type: ignore[method-assign]
+        h._auto_resolve_cleared = AsyncMock()  # type: ignore[method-assign]
+        for _op in range(24):
+            pulse = await h._check_maintenance()
+            if pulse is not None:
+                pulses += 1
+    assert pulses == 96, (
+        f"2400 total ops at interval 25 must pulse 96 times across sessions; got {pulses}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_storage_failure_degrades_to_per_process() -> None:
+    h = MaintenanceHandler.__new__(MaintenanceHandler)
+    h._op_count = 0
+    h._op_base = None
+    h._last_pulse = None
+    h._last_consolidation_at = None
+    h._last_dream_at = None
+    h._effective_check_interval = None
+    h._consolidation_task = None
+    h.config = MagicMock()
+    h.config.maintenance.enabled = True
+    h.config.maintenance.check_interval = 25
+
+    async def _boom() -> None:
+        raise RuntimeError("storage down")
+
+    h.get_storage = AsyncMock(side_effect=RuntimeError("storage down"))  # type: ignore[method-assign]
+    total = await h._increment_op_counter()
+    assert total == 1, "fail-soft: the counter still works per-process"
+    assert h._should_check_health(total) is False
+    h._op_count = 25
+    assert h._should_check_health() is True, "in-process modulo semantics unchanged"


### PR DESCRIPTION
## Summary

- `MaintenanceHandler`'s op counter seeds lazily from `brain.metadata["_maintenance_op_count"]` and persists the running total on every op; `_should_check_health` runs the modulo on the brain-wide total.
- Persistence is fail-soft: on any storage error the counter degrades to the previous per-process semantics — never an outage on the hot remember/recall path.

## Why

Closes #222. The reporter's arithmetic: with `check_interval=25`, 100 sessions × 24 operations = 2400 ops → **0 pulses**, while one 2400-op session → 96 pulses. Short-lived MCP sessions (the typical editor integration) took no pulses at all, so `smem_alerts` stayed empty on deployments with plenty to say. Wall-clock timestamps alone would not fix it (noted in the issue — the state must persist); the scheduled-consolidation loop can't fill the gap either (24 h default sleep).

## Test plan

- [x] `pytest tests/ -m "not stress" -n auto` — 7354 passed; the reporter's arithmetic is now a test (100×24 ops across fresh handlers sharing one brain store → exactly 96 pulses) plus a storage-failure degradation test.
- [x] Existing maintenance + stress suites updated to the awaited counter; `ruff` clean; `mypy` — only the pre-existing google.genai noise.

## Verified by

@acidkill